### PR TITLE
docs: feature/4321 환경별 API 가이드 동기화 (백업 복제 리전 노출 정합화)

### DIFF
--- a/en/api-guide-v3.0-gov.md
+++ b/en/api-guide-v3.0-gov.md
@@ -1,167 +1,195 @@
-## Database > RDS for MariaDB > API Guide
+## RDS for MariaDB API Guide
+
+**Database > RDS for MariaDB > API v3.0 Guide**
 
 ## RDS for MariaDB API Common Information
 
 ### API Endpoint
 
 | Region | Endpoint |
-|--------|----------|
+|------|----------|
 | Korea (Pangyo) region | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
+
 
 ### Authentication and Authorization
 
 User Access Key is required to use the RDS for MariaDB API. A User Access Key is an authentication key issued based on an NHN Cloud or IAM account. It is used in conjunction with a Secret Access Key to authenticate API requests.
 
 User Access Keys and Secret Access Keys can be issued in the console's API Security Setting. For more information on issuing and using User Access Key, please refer to the [User Access Key](/nhncloud/en/public-api/user-access-key).
-
 The created Key must be included in the request Header.
 
-| Name                       | Type   | Format | Required | Description                                                              |
-|----------------------------|--------|--------|----------|--------------------------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O        | Appkey of RDS for MariaDB or integrated Appkey for project |
-| X-TC-AUTHENTICATION-ID     | Header | String | O        | User Access Key ID in API Security Settings menu                         |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O        | Secret Access Key in API Security Settings menu                          |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | Appkey of RDS for MariaDB or integrated Appkey for project |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | User Access Key ID in API Security Settings menu |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | Secret Access Key in API Security Settings menu |
 
 In addition, the APIs you can call are limited based on the project member role. You can grant permissions separately for `RDS for MariaDB ADMIN` and `RDS for MariaDB VIEWER`.
 
 * `RDS for MariaDB ADMIN permission holders` can use all available features as before.
 * `RDS for MariaDB VIEWER permission holders` can use read-only feature.
-    * Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
-    * But, notification group and user group-related features are available.
+* Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
+* But, notification group and user group-related features are available.
 
 If an API request fails to authenticate or is not authorized, the following error occurs.
 
-| resultCode | resultMessage | Description            |
-|------------|---------------|------------------------|
-| 80401      | Unauthorized  | Failed to authenticate |
-| 80403      | Forbidden     | Unauthorized.          |
+| resultCode | resultMessage | Description |
+|------------|---------------|-----|
+| 80401 | Unauthorized | Failed to authenticate |
+| 80403 | Forbidden | Unauthorized. |
 
 ### Common Response Information
 
 The API responds with "200 OK" to all API requests. For more information on the response results, see Response Body Header.
 
-#### Response Body
+<details>
+  <summary><strong>Successful Response</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### Field
-| Name          | Format  | Description                                              |
-|---------------|---------|----------------------------------------------------------|
-| resultCode    | Number  | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
-| resultMessage | String  | Result message                                           |
-| isSuccessful  | Boolean | Successful or not                                        |
+</details>
 
+<details>
+  <summary><strong>Failure Response</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| resultCode | Number | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
+| resultMessage | String | Result message |
+| isSuccessful | Boolean | Successful or not |
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
 
 ## Project Information
 
-### List Regions
-
-```http
-GET /v3.0/project/regions
-```
+### List Project Members
 
 #### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name    | Type | Format | Description |
-|---------|------|--------|-------------|
-| regions | Body | Array  | Region list |
-| regions.regionCode | Body | Enum    | Region code<br/>- `KR1`: Korea (Pangyo) Region|
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                                                                 |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### List Project Members
 
 ```http
 GET /v3.0/project/members
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                 | Type | Format | Description                  |
-|----------------------|------|--------|------------------------------|
-| members              | Body | Array  | Project member list          |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name          |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile        |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| members.memberName | String | Project member name |
+| members.emailAddress | String | Project member email address |
+| members.phoneNumber | String | Project member mobile |
+
+---
+
+### List Regions
+
+#### Request
+
+```http
+GET /v3.0/project/regions
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| regions | Array | Region list |
+| regions.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Boolean | Whether to enable a region |
 
 ---
 
@@ -169,47 +197,48 @@ This API does not require a request body.
 
 ### List DB Instance Specifications
 
+#### Request
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                   | Type | Format | Description                              |
-|------------------------|------|--------|------------------------------------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications       |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications       |
-| dbFlavors.ram          | Body | Number | Memory size (MB)                         |
-| dbFlavors.vcpus        | Body | Number | CPU cores                                |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbFlavors | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | String | Name of DB instance specifications |
+| dbFlavors.ram | Number | Memory size (MB) |
+| dbFlavors.vcpus | Number | CPU cores |
 
 ---
 
@@ -217,49 +246,50 @@ This API does not require a request body.
 
 ### List Subnets
 
+#### Request
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format  | Description              |
-|--------------------------|------|---------|--------------------------|
-| subnets                  | Body | Array   | Subnet list              |
-| subnets.subnetId         | Body | UUID    | Subnet identifier        |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet           |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway   |
-| subnets.availableIpCount | Body | Number  | Number of available IPs  |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| subnets | Array | Subnet list |
+| subnets.subnetId | UUID | Subnet identifier |
+| subnets.subnetName | String | Name to identify subnets |
+| subnets.subnetCidr | String | CIDR of subnet |
+| subnets.usingGateway | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Number | Number of available IPs |
 
 ---
 
@@ -267,122 +297,126 @@ This API does not require a request body.
 
 ### List DB Engines
 
+#### Request
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB engine list                                        |
-| dbVersions.dbVersion         | Body | String  | DB engine type                                        |
-| dbVersions.dbVersionName     | Body | String  | DB engine name                                        |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbVersions | Array | DB engine list |
+| dbVersions.dbVersion | String | DB engine type |
+| dbVersions.dbVersionName | String | DB engine name |
+| dbVersions.restorableFromObs | Boolean | Restoring backup from object storage available or not |
 
 ---
 
 ## Storage
 
 ### List Storage Type
+
+#### Request
+
 ```http
 GET /v3.0/storage-types
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name         | Type | Format | Description       |
-|--------------|------|--------|-------------------|
-| storageTypes | Body | Array  | Storage type list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageTypes | Array | Storage type list |
 
 ---
 
 ### List Storage
 
+#### Request
+
 ```http
 GET /v3.0/storages
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name     | Type | Format | Description  |
-|----------|------|--------|--------------|
-| storages | Body | Array  | Storage list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storages": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storages": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storages | Array | Storage list |
 
 ---
 
@@ -390,72 +424,75 @@ This API does not require a request body.
 
 ### Task Status
 
-| Status Name        | Description                           |
-|--------------------|---------------------------------------|
-| `PREPARING`        | Task in preparation                   |
-| `READY`            | Task in ready                         |
-| `RUNNING`          | Task in progress                      |
-| `COMPLETED`        | Task completed                        |
-| `REGISTERED`       | Task registered                       |
-| `WAIT_TO_REGISTER` | Task waiting to register              |
-| `INTERRUPTED`      | Task being interrupted                |
-| `CANCELED`         | Task canceled                         |
-| `FAILED`           | Task failed                           |
-| `ERROR`            | Error occurred while task in progress |
-| `DELETED`          | Task deleted                          |
-| `FAIL_TO_READY`    | Failed to get ready for task          |
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | Task in preparation |
+| `READY` | Task in ready |
+| `RUNNING` | Task in progress |
+| `COMPLETED` | Task completed |
+| `REGISTERED` | Task registered |
+| `WAIT_TO_REGISTER` | Task waiting to register |
+| `INTERRUPTED` | Task being interrupted |
+| `CANCELED` | Task canceled |
+| `FAILED` | Task failed |
+| `ERROR` | Error occurred while task in progress |
+| `DELETED` | Task deleted |
+| `FAIL_TO_READY` | Failed to get ready for task |
 
 ### List Task Details
+
+#### Request
 
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name  | Type | Format | Required | Description     |
-|-------|------|--------|----------|-----------------|
-| jobId | URL  | UUID   | O        | Task identifier |
-
 #### Response
 
-| Name                           | Type | Format   | Description                                         |
-|--------------------------------|------|----------|-----------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                     |
-| jobStatus                      | Body | Enum     | Current task status                                 |
-| resourceRelations              | Body | Array    | Relevant resource list                              |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type                              |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                        |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+| jobStatus | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | Relevant resource list |
+| resourceRelations.resourceType | String | Relevant resource type |
+| resourceRelations.resourceId | String | Relevant resource identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -463,103 +500,107 @@ This API does not require a request body.
 
 ### List DB Instance Groups
 
+#### Request
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                               | Type | Format   | Description                                                                                                    |
-|------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB instance groups                                                                                             |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                   |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                             |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                            |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB instance groups |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Standalone`<br/>- HIGH_AVAILABILITY: `High availability` |
+| dbInstanceGroups.createdYmdt | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### List DB Instance Group Details
 
+#### Request
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbInstanceGroupId | URL  | UUID   | O        | DB instance group identifier |
-
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                             |
-|------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                          |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                                                |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                                              |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Standalone`<br/>- HIGH_AVAILABILITY: `High availability` |
+| dbInstances | Array | DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -567,1773 +608,2332 @@ This API does not require a request body.
 
 ### DB Instance Status
 
-| Status             | Description                               |
-|--------------------|-------------------------------------------|
-| `AVAILABLE`        | DB instance is available                  |
-| `BEFORE_CREATE`    | Before DB instance is created             |
-| `STORAGE_FULL`     | Insufficient DB instance storage          |
-| `FAIL_TO_CREATE`   | Failed to create DB instance              |
-| `FAIL_TO_CONNECT`  | Failed to connect DB instance             |
-| `REPLICATION_STOP` | Replication of DB instance is stopped     |
-| `FAILOVER`         | High availability DB instance failed over |
-| `SHUTDOWN`         | DB instance is stopped                    |
-| `DELETED`          | DB instance is deleted                    |
+| Status | Description |
+|---------------------|------------------------------|
+| `AVAILABLE` | DB instance is available |
+| `BEFORE_CREATE` | Before DB instance is created |
+| `STORAGE_FULL` | Insufficient DB instance storage |
+| `FAIL_TO_CREATE` | Failed to create DB instance |
+| `FAIL_TO_CONNECT` | Failed to connect DB instance |
+| `REPLICATION_STOP` | Replication of DB instance is stopped |
+| `FAILOVER` | High availability DB instance failed over |
+| `SHUTDOWN` | DB instance is stopped |
+| `DELETED` | DB instance is deleted |
 
 ### DB Instance Progress Status
 
-| Status                     | Description                      |
-|----------------------------|----------------------------------|
+| Status | Description |
+|----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up                       |
-| `CANCELING`                | Canceling                        |
-| `CREATING`                 | Creating                         |
-| `CREATING_SCHEMA`          | Creating DB schema	              |
-| `CREATING_USER`            | Creating user	                   |
-| `DELETING`                 | Deleting                         |
-| `DELETING_SCHEMA`          | Deleting DB schema               |
-| `DELETING_USER`            | Deleting user                    |
-| `EXPORTING_BACKUP`         | Exporting backup                 |
-| `FAILING_OVER`             | Under failover                   |
-| `MIGRATING`                | Under migration                  |
-| `MODIFYING`                | Under modification               |
-| `PREPARING`                | In preparation                   |
-| `PROMOTING`                | Promoting                        |
-| `REBUILDING`               | Rebuilding                       |
-| `REPAIRING`                | Recovering                       |
-| `REPLICATING`              | Replicating                      |
-| `RESTARTING`               | Restarting                       |
-| `RESTARTING_FORCIBLY`      | Force restarting                 |
-| `RESTORING`                | Restoring                        |
-| `STARTING`                 | Starting                         |
-| `STOPPING`                 | Stopping                         |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema          |
-| `SYNCING_USER`             | Synchronizing user	              |
-| `UPDATING_USER`            | Modifying user	                  |
+| `BACKING_UP` | Backing up |
+| `CANCELING` | Canceling |
+| `CREATING` | Creating |
+| `CREATING_SCHEMA` | Creating DB schema |
+| `CREATING_USER` | Creating user |
+| `DELETING` | Deleting |
+| `DELETING_SCHEMA` | Deleting DB schema |
+| `DELETING_USER` | Deleting user |
+| `EXPORTING_BACKUP` | Exporting backup |
+| `FAILING_OVER` | Under failover |
+| `MIGRATING` | Under migration |
+| `MODIFYING` | Under modification |
+| `PREPARING` | In preparation |
+| `PROMOTING` | Promoting |
+| `REBUILDING` | Rebuilding |
+| `REPAIRING` | Recovering |
+| `REPLICATING` | Replicating |
+| `RESTARTING` | Restarting |
+| `RESTARTING_FORCIBLY` | Force restarting |
+| `RESTORING` | Restoring |
+| `STARTING` | Starting |
+| `STOPPING` | Stopping |
+| `SYNCING_SCHEMA` | Synchronizing DB schema |
+| `SYNCING_USER` | Synchronizing user |
+| `UPDATING_USER` | Modifying user |
 
-### List DB instances
+### List DB Instances
+
+#### Request
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                                             |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                                           |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbInstances.dbVersion         | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current progress status                                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List DB Instance Details
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                        | Type | Format   | Description                                                                                                                                                             |
-|-----------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstanceGroupId           | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstanceName              | Body | String   | Name to identify DB instances                                                                                                                                           |
-| description                 | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbVersion                   | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbPort                      | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus            | Body | Enum     | DB instance current status                                                                                                                                              |
-| progressStatus              | Body | Enum     | Current task status of DB instance                                                                                                                                      |
-| dbFlavorId                  | Body | UUID     | Identifier of DB instance specifications                                                                                                                                |
-| parameterGroupId            | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                                       |
-| dbSecurityGroupIds          | Body | Array    | DB security group identifiers applied to DB instance                                                                                                                    |
-| notificationGroupIds        | Body | Array    | Notification group identifiers applied to DB instance                                                                                                                   |
-| useDeletionProtection       | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | Whether to support authentication plugin                                                                                                                                |
-| needToApplyParameterGroup   | Body | Boolean  | Need to apply the latest parameter group                                                                                                                                |
-| needMigration               | Body | Boolean  | Need to migrate                                                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | Whether to support DB version upgrade                                                                                                                                   |
-| createdYmdt                 | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                 | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstances | Array | DB instances |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| dbInstances.description | String | Additional information on DB instances |
+| dbInstances.dbVersion | String | DB engine type |
+| dbInstances.dbPort | Number | DB port |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Enum | Current progress status of DB instance<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | Created date and time |
+| dbInstances.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Instance
 
+#### Request
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### Request
+#### Request Body
 
-| Name                                     | Type | Format  | Required | Description                                                                                                           |
-|------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                               |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                |
-| dbFlavorId                               | Body | UUID    | O        | Identifier of DB instance specifications                                                                              |
-| dbVersion                                | Body | Enum    | O        | DB engine type                                                                                                        |
-| dbPort                                   | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                      |
-| dbUserName                               | Body | String  | O        | DB user account name                                                                                                  |
-| dbPassword                               | Body | String  | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                        |
-| parameterGroupId                         | Body | UUID    | O        | Parameter group identifier                                                                                            |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers                                                                                         ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                |
-| useHighAvailability                      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval                             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                              |
-| authenticationPlugin                     | Body | Enum    | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbVersion | String | Y | DB engine type |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| authenticationPlugin | Enum | N | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB Instance
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### Request
-
-| Name               | Type | Format  | Required | Description                                                                                                       |
-|--------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| dbInstanceName     | Body | String  | X        | Master name to identify DB                                                                                        |
-| dbInstanceCandidateName  | Body | String  | X        | Candidate name to identify DB instances                                                                     |
-| description        | Body | String  | X        | Additional information on DB instances                                                                            |
-| dbPort             | Body | Number  | X        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                  |
-| dbFlavorId         | Body | UUID    | X        | Identifier of DB instance specifications                                                                          |
-| parameterGroupId   | Body | UUID    | X        | Parameter group identifier                                                                                        |
-| dbSecurityGroupIds | Body | Array   | X        | DB security group identifiers                                                                                     |
-| executeBackup      | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| useOnlineFailover  | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### Delete DB instance
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
+### Restore DB Instance from Object Storage
 
 #### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Request
-
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| executeBackup     | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-### Force Restart DB instance
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### Start DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Stop DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Backup DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description              |
-|--------------|------|--------|----------|--------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier   |
-| backupName   | Body | String | O        | Name to identify backups |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Export after Backing up DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                 |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud member or IAM member ID                      |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Replicate DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Request
-
-| Name                                     | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                                         |
-|------------------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                                              |
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                                              |
-| dbFlavorId                               | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                                                                                                                                                  |
-| dbPort                                   | Body | Number  | X        | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers<br/>- Default: Original DB instance value                                                                                                                                                                                                                                             |
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                                              |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                                                                                                                                                                                            |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: Original DB instance value                                                                                                                                                                                                                                       |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                                                                       |
-| storage                                  | Body | Object  | X        | Storage information objects                                                                                                                                                                                                                                                                                         |    
-| storage.storageType                      | Body | Enum    | X        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                                                                     |
-| storage.storageSize                      | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | X        | Backup information objects                                                                                                                                                                                                                                                                                          |
-| backup.backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                 |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Promote DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Restoration Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type | Format   | Description                                                                                                                                                                                                          |
-|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restorable time                                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restorable time                                                                                                                                                                                          |
-| restorableBackups                       | Body | Array    | List of restorable backups                                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                                                                          |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | Whether to use table lock                                                                                                                                                                                            |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                                                                          |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                                     |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>- `BACKING_UP`: Backup in progress<br/>- `COMPLETED`: Backup completed<br/>- `DELETING`: Backup being deleted<br/>- `DELETED`: Backup deleted<br/>- `ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DB engine type                                                                                                                                                                                                       |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                                                                                  |
-| restorableBackups.backup.binLogFileName | Body | String   | Binary log file name                                                                                                                                                                                                 |
-| restorableBackups.backup.binLogPosition | Body | Number   | Binary log file location                                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                                                                      |
-| restorableBackups.restorableBinLogs     | Body | Array    | Binary log names that can be restored using the backup                                                                                                                                                               |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### View the last query to be restored
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Common Request
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                                                        |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                                                             |
-| restoreType  | Query | Enum   | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored. |
-
-#### If restoreType is `TIMESTAMP`
-
-| Name        | Type  | Format   | Required | Description                                           |
-|-------------|-------|----------|----------|-------------------------------------------------------|
-| restoreYmdt | Query | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### If restoreType is `BINLOG`
-
-| Name           | Type  | Format | Required | Description                                     |
-|----------------|-------|--------|----------|-------------------------------------------------|
-| backupId       | Query | UUID   | O        | Identifier of the backup to use for restoration |
-| binLogFileName | Query | String | O        | Binary log name to use for restoration          |
-| binLogPosition | Query | Number | O        | Binary log location to use for restoration      |
-
-#### Response
-
-| Name         | Type | Format   | Description                                      |
-|--------------|------|----------|--------------------------------------------------|
-| executedYmdt | Body | DateTime | Query executed date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | Last executed query                              |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### Restoration
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Common Request
-
-| Name                    | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                                      |
-|-------------------------|------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                                           |
-| restore                 | Body | Object  | O        | Restoration information object                                                                                                                                                                                                                                                                                   |
-| restore.restoreType     | Body | Enum    | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored.<br/>- `BACKUP`: Snapshot restoration type using a previously created backup |
-| dbInstanceName          | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description             | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                                           |
-| dbFlavorId              | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                                                                                                                                                                                         |
-| dbPort                  | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                                                 |
-| parameterGroupId        | Body | UUID    | O        | Parameter group identifier                                                                                                                                                                                                                                                                                       |
-| dbSecurityGroupIds      | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                                                                    |
-| userGroupIds            | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                                           |
-| useHighAvailability     | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                                           |
-| pingInterval            | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                   |
-| useDefaultNotification  | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                        |
-| network                 | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                                                                      |
-| network.subnetId        | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                                                                |
-| network.usePublicAccess | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                                        |
-| network.availabilityZone | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                                                   |
-| storage                 | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                                                                      |
-| storage.storageType     | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                                                 |
-| storage.storageSize     | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                                                 |
-| backup                  | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                                                       |
-| backup.backupPeriod     | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                |
-| backup.backupRetryCount | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                           |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                   |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                       |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour    |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                                                          |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                | Type | Format   | Required | Description                                                                                                                                                                             |
-|---------------------|------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
-
-| Name                          | Type | Format | Required | Description                                     |
-|-------------------------------|------|--------|----------|-------------------------------------------------|
-| restore.backupId              | Body | UUID   | O        | Identifier of the backup to use for restoration |
-| restore.binLog                | Body | Object | O        | Binary log information object                   |
-| restore.binLog.binLogFileName | Body | String | O        | Binary log name to use for restoration          |
-| restore.binLog.binLogPosition | Body | Number | O        | Binary log location to use for restoration      |
-
-* When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request when restoring from backup (if restoreType is `BACKUP`)
-
-| Name             | Type | Format | Required                       | Description                                     |
-|------------------|------|--------|--------------------------------|-------------------------------------------------|
-| restore.backupId | Body | UUID   | O (if restoreType is `BACKUP`) | Identifier of the backup to use for restoration |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-### Restore from Object Storage
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### Request
+#### Request Body
 
-| Name                     | Type | Format  | Required | Description                                                                                                             |
-|--------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------------|
-| restore                  | Body | Object  | O        | Restoration information object                                                                                          |
-| restore.tenantId         | Body | String  | O        | Tenant ID of object storage where backups are stored                                                                    |
-| restore.username         | Body | String  | O        | NHN Cloud account or IAM member ID                                                                                      |
-| restore.password         | Body | String  | O        | API password for object storage where backups are stored                                                                |
-| restore.targetContainer  | Body | String  | O        | Container for object storage where backups are stored                                                                   |
-| restore.objectPath       | Body | String  | O        | Backup path stored in container                                                                                         |
-| dbVersion                | Body | Enum    | O        | DB engine type                                                                                                          |
-| dbInstanceName           | Body | String  | O        | Master name to identify DB instances                                                                                    |
-| dbInstanceCandidateName  | Body | String  | X        | Candidate name to identify DB instances                                                                                 |
-| description              | Body | String  | X        | Additional information on DB instances                                                                                  |
-| dbFlavorId               | Body | UUID    | O        | Identifier of DB instance specifications                                                                                |
-| dbPort                   | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                        |
-| parameterGroupId         | Body | UUID    | O        | Parameter group identifier                                                                                              |
-| dbSecurityGroupIds       | Body | Array   | X        | DB security group identifiers                                                                                           |
-| userGroupIds             | Body | Array   | X        | User group identifiers                                                                                                  |
-| useHighAvailability      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| network                  | Body | Object  | O        | Network information objects                                                                                             |
-| network.subnetId         | Body | UUID    | O        | Subnet identifier                                                                                                       |
-| network.usePublicAccess  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                              |
-| network.availabilityZone | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                           |
-| storage                  | Body | Object  | O        | Storage information objects                                                                                             |
-| storage.storageType      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                         |
-| storage.storageSize      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                           |
-| backup                   | Body | Object  | O        | Backup information objects                                                                                              |
-| backup.backupPeriod      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                             |
-| backup.ftwrlWaitTimeout  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                         |
-| backup.backupRetryCount  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                          |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                         |
-|-----------------------|------|---------|----------|-------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier              |
-| useDeletionProtection | Body | Boolean | O        | Whether to protect against deletion |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port |
+| dbVersion | String | Y | DB engine type |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Identifier of the image |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.tenantId | String | Y | Tenant ID of object storage where backups are stored |
+| restore.username | String | Y | NHN Cloud account or IAM member ID |
+| restore.password | String | Y | API password for object storage where backups are stored |
+| restore.targetContainer | String | Y | Container of object storage where backups are stored |
+| restore.objectPath | String | Y | Path of backup stored in container |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### Delete DB Instance
+
+#### Request
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### Modify High Availability
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Request
-
-| Name                | Type | Format  | Required | Description                                                                                          |
-|---------------------|------|---------|----------|------------------------------------------------------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O        | DB instance identifier                                                                               |
-| useHighAvailability | Body | Boolean | O        | Whether to use high availability                                                                     |
-| pingInterval        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### Restart High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
-```
+### View DB Instance Details
 
 #### Request
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Pause High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Recover High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Separate High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Storage Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name          | Type | Format | Description                                                                                                |
-|---------------|------|--------|------------------------------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | Block Storage Type                                                                                         |
-| storageSize   | Body | Number | Block Storage Size (GB)                                                                                    |
-| storageStatus | Body | Enum   | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB instance identifier |
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceName | String | Name to identify DB instances |
+| description | String | Additional information on DB instances |
+| dbVersion | String | DB engine type |
+| dbPort | Number | DB port |
+| dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Enum | Current progress status of DB instance<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | Identifier of DB instance specifications |
+| parameterGroupId | UUID | Identifier of the parameter group applied to the DB instance |
+| dbSecurityGroupIds | Array | List of identifiers of DB security groups applied to the DB instance |
+| notificationGroupIds | Array | List of identifiers of notification groups applied to the DB instance |
+| useDeletionProtection | Boolean | Whether deletion protection is enabled for the DB instance |
+| supportAuthenticationPlugin | Boolean | Whether authentication plugin is supported |
+| needToApplyParameterGroup | Boolean | Whether the latest parameter group needs to be applied |
+| needMigration | Boolean | Whether migration is required |
+| supportDbVersionUpgrade | Boolean | Whether DB version upgrade is supported |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### Modify Storage Information
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### Modify DB Instance
 
 #### Request
 
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| storageSize       | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbVersion | String | N | DB engine version code |
+| useDummy | Boolean | N | Whether to use a dummy during DB version upgrade of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| executeBackup | Boolean | N | Whether to execute backup at the current point in time<br/>- Default: `false` |
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Whether to wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Whether to block write workload<br/>- Default: `false` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Backup DB Instance
+
+#### Request
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"backupName": "backupName"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupName | String | Y | Name to identify backups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### View Backup Information
 
+#### Request
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                              | Type | Format  | Description                |
-|-----------------------------------|------|---------|----------------------------|
-| backupPeriod                      | Body | Number  | Backup retention period    |
-| ftwrlWaitTimeout                  | Body | Number  | Query latency (sec)        |
-| backupRetryCount                  | Body | Number  | Number of backup retries   |
-| replicationRegion                 | Body | Enum    | Backup replication region  |
-| useBackupLock                     | Body | Boolean | Whether to use table lock  |
-| backupSchedules                   | Body | Array   | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime  | Body | String  | Backup started time        |
-| backupSchedules.backupWndDuration | Body | Enum    | Backup duration            |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| backupPeriod | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Number | Query latency (sec) |
+| backupRetryCount | Number | Number of backup retries |
+| replicationRegion | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Boolean | Whether to use table lock |
+| backupSchedules | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Backup started time |
+| backupSchedules.backupWndDuration | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### Modify Backup Information
 
+#### Request
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### Request
+#### Request Parameters
 
-| Name                              | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|-----------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                    |
-| backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| useBackupLock                     | Body | Boolean | X        | Whether to use table lock                                                                                                                                                                                                                                                 |
-| backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Boolean | N | Whether to use table lock |
+| backupSchedules | Array | N | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### List Network Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
+### Export after Backing up DB Instance
 
 #### Request
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup is stored |
+| targetContainer | String | Y | Object storage container where backup is stored |
+| objectPath | String | Y | Backup path to be stored in container |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Change DB Image Meta for Testing
+
+#### Request
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                   | Type | Format | Description                                                                                                                                                                                                |
-|------------------------|------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | Availability zone where DB instance will be created                                                                                                                                                        |
-| subnet                 | Body | Object | Subnet object                                                                                                                                                                                              |
-| subnet.subnetId        | Body | UUID   | Subnet identifier                                                                                                                                                                                          |
-| subnet.subnetName      | Body | UUID   | Name to identify subnets                                                                                                                                                                                   |
-| subnet.subnetCidr      | Body | UUID   | CIDR of subnet                                                                                                                                                                                             |
-| endPoints              | Body | Array  | List of access information                                                                                                                                                                                 |
-| endPoints.domain       | Body | String | Domain                                                                                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP address                                                                                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | Access information type<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Network Information
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Request
-
-| Name            | Type | Format  | Required | Description                         |
-|-----------------|------|---------|----------|-------------------------------------|
-| dbInstanceId    | URL  | UUID    | O        | DB instance identifier              |
-| usePublicAccess | Body | Boolean | O        | External access is available or not |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Users
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                         | Type | Format   | Description                                                                                                                                                              |
-|------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB users                                                                                                                                                                 |
-| dbUsers.dbUserId             | Body | UUID     | DB user identifier                                                                                                                                                       |
-| dbUsers.dbUserName           | Body | String   | DB user account name                                                                                                                                                     |
-| dbUsers.host                 | Body | String   | DB user account host name                                                                                                                                                |
-| dbUsers.authorityType        | Body | Enum     | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| dbUsers.dbUserStatus         | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `UPDATING`: Modifying<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted                     |
-| dbUsers.authenticationPlugin | Body | Enum     | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                       |
-| dbUsers.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Create DB User
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserName           | Body | String | O        | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                                                                                |
-| dbPassword           | Body | String | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| host                 | Body | String | O        | DB user account host name<br/>- Example: `1.1.1.%`                                                                                                                       |
-| authorityType        | Body | Enum   | O        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB User
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserId             | URL  | UUID   | O        | DB user identifier                                                                                                                                                       |
-| dbPassword           | Body | String | X        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| authorityType        | Body | Enum   | X        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum    | X        | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB User
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbUserId     | URL  | UUID   | O        | DB user identifier     |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+This API does not return a response body.
 
 ---
 
 ### List DB Schema
 
+#### Request
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                     | Type | Format   | Description                                                                                                                  |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB schema list                                                                                                               |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB schema identifier                                                                                                         |
-| dbSchemas.dbSchemaName   | Body | String   | DB schema name                                                                                                               |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB schema current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted |
-| dbSchemas.createdYmdt    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                           |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSchemas | Array | DB schema list |
+| dbSchemas.dbSchemaId | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | Created date and time |
 
 ---
 
 ### Create DB Schema
 
+#### Request
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### Request
+#### Request Parameters
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaName | Body | String | O        | DB schema name         |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### Delete DB Schema
 
+#### Request
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaId   | URL  | UUID   | O        | DB schema identifier   |
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### List DB Users
+
+#### Request
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbUsers | Array | DB users |
+| dbUsers.dbUserId | UUID | DB user identifier |
+| dbUsers.dbUserName | String | DB user account name |
+| dbUsers.host | String | DB user account host name |
+| dbUsers.authorityType | Enum | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| dbUsers.dbUserStatus | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | Created date and time |
+| dbUsers.updatedYmdt | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+---
+
+### Create DB User
+
+#### Request
+
+```http
+<!-- TERM-UNRESOLVED: DB 이미지 메타 (section "Change DB Image Meta for Testing" — no published EN precedent found for this term) -->
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | String | Y | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Enum | Y | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Delete DB User
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Modify DB User
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Enum | N | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Change DB Instance Deletion Protection Settings
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | Whether to protect against deletion |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Modify High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"useHighAvailability": false,
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | Whether to use high availability |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Pause High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Recover High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restart High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Separate High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### List Log Files
 
+#### Request
+
 ```http
-GET /v3.0/db-instances/{dbInstanceId}/log-files
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                         |
-|--------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                              |
-| logFileTypes | Query | Array  | X        | Log File type list<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                                                                                                                                                                    |
-|----------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | Log File list                                                                                                                                                                                  |
-| logFiles.logFileName | Body | String   | Log File name                                                                                                                                                                                  |
-| logFiles.logFileType | Body | Enum     | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | Log File size(Byte)                                                                                                                                                                            |
-| logFiles.createdYmdt | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                             |
-
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| logFiles | Array | Log File list |
+| logFiles.logFileName | String | Log File name |
+| logFiles.logFileType | Enum | Log File type<br/>- `ERROR`<br/>- `BINLOG`<br/>- `GENERAL`<br/>- `SLOW_QUERY`<br/>- `AUDIT`<br/>- `BACKUP` |
+| logFiles.logFileSize | Number | Log File size(Byte) |
+| logFiles.createdYmdt | DateTime | Created date and time |
 
 ---
 
 ### Export Log File
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/log-files/export
-```
-
 #### Request
 
-| Name            | Type | Format | Required | Description                                              |
-|-----------------|------|--------|----------|----------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                   |
-| logFileNames    | Body | Array  | O        | Log File name list<br/>- Minimum size: `1`               |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store log file            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                       |
-| password        | Body | String | O        | API password for object storage where log file is stored |
-| targetContainer | Body | String | O        | Object storage container where log file is stored        |
-| objectPath      | Body | String | O        | Log file path to be stored in container                  |
+```http
+---
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | Log File name list |
+| tenantId | String | Y | Tenant ID of object storage to store log file<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where log file is stored |
+| targetContainer | String | Y | Object storage container where log file is stored |
+| objectPath | String | Y | Log file path to be stored in container |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### List Network Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"availabilityZone": "kr-pub-a",
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetName": "subnetName-example",
+},
+},
+{
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZone | String | Availability zone where DB instance will be created |
+| subnet | Object | Subnet object |
+| subnet.subnetId | UUID | Subnet identifier |
+| subnet.subnetName | String | Name to identify subnets |
+| subnet.subnetCidr | String | CIDR of subnet |
+| endPoints | Array | List of access information |
+| endPoints.domain | String | Domain |
+| endPoints.ipAddress | String | IP address |
+| endPoints.endPointType | String | Access information type |
+
+---
+
+### Modify Network Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | Whether external access is available |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Promote DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Replicate DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| network | Object | Y | Network information objects |
+| network.usePublicAccess | Boolean | N | Whether external access is available |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | N | Storage information objects |
+| storage.storageType | Enum | N | Data storage type |
+| storage.storageSize | Number | N | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | N | Backup information objects |
+| backup.backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock |
+| backup.backupSchedules | Array | N | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restart DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Boolean | N | Whether to execute backup at the current point in time<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Whether to wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Whether to block write workload<br/>- Default: `false` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### View Restoration Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### View the Last Query to Be Restored
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| executedYmdt | DateTime | Query execution date and time |
+| lastQuery | String | Last executed query |
+
+---
+
+### Restore DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+}
+}
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Identifier of the image |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.restoreType | Enum | Y | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration using a restorable binary log location`<br/>- BACKUP: `Snapshot restoration using a previously created backup` |
+| restore.binLog.binLogFileName | String | N | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Object | N | Binary log location to use for restoration |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+
+#### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB instance restoration date and time |
+
+POST /v3.0/db-instances/{dbInstanceId}/restore
+
+#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+| restore.binLog | Object | N | Binary log information object to use for restoration |
+
+Restoration is possible only before the most recent restorable time queried through restoration information inquiry.
+
+#### Request when restoring from backup (if restoreType is `BACKUP`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Start DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Stop DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### View Storage Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageType": "General SSD",
+"storageSize": 1,
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageType | Enum | Data storage type |
+| storageSize | Number | Data storage size (GB) |
+| storageStatus | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+
+---
+
+### Modify Storage Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | Data storage size (GB)<br/>- Maximum value: `2048` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
@@ -2341,629 +2941,755 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### Backup Status
 
-| Status       | Description             |
-|--------------|-------------------------|
-| `BACKING_UP` | Backup in progress      |
-| `COMPLETED`  | Backup is completed     |
-| `DELETING`   | Backup is being deleted |
-| `DELETED`    | Backup is deleted       |
-| `ERROR`      | Error occurred          |
+| Status | Description |
+|--------------|--------------|
+| `BACKING_UP` | Backup in progress |
+| `COMPLETED` | Backup is completed |
+| `DELETING` | Backup is being deleted |
+| `DELETED` | Backup is deleted |
+| `ERROR` | Error occurred |
 
 ### Retrieve Backup List
 
+#### Request
+
 ```http
-GET /v3.0/backups
+---
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                          |
-|--------------|-------|--------|----------|--------------------------------------------------------------------------------------|
-| page         | Query | Number | O        | Page to retrieve<br/>- Minimum value: `1`                                            |
-| size         | Query | Number | O        | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`            |
-| backupType   | Query | Enum   | X        | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X        | Original DB instance identifier                                                      |
-| dbVersion    | Query | Enum   | X        | DB engine type                                                                       |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                         |
-|----------------------|------|----------|-----------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                          |
-| backups              | Body | Array    | Backup list                                         |
-| backups.backupId     | Body | UUID     | Backup identifier                                   |
-| backups.backupName   | Body | String   | Name to identify backups                            |
-| backups.backupStatus | Body | Enum     | Backup current status                               |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                     |
-| backups.dbVersion    | Body | Enum     | DB engine type                                      |
-| backups.backupType   | Body | Enum     | Backup type                                         |
-| backups.backupSize   | Body | Number   | Backup size (Byte)                                  |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Export Backup
-
-```http
-POST /v3.0/backups/{backupId}/export
-```
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| backupId        | URL  | UUID   | O        | Backup identifier                                      |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                     |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-> [Caution]
-> To export a manual backup, the DB instance from which the backup originated must exist.
-
----
-
-### Restore Backup
-
-```http
-POST /v3.0/backups/{backupId}/restore
-```
-
-#### Request
-
-| Name                                     | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|------------------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O        | Backup identifier                                                                                                                                                                                                                                                         |
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                    |
-| dbFlavorId                               | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                                                                                                                                                  |
-| dbPort                                   | Body | Integer | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O        | Parameter group identifier                                                                                                                                                                                                                                                |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                             ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                    |
-| useHighAvailability                      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                     |
-| pingInterval                             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                     |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                  |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                                                                                                                                                  | 
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Number of all backup lists |
+| backups | Array | Backup list |
+| backups.backupId | UUID | Backup identifier |
+| backups.backupName | String | Name to identify backups |
+| backups.backupStatus | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | UUID | Original DB instance identifier |
+| backups.dbVersion | String | DB engine type |
+| backups.utilVersion | String | Utility version |
+| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | Backup size (Byte) |
+| backups.createdYmdt | DateTime | Created date and time |
+| backups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Delete Backup
 
+#### Request
+
 ```http
-DELETE /v3.0/backups/{backupId}
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name     | Type | Format | Required | Description       |
-|----------|------|--------|----------|-------------------|
-| backupId | URL  | UUID   | O        | Backup identifier |
-
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-## DB Security Group
+### Export Backup
 
-### DB Security Group Progress
+#### Request
 
-| Status          | Description         |
-|-----------------|---------------------|
-| `NONE`          | No task in progress |
-| `CREATING_RULE` | Creating rules      |
-| `UPDATING_RULE` | Modifying rules     |
-| `DELETING_RULE` | Deleting rules      |
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup is stored |
+| targetContainer | String | Y | Object storage container where backup is stored |
+| objectPath | String | Y | Backup path to be stored in container |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restore Backup
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+## DB Security Groups
+
+### DB Security Group Progress Status
+
+| Status | Description |
+|-----------------|--------------|
+| `NONE` | No operation in progress |
+| `CREATING_RULE` | Creating rule policy |
+| `UPDATING_RULE` | Modifying rule policy |
+| `DELETING_RULE` | Deleting rule policy |
 
 ### List DB Security Groups
 
-```http
-GET /v3.0/db-security-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                                 | Type | Format   | Description                                         |
-|--------------------------------------|------|----------|-----------------------------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB security groups                                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB security group identifier                        |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | Name to identify DB instances                       |
-| dbSecurityGroups.description         | Body | String   | Additional information on DB security group         |
-| dbSecurityGroups.progressStatus      | Body | Enum     | Current status of DB security group                 |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### List DB Security Group Details
-
-```http
-GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
-
 #### Response
 
-| Name                | Type | Format   | Description                                                                                                                                              |
-|---------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB security group identifier                                                                                                                             |
-| dbSecurityGroupName | Body | String   | Name to identify DB instances                                                                                                                            |
-| description         | Body | String   | Additional information on DB security group                                                                                                              |
-| progressStatus      | Body | Enum     | Current status of DB security group                                                                                                                      |
-| rules               | Body | Array    | DB security group rules                                                                                                                                  |
-| rules.ruleId        | Body | UUID     | DB security group rule identifier                                                                                                                        |
-| rules.description   | Body | String   | Additional information on DB security group rule                                                                                                         |
-| rules.direction     | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                |
-| rules.etherType     | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                         |
-| rules.port          | Body | Object   | Port object                                                                                                                                              |
-| rules.port.portType | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number   | Minimum port range                                                                                                                                       |
-| rules.port.maxPort  | Body | Number   | Maximum port range                                                                                                                                       |
-| rules.cidr          | Body | String   | Remote source for traffic to allow                                                                                                                       |
-| rules.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| rules.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-| createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB security group list |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroups.description | String | Additional information on the DB security group |
+| dbSecurityGroups.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rule`<br/>- UPDATING_RULE: `Modifying rule`<br/>- DELETING_RULE: `Deleting rule`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroups.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Security Group
 
-```http
-POST /v3.0/db-security-groups
-```
-
 #### Request
 
-| Name                | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|---------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O        | Name to identify DB instances                                                                                                                                                                                                    |
-| description         | Body | String | X        | Additional information on DB security group                                                                                                                                                                                      |
-| rules               | Body | Array  | O        | DB security group rules                                                                                                                                                                                                          |
-| rules.description   | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| rules.etherType     | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| rules.cidr          | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| rules.port.portType | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name              | Type | Format | Description                  |
-|-------------------|------|--------|------------------------------|
-| dbSecurityGroupId | Body | UUID   | DB security group identifier |
-
+```http
 ---
-
-### Modify DB Security Group
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name                | Type | Format | Required | Description                                 |
-|---------------------|------|--------|----------|---------------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O        | DB security group identifier                |
-| dbSecurityGroupName | Body | String | X        | Name to identify DB instances               |
-| description         | Body | String | X        | Additional information on DB security group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+{
+"description": "description-example",
+"description": "description-example",
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB security group<br/>- Maximum length: `100` |
+| rules | Array | Y | DB security group rule list |
+| rules.direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| rules.port | Object | Y | Port object |
+| rules.port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | Additional information on the security group rule |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
 
 ---
 
 ### Delete DB Security Group
 
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-### Create DB Security Group Rule
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+### List DB Security Group Details
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"description": "description-example",
+{
+{
+"description": "description-example",
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB security group |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroup.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroup.description | String | Additional information on the DB security group |
+| dbSecurityGroup.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rule`<br/>- UPDATING_RULE: `Modifying rule`<br/>- DELETING_RULE: `Deleting rule`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroup.rules | Array | DB security group rule list |
+| dbSecurityGroup.rules.ruleId | UUID | DB security group rule identifier |
+| dbSecurityGroup.rules.description | String | Additional information on the DB security group rule |
+| dbSecurityGroup.rules.direction | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| dbSecurityGroup.rules.etherType | Enum | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| dbSecurityGroup.rules.port | Object | Port object |
+| dbSecurityGroup.rules.port.portType | Enum | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| dbSecurityGroup.rules.port.minPort | Number | Minimum port range |
+| dbSecurityGroup.rules.port.maxPort | Number | Maximum port range |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | Modified date and time |
+| dbSecurityGroup.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### Modify DB Security Group Rule
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
+### Modify DB Security Group
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O        | DB security group rule identifier                                                                                                                                                                                                |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
+```http
+---
+```
 
-> [Caution]
-> DB port cannot be set to transmit direction.
+#### Request Parameters
 
-<details><summary>Example</summary>
-<p>
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB security group<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+This API does not return a response body.
 
 ---
 
 ### Delete DB Security Group Rule
 
+#### Request
+
 ```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type  | Format | Required | Description                        |
-|-------------------|-------|--------|----------|------------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O        | DB security group identifier       |
-| ruleIds           | Query | Array  | O        | DB security group rule identifiers |
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Create DB Security Group Rule
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Modify DB Security Group Rule
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule<br/>- Maximum length: `200` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
@@ -2971,375 +3697,372 @@ This API does not require a request body.
 
 ### List Parameter Groups
 
-```http
-GET /v3.0/parameter-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-| Name      | Type  | Format | Required | Description    |
-|-----------|-------|--------|----------|----------------|
-| dbVersion | Query | Enum   | X        | DB engine type |
-
-#### Response
-
-| Name                                 | Type | Format   | Description                                                                                 |
-|--------------------------------------|------|----------|---------------------------------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                                            |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                                  |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                                           |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                   |
-| parameterGroups.dbVersion            | Body | Enum     | DB engine type                                                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                          |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                         |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
+```http
 ---
-
-### List Parameter Group Details
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                           |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | Parameter group identifier                                                                                                                            |
-| parameterGroupName            | Body | String   | Name to identify parameter groups                                                                                                                     |
-| description                   | Body | String   | Additional information on parameter group                                                                                                             |
-| dbVersion                     | Body | Enum     | DB engine type                                                                                                                                        |
-| parameterGroupStatus          | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply                                                           |
-| parameters                    | Body | Array    | Parameter list                                                                                                                                        |
-| parameters.parameterId        | Body | UUID     | Parameter identifier                                                                                                                                  |
-| parameters.parameterFileGroup | Body | Enum     | Parameter file group type<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                                                          |
-| parameters.parameterName      | Body | String   | Parameter name                                                                                                                                        |
-| parameters.fileParameterName  | Body | String   | Parameter file name                                                                                                                                   |
-| parameters.value              | Body | String   | Current value                                                                                                                                         |
-| parameters.defaultValue       | Body | String   | Default value                                                                                                                                         |
-| parameters.allowedValue       | Body | String   | Permitted values                                                                                                                                      |
-| parameters.updateType         | Body | Enum     | Modify type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable<br/>- `INIT_VARIABLE`: Only modifiable when DB instance is created |
-| parameters.applyType          | Body | Enum     | Apply type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All (restart required)                    |
-| createdYmdt                   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| updatedYmdt                   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                   |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroups | Array | Parameter groups |
+| parameterGroups.parameterGroupId | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | String | Name to identify parameter groups |
+| parameterGroups.description | String | Additional information on parameter group |
+| parameterGroups.dbVersion | String | DB engine type |
+| parameterGroups.parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Parameter Group
 
-```http
-POST /v3.0/parameter-groups
-```
-
 #### Request
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-| dbVersion          | Body | Enum   | O        | DB engine type                            |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
+```http
 ---
-
-### Copy Parameter Group
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
 ```
 
-#### Request
+#### Request Body
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
+{
+"description": "description-example",
+"description": "description-example",
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | String | Y | DB engine type |
 
 #### Response
 
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Modify Parameter Group
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | X        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Parameter
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Request
-
-| Name                           | Type | Format | Required | Description                |
-|--------------------------------|------|--------|----------|----------------------------|
-| parameterGroupId               | URL  | UUID   | O        | Parameter group identifier |
-| modifiedParameters             | Body | Array  | O        | Parameters to change       |
-| modifiedParameters.parameterId | Body | UUID   | O        | Parameter identifier       |
-| modifiedParameters.value       | Body | String | O        | Parameter value to change  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Reset Parameter Group
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Request
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Delete Parameter Group
 
-```http
-DELETE /v3.0/parameter-groups/{parameterGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### List Parameter Group Details
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+| parameterGroupName | String | Name to identify parameter groups |
+| description | String | Additional information on parameter group |
+| dbVersion | String | DB engine type |
+| parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Array | Parameter list |
+| parameters.parameterId | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | Parameter name |
+| parameters.fileParameterName | String | Parameter file name |
+| parameters.value | String | Current value |
+| parameters.defaultValue | String | Default value |
+| parameters.allowedValue | String | Permitted values |
+| parameters.updateType | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
+
+---
+
+### Modify Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+
+---
+
+### Modify Parameter
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | Parameters to change |
+| modifiedParameters.parameterId | UUID | Y | Parameter identifier |
+| modifiedParameters.value | String | Y | Parameter value to change |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
 
 ---
 
@@ -3347,232 +4070,223 @@ This API does not return a response body.
 
 ### List User Groups
 
-```http
-GET /v3.0/user-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                     | Type | Format   | Description                                         |
-|--------------------------|------|----------|-----------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                         |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                        |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### List User Group Details
-
-```http
-GET /v3.0/user-groups/{userGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
-
 #### Response
 
-| Name              | Type | Format   | Description                                                                                                                                            |
-|-------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                                                                  |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                                                           |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| members           | Body | Array    | Project member list                                                                                                                                    |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| userGroups.createdYmdt | DateTime | Created date and time |
+| userGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create User Group
 
-```http
-POST /v3.0/user-groups
-```
-
 #### Request
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupName | Body | String  | O        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | O        | Project member identifiers <br /> Ignored when `selectAllYN` is true        |
-| selectAllYN   | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name        | Type | Format | Description           |
-|-------------|------|--------|-----------------------|
-| userGroupId | Body | UUID   | User group identifier |
-
+```http
 ---
-
-### Modify User Group
-
-```http
-PUT /v3.0/user-groups/{userGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O        | User group identifier                                                       |
-| userGroupName | Body | String  | X        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | X        | Project member identifiers                                                  |
-| selectAllYN   | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | Y | Project member identifier list |
+| selectAllYN | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
 
 ---
 
 ### Delete User Group
 
-```http
-DELETE /v3.0/user-groups/{userGroupId}
-```
-
 #### Request
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### View User Group Details
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"members": [
+{
+{
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
+| userGroupName | String | Name to identify user groups |
+| userGroupTypeCode | Enum | User group type<br/>- `ENTIRE`: User group including all project members<br/>- `INDIVIDUAL_MEMBER`: User group including specific project members |
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
+
+---
+
+### Modify User Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | N | Project member identifier list |
+| selectAllYN | Boolean | N | Whether to include all project members<br/>- Default: `false` |
+
+#### Response
+
+This API does not return a response body.
 
 ---
 
@@ -3580,363 +4294,319 @@ This API does not return a response body.
 
 ### List Notification Groups
 
-```http
-GET /v3.0/notification-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                                     | Type | Format   | Description                                         |
-|------------------------------------------|------|----------|-----------------------------------------------------|
-| notificationGroups                       | Body | Array    | Notification Groups                                 |
-| notificationGroups.notificationGroupId   | Body | UUID     | Notification group identifier                       |
-| notificationGroups.notificationGroupName | Body | String   | Name to identify notification groups                |
-| notificationGroups.notifyEmail           | Body | Boolean  | Whether to be notified by email                     |
-| notificationGroups.notifySms             | Body | Boolean  | Whether to be notified by SMS                       |
-| notificationGroups.isEnabled             | Body | Boolean  | Indicates whether the flavor is enabled             |
-| notificationGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| notificationGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### View Notification Group Details
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
-
 #### Response
 
-| Name                       | Type | Format   | Description                                         |
-|----------------------------|------|----------|-----------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                       |
-| notificationGroupName      | Body | String   | Name to identify notification groups                |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                     |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                       |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled             |
-| dbInstances                | Body | Array    | DB Instances to monitor                             |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                              |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                       |
-| userGroups                 | Body | Array    | User Groups                                         |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                        |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroups | Array | Notification group list |
+| notificationGroups.notificationGroupId | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Boolean | Whether enabled |
+| notificationGroups.createdYmdt | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Notification Group
 
-```http
-POST /v3.0/notification-groups
-```
-
 #### Request
 
-| Name                  | Type | Format  | Required | Description                                                 |
-|-----------------------|------|---------|----------|-------------------------------------------------------------|
-| notificationGroupName | Body | String  | O        | Name to identify notification groups                        |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email<br/>- Default: `true`         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS<br/>- Default: `true`           |
-| isEnabled             | Body | Boolean | X        | Whether enabled<br/>- Default: `true`                         |
-| dbInstanceIds         | Body | Array   | O        | DB instance identifiers to monitor                          |
-| userGroupIds          | Body | Array   | O        | User group identifiers                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name                | Type | Format | Description                   |
-|---------------------|------|--------|-------------------------------|
-| notificationGroupId | Body | UUID   | Notification group identifier |
-
+```http
 ---
-
-### Modify Notification Group
-
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name                  | Type | Format  | Required | Description                             |
-|-----------------------|------|---------|----------|-----------------------------------------|
-| notificationGroupId   | URL  | UUID    | O        | Notification group identifier           |
-| notificationGroupName | Body | String  | X        | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled |
-| dbInstanceIds         | Body | Array   | X        | DB instance identifiers to monitor      |
-| userGroupIds          | Body | Array   | X        | User group identifiers                  |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+{
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Array | Y | Identifier list of DB instances to monitor |
+| userGroupIds | Array | Y | User group identifier list |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
 
 ---
 
 ### Delete Notification Group
 
-```http
-DELETE /v3.0/notification-groups/{notificationGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-## Monitoring
-
-### List Metric List
-
-```http
-GET /v3.0/metrics
-```
+### View Notification Group Details
 
 #### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                | Type | Format | Description          |
-|---------------------|------|--------|----------------------|
-| metrics             | Body | Array  | Metric List          |
-| metrics.measureName | Body | Enum   | Metric type to query |
-| metrics.unit        | Body | String | Measure unit         |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
+| notificationGroupName | String | Name to identify notification groups |
+| notifyEmail | Boolean | Whether to be notified by email |
+| notifySms | Boolean | Whether to be notified by SMS |
+| isEnabled | Boolean | Whether enabled |
+| dbInstances | Array | DB instance list to monitor |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### View stats
-
-```http
-GET /v3.0/metric-statistics
-```
+### Modify Notification Group
 
 #### Request
 
-| Name         | Type  | Format   | Required | Description                                      |
-|--------------|-------|----------|----------|--------------------------------------------------|
-| dbInstanceId | Query | UUID     | O        | DB instance identifier                           |
-| measureNames | Query | Array    | O        | Metric list to query<br/>- Minimum length: `1`   |
-| from         | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)   |
-| interval     | Query | Number   | X        | View interval                                    |
+```http
+---
+```
 
-#### Response
+#### Request Parameters
 
-| Name                              | Type | Format    | Description                 |
-|-----------------------------------|------|-----------|-----------------------------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.measureName      | Body | Enum      | Measure type                |
-| metricStatistics.unit             | Body | String    | Measure unit                |
-| metricStatistics.values           | Body | Array     | Measure values              |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time                |
-| metricStatistics.values.value     | Body | Object    | Measure value               |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Array | N | Identifier list of DB instances to monitor |
+| userGroupIds | Array | N | User group identifier list |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+## Monitoring
+
+### View stats
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### List Metric List
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"measureName": "measureName-example",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| metrics | Array | Metric list |
+| metrics.measureName | String | Metric type to query |
+| metrics.unit | String | Measure unit |
 
 ---
 
@@ -3944,137 +4614,340 @@ GET /v3.0/metric-statistics
 
 ### Event category
 
-Events can be categorized into categories, which are shown below.
+---
 
 | Event category | Description |
-|----------------|-------------|
-| ALL            | All         |
-| BACKUP         | Backups     |
-| DB_INSTANCE    | DB Instance |
-| JOB            | Jobs        |
-| TENANT         | Tenant      |
-| MONITORING     | Monitoring  |
-
-### List Events
-
-```http
-GET /v3.0/events
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format   | Required | Description                                                                                                                                                         |
-|-------------------|-------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O        | Page to retrieve<br/>- Minimum value: `1`                                                                                                                           |
-| size              | Query | Number   | O        | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`                                                                                           |
-| from              | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                    |
-| to                | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| eventCategoryType | Query | Enum     | O        | Event category types to query<br/>- `ALL`: All<br/>- `INSTANCE`: DB instance<br/>- `BACKUP`: Backup<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `TENANT`: Tenant |
-| sourceId          | Query | String   | X        | Event target resource identifier                                                                                                                                    |
-| keyword           | Query | String   | X        | String keyword in event message                                                                                                                                     |
-| ascendingOrder    | Query | Enum     | X        | Event message sorting order<br/>- `ASC`: Ascending order<br/>- `DESC`: Descending order<br/>- Default value: `DESC`                                                       |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                               |
-|--------------------------|------|----------|-----------------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                    |
-| events                   | Body | Array    | Events                                                    |
-| events.eventCategoryType | Body | Enum     | Event category type                                       |
-| events.eventCode         | Body | Enum     | Occurred event type                                       |
-| events.sourceId          | Body | String   | Event source identifier                                   |
-| events.sourceName        | Body | String   | Name to identify event sources                            |
-| events.messages          | Body | Array    | Event messages                                            |
-| events.messages.langCode | Body | String   | Language code                                             |
-| events.messages.message  | Body | String   | Event Message                                             |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+|-------------|---------|
+| ALL | All |
+| BACKUP | Backup |
+| DB_INSTANCE | DB instance |
+| JOB | Job |
+| TENANT | Tenant |
+| MONITORING | Monitoring |
 
 ### List Subscribable Event Codes
 
+#### Request
+
 ```http
-GET /v3.0/event-codes
+Events can be categorized into categories, which are shown below.
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format | Description         |
-|------------------------------|------|--------|---------------------|
-| eventCodes                   | Body | Array  | Event Codes         |
-| eventCodes.eventCode         | Body | Enum   | Event Code          |
-| eventCodes.eventCategoryType | Body | Enum   | Event category type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"eventCode": "ENUM_VALUE",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventCodes | Array | Event code list |
+| eventCodes.eventCode | Enum | Event code |
+| eventCodes.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
+---
+
+### List Events
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+{
+{
+"langCode": "KO",
+}
+],
+],
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of events |
+| events | Array | Event list |
+| events.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | Occurred event type |
+| events.sourceId | UUID | Event source identifier |
+| events.sourceName | String | Name to identify event sources |
+| events.messages | Array | Event message list |
+| events.messages.langCode | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | Event message |
+| events.eventYmdt | DateTime | Event occurred date and time |
+
+---
+
+## Event Subscription
+
+### List Event Subscriptions
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+],
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of event subscriptions |
+| eventSubscriptions | Array | Event subscription list |
+| eventSubscriptions.eventSubscriptionId | UUID | Event subscription identifier |
+| eventSubscriptions.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | Name to identify the event subscription |
+| eventSubscriptions.enabled | Boolean | Whether enabled |
+| eventSubscriptions.notifyEmail | Boolean | Whether to send email notifications |
+| eventSubscriptions.notifySms | Boolean | Whether to send SMS notifications |
+| eventSubscriptions.eventCodes | Array | Event code list to subscribe to |
+| eventSubscriptions.sources | Array | Event source list to subscribe to |
+| eventSubscriptions.sources.sourceId | UUID | Event source identifier |
+| eventSubscriptions.sources.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | List of user group identifiers subscribed to the event |
+| eventSubscriptions.createdYmdt | DateTime | Created date and time |
+
+---
+
+### Create Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | Name to identify the event subscription |
+| enabled | Boolean | Y | Whether enabled |
+| notifyEmail | Boolean | Y | Whether to send email notifications |
+| notifySms | Boolean | Y | Whether to send SMS notifications |
+| eventCodes | Array | Y | Event code list to subscribe to |
+| sources | Array | Y | Event source list to subscribe to |
+| sources.sourceId | UUID | Y | Event source identifier |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | List of user group identifiers to subscribe to the event |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | Event subscription identifier |
+
+---
+
+### Delete Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Modify Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | Name to identify the event subscription |
+| enabled | Boolean | N | Whether enabled |
+| notifyEmail | Boolean | N | Whether to send email notifications |
+| notifySms | Boolean | N | Whether to send SMS notifications |
+| eventCodes | Array | N | Event code list to subscribe to |
+| sources | Array | N | Event source list to subscribe to |
+| sources.sourceId | UUID | Y | Event source identifier |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | List of user group identifiers to subscribe to the event |
+
+#### Response
+
+This API does not return a response body.
 
 ---

--- a/en/api-guide-v3.0.md
+++ b/en/api-guide-v3.0.md
@@ -1,167 +1,195 @@
-## Database > RDS for MariaDB > API Guide
+## RDS for MariaDB API Guide
+
+**Database > RDS for MariaDB > API v3.0 Guide**
 
 ## RDS for MariaDB API Common Information
 
 ### API Endpoint
 
 | Region | Endpoint |
-|--------|----------|
+|------|----------|
 | Korea (Pangyo) region | https://kr1-rds-mariadb.api.nhncloudservice.com |
+
 
 ### Authentication and Authorization
 
 User Access Key is required to use the RDS for MariaDB API. A User Access Key is an authentication key issued based on an NHN Cloud or IAM account. It is used in conjunction with a Secret Access Key to authenticate API requests.
 
 User Access Keys and Secret Access Keys can be issued in the console's API Security Setting. For more information on issuing and using User Access Key, please refer to the [User Access Key](/nhncloud/en/public-api/user-access-key).
-
 The created Key must be included in the request Header.
 
-| Name                       | Type   | Format | Required | Description                                                              |
-|----------------------------|--------|--------|----------|--------------------------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O        | Appkey of RDS for MariaDB or integrated Appkey for project |
-| X-TC-AUTHENTICATION-ID     | Header | String | O        | User Access Key ID in API Security Settings menu                         |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O        | Secret Access Key in API Security Settings menu                          |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | Appkey of RDS for MariaDB or integrated Appkey for project |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | User Access Key ID in API Security Settings menu |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | Secret Access Key in API Security Settings menu |
 
 In addition, the APIs you can call are limited based on the project member role. You can grant permissions separately for `RDS for MariaDB ADMIN` and `RDS for MariaDB VIEWER`.
 
 * `RDS for MariaDB ADMIN permission holders` can use all available features as before.
 * `RDS for MariaDB VIEWER permission holders` can use read-only feature.
-    * Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
-    * But, notification group and user group-related features are available.
+* Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
+* But, notification group and user group-related features are available.
 
 If an API request fails to authenticate or is not authorized, the following error occurs.
 
-| resultCode | resultMessage | Description            |
-|------------|---------------|------------------------|
-| 80401      | Unauthorized  | Failed to authenticate |
-| 80403      | Forbidden     | Unauthorized.          |
+| resultCode | resultMessage | Description |
+|------------|---------------|-----|
+| 80401 | Unauthorized | Failed to authenticate |
+| 80403 | Forbidden | Unauthorized. |
 
 ### Common Response Information
 
 The API responds with "200 OK" to all API requests. For more information on the response results, see Response Body Header.
 
-#### Response Body
+<details>
+  <summary><strong>Successful Response</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### Field
-| Name          | Format  | Description                                              |
-|---------------|---------|----------------------------------------------------------|
-| resultCode    | Number  | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
-| resultMessage | String  | Result message                                           |
-| isSuccessful  | Boolean | Successful or not                                        |
+</details>
 
+<details>
+  <summary><strong>Failure Response</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| resultCode | Number | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
+| resultMessage | String | Result message |
+| isSuccessful | Boolean | Successful or not |
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
 
 ## Project Information
 
-### List Regions
-
-```http
-GET /v3.0/project/regions
-```
+### List Project Members
 
 #### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name    | Type | Format | Description |
-|---------|------|--------|-------------|
-| regions | Body | Array  | Region list |
-| regions.regionCode | Body | Enum    | Region code<br/>- `KR1`: Korea (Pangyo) Region|
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                                                                 |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### List Project Members
 
 ```http
 GET /v3.0/project/members
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                 | Type | Format | Description                  |
-|----------------------|------|--------|------------------------------|
-| members              | Body | Array  | Project member list          |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name          |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile        |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| members.memberName | String | Project member name |
+| members.emailAddress | String | Project member email address |
+| members.phoneNumber | String | Project member mobile |
+
+---
+
+### List Regions
+
+#### Request
+
+```http
+GET /v3.0/project/regions
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| regions | Array | Region list |
+| regions.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Boolean | Whether to enable a region |
 
 ---
 
@@ -169,47 +197,48 @@ This API does not require a request body.
 
 ### List DB Instance Specifications
 
+#### Request
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                   | Type | Format | Description                              |
-|------------------------|------|--------|------------------------------------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications       |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications       |
-| dbFlavors.ram          | Body | Number | Memory size (MB)                         |
-| dbFlavors.vcpus        | Body | Number | CPU cores                                |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbFlavors | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | String | Name of DB instance specifications |
+| dbFlavors.ram | Number | Memory size (MB) |
+| dbFlavors.vcpus | Number | CPU cores |
 
 ---
 
@@ -217,49 +246,50 @@ This API does not require a request body.
 
 ### List Subnets
 
+#### Request
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format  | Description              |
-|--------------------------|------|---------|--------------------------|
-| subnets                  | Body | Array   | Subnet list              |
-| subnets.subnetId         | Body | UUID    | Subnet identifier        |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet           |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway   |
-| subnets.availableIpCount | Body | Number  | Number of available IPs  |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| subnets | Array | Subnet list |
+| subnets.subnetId | UUID | Subnet identifier |
+| subnets.subnetName | String | Name to identify subnets |
+| subnets.subnetCidr | String | CIDR of subnet |
+| subnets.usingGateway | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Number | Number of available IPs |
 
 ---
 
@@ -267,122 +297,126 @@ This API does not require a request body.
 
 ### List DB Engines
 
+#### Request
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB engine list                                        |
-| dbVersions.dbVersion         | Body | String  | DB engine type                                        |
-| dbVersions.dbVersionName     | Body | String  | DB engine name                                        |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbVersions | Array | DB engine list |
+| dbVersions.dbVersion | String | DB engine type |
+| dbVersions.dbVersionName | String | DB engine name |
+| dbVersions.restorableFromObs | Boolean | Restoring backup from object storage available or not |
 
 ---
 
 ## Storage
 
 ### List Storage Type
+
+#### Request
+
 ```http
 GET /v3.0/storage-types
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name         | Type | Format | Description       |
-|--------------|------|--------|-------------------|
-| storageTypes | Body | Array  | Storage type list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageTypes | Array | Storage type list |
 
 ---
 
 ### List Storage
 
+#### Request
+
 ```http
 GET /v3.0/storages
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name     | Type | Format | Description  |
-|----------|------|--------|--------------|
-| storages | Body | Array  | Storage list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storages": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storages": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storages | Array | Storage list |
 
 ---
 
@@ -390,72 +424,75 @@ This API does not require a request body.
 
 ### Task Status
 
-| Status Name        | Description                           |
-|--------------------|---------------------------------------|
-| `PREPARING`        | Task in preparation                   |
-| `READY`            | Task in ready                         |
-| `RUNNING`          | Task in progress                      |
-| `COMPLETED`        | Task completed                        |
-| `REGISTERED`       | Task registered                       |
-| `WAIT_TO_REGISTER` | Task waiting to register              |
-| `INTERRUPTED`      | Task being interrupted                |
-| `CANCELED`         | Task canceled                         |
-| `FAILED`           | Task failed                           |
-| `ERROR`            | Error occurred while task in progress |
-| `DELETED`          | Task deleted                          |
-| `FAIL_TO_READY`    | Failed to get ready for task          |
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | Task in preparation |
+| `READY` | Task in ready |
+| `RUNNING` | Task in progress |
+| `COMPLETED` | Task completed |
+| `REGISTERED` | Task registered |
+| `WAIT_TO_REGISTER` | Task waiting to register |
+| `INTERRUPTED` | Task being interrupted |
+| `CANCELED` | Task canceled |
+| `FAILED` | Task failed |
+| `ERROR` | Error occurred while task in progress |
+| `DELETED` | Task deleted |
+| `FAIL_TO_READY` | Failed to get ready for task |
 
 ### List Task Details
+
+#### Request
 
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name  | Type | Format | Required | Description     |
-|-------|------|--------|----------|-----------------|
-| jobId | URL  | UUID   | O        | Task identifier |
-
 #### Response
 
-| Name                           | Type | Format   | Description                                         |
-|--------------------------------|------|----------|-----------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                     |
-| jobStatus                      | Body | Enum     | Current task status                                 |
-| resourceRelations              | Body | Array    | Relevant resource list                              |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type                              |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                        |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+| jobStatus | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | Relevant resource list |
+| resourceRelations.resourceType | String | Relevant resource type |
+| resourceRelations.resourceId | String | Relevant resource identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -463,103 +500,107 @@ This API does not require a request body.
 
 ### List DB Instance Groups
 
+#### Request
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                               | Type | Format   | Description                                                                                                    |
-|------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB instance groups                                                                                             |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                   |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                             |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                            |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB instance groups |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Standalone`<br/>- HIGH_AVAILABILITY: `High availability` |
+| dbInstanceGroups.createdYmdt | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### List DB Instance Group Details
 
+#### Request
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbInstanceGroupId | URL  | UUID   | O        | DB instance group identifier |
-
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                             |
-|------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                          |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                                                |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                                              |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Standalone`<br/>- HIGH_AVAILABILITY: `High availability` |
+| dbInstances | Array | DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -567,1773 +608,2332 @@ This API does not require a request body.
 
 ### DB Instance Status
 
-| Status             | Description                               |
-|--------------------|-------------------------------------------|
-| `AVAILABLE`        | DB instance is available                  |
-| `BEFORE_CREATE`    | Before DB instance is created             |
-| `STORAGE_FULL`     | Insufficient DB instance storage          |
-| `FAIL_TO_CREATE`   | Failed to create DB instance              |
-| `FAIL_TO_CONNECT`  | Failed to connect DB instance             |
-| `REPLICATION_STOP` | Replication of DB instance is stopped     |
-| `FAILOVER`         | High availability DB instance failed over |
-| `SHUTDOWN`         | DB instance is stopped                    |
-| `DELETED`          | DB instance is deleted                    |
+| Status | Description |
+|---------------------|------------------------------|
+| `AVAILABLE` | DB instance is available |
+| `BEFORE_CREATE` | Before DB instance is created |
+| `STORAGE_FULL` | Insufficient DB instance storage |
+| `FAIL_TO_CREATE` | Failed to create DB instance |
+| `FAIL_TO_CONNECT` | Failed to connect DB instance |
+| `REPLICATION_STOP` | Replication of DB instance is stopped |
+| `FAILOVER` | High availability DB instance failed over |
+| `SHUTDOWN` | DB instance is stopped |
+| `DELETED` | DB instance is deleted |
 
 ### DB Instance Progress Status
 
-| Status                     | Description                      |
-|----------------------------|----------------------------------|
+| Status | Description |
+|----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up                       |
-| `CANCELING`                | Canceling                        |
-| `CREATING`                 | Creating                         |
-| `CREATING_SCHEMA`          | Creating DB schema	              |
-| `CREATING_USER`            | Creating user	                   |
-| `DELETING`                 | Deleting                         |
-| `DELETING_SCHEMA`          | Deleting DB schema               |
-| `DELETING_USER`            | Deleting user                    |
-| `EXPORTING_BACKUP`         | Exporting backup                 |
-| `FAILING_OVER`             | Under failover                   |
-| `MIGRATING`                | Under migration                  |
-| `MODIFYING`                | Under modification               |
-| `PREPARING`                | In preparation                   |
-| `PROMOTING`                | Promoting                        |
-| `REBUILDING`               | Rebuilding                       |
-| `REPAIRING`                | Recovering                       |
-| `REPLICATING`              | Replicating                      |
-| `RESTARTING`               | Restarting                       |
-| `RESTARTING_FORCIBLY`      | Force restarting                 |
-| `RESTORING`                | Restoring                        |
-| `STARTING`                 | Starting                         |
-| `STOPPING`                 | Stopping                         |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema          |
-| `SYNCING_USER`             | Synchronizing user	              |
-| `UPDATING_USER`            | Modifying user	                  |
+| `BACKING_UP` | Backing up |
+| `CANCELING` | Canceling |
+| `CREATING` | Creating |
+| `CREATING_SCHEMA` | Creating DB schema |
+| `CREATING_USER` | Creating user |
+| `DELETING` | Deleting |
+| `DELETING_SCHEMA` | Deleting DB schema |
+| `DELETING_USER` | Deleting user |
+| `EXPORTING_BACKUP` | Exporting backup |
+| `FAILING_OVER` | Under failover |
+| `MIGRATING` | Under migration |
+| `MODIFYING` | Under modification |
+| `PREPARING` | In preparation |
+| `PROMOTING` | Promoting |
+| `REBUILDING` | Rebuilding |
+| `REPAIRING` | Recovering |
+| `REPLICATING` | Replicating |
+| `RESTARTING` | Restarting |
+| `RESTARTING_FORCIBLY` | Force restarting |
+| `RESTORING` | Restoring |
+| `STARTING` | Starting |
+| `STOPPING` | Stopping |
+| `SYNCING_SCHEMA` | Synchronizing DB schema |
+| `SYNCING_USER` | Synchronizing user |
+| `UPDATING_USER` | Modifying user |
 
-### List DB instances
+### List DB Instances
+
+#### Request
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                                             |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                                           |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbInstances.dbVersion         | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current progress status                                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List DB Instance Details
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                        | Type | Format   | Description                                                                                                                                                             |
-|-----------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstanceGroupId           | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstanceName              | Body | String   | Name to identify DB instances                                                                                                                                           |
-| description                 | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbVersion                   | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbPort                      | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus            | Body | Enum     | DB instance current status                                                                                                                                              |
-| progressStatus              | Body | Enum     | Current task status of DB instance                                                                                                                                      |
-| dbFlavorId                  | Body | UUID     | Identifier of DB instance specifications                                                                                                                                |
-| parameterGroupId            | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                                       |
-| dbSecurityGroupIds          | Body | Array    | DB security group identifiers applied to DB instance                                                                                                                    |
-| notificationGroupIds        | Body | Array    | Notification group identifiers applied to DB instance                                                                                                                   |
-| useDeletionProtection       | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | Whether to support authentication plugin                                                                                                                                |
-| needToApplyParameterGroup   | Body | Boolean  | Need to apply the latest parameter group                                                                                                                                |
-| needMigration               | Body | Boolean  | Need to migrate                                                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | Whether to support DB version upgrade                                                                                                                                   |
-| createdYmdt                 | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                 | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
-
-<details><summary>Example</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstances | Array | DB instances |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| dbInstances.description | String | Additional information on DB instances |
+| dbInstances.dbVersion | String | DB engine type |
+| dbInstances.dbPort | Number | DB port |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Enum | Current progress status of DB instance<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | Created date and time |
+| dbInstances.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Instance
 
+#### Request
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### Request
+#### Request Body
 
-| Name                                     | Type | Format  | Required | Description                                                                                                           |
-|------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                               |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                |
-| dbFlavorId                               | Body | UUID    | O        | Identifier of DB instance specifications                                                                              |
-| dbVersion                                | Body | Enum    | O        | DB engine type                                                                                                        |
-| dbPort                                   | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                      |
-| dbUserName                               | Body | String  | O        | DB user account name                                                                                                  |
-| dbPassword                               | Body | String  | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                        |
-| parameterGroupId                         | Body | UUID    | O        | Parameter group identifier                                                                                            |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers                                                                                         ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                |
-| useHighAvailability                      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval                             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                              |
-| authenticationPlugin                     | Body | Enum    | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbVersion | String | Y | DB engine type |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| authenticationPlugin | Enum | N | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB Instance
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### Request
-
-| Name               | Type | Format  | Required | Description                                                                                                       |
-|--------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| dbInstanceName     | Body | String  | X        | Master name to identify DB                                                                                        |
-| dbInstanceCandidateName  | Body | String  | X        | Candidate name to identify DB instances                                                                     |
-| description        | Body | String  | X        | Additional information on DB instances                                                                            |
-| dbPort             | Body | Number  | X        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                  |
-| dbFlavorId         | Body | UUID    | X        | Identifier of DB instance specifications                                                                          |
-| parameterGroupId   | Body | UUID    | X        | Parameter group identifier                                                                                        |
-| dbSecurityGroupIds | Body | Array   | X        | DB security group identifiers                                                                                     |
-| executeBackup      | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| useOnlineFailover  | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### Delete DB instance
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
+### Restore DB Instance from Object Storage
 
 #### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Request
-
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| executeBackup     | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-### Force Restart DB instance
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### Start DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Stop DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Backup DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description              |
-|--------------|------|--------|----------|--------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier   |
-| backupName   | Body | String | O        | Name to identify backups |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Export after Backing up DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                 |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud member or IAM member ID                      |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Replicate DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Request
-
-| Name                                     | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                                         |
-|------------------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                             | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                                              |
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                                              |
-| dbFlavorId                               | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                                                                                                                                                  |
-| dbPort                                   | Body | Number  | X        | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers<br/>- Default: Original DB instance value                                                                                                                                                                                                                                             |
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                                              |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                                                                                                                                                                                            |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: Original DB instance value                                                                                                                                                                                                                                       |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                                                                       |
-| storage                                  | Body | Object  | X        | Storage information objects                                                                                                                                                                                                                                                                                         |    
-| storage.storageType                      | Body | Enum    | X        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                                                                     |
-| storage.storageSize                      | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | X        | Backup information objects                                                                                                                                                                                                                                                                                          |
-| backup.backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                 |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Promote DB Instance
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Restoration Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type | Format   | Description                                                                                                                                                                                                          |
-|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restorable time                                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restorable time                                                                                                                                                                                          |
-| restorableBackups                       | Body | Array    | List of restorable backups                                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                                                                          |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | Whether to use table lock                                                                                                                                                                                            |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                                                                          |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                                     |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>- `BACKING_UP`: Backup in progress<br/>- `COMPLETED`: Backup completed<br/>- `DELETING`: Backup being deleted<br/>- `DELETED`: Backup deleted<br/>- `ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DB engine type                                                                                                                                                                                                       |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                                                                                  |
-| restorableBackups.backup.binLogFileName | Body | String   | Binary log file name                                                                                                                                                                                                 |
-| restorableBackups.backup.binLogPosition | Body | Number   | Binary log file location                                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                                                                      |
-| restorableBackups.restorableBinLogs     | Body | Array    | Binary log names that can be restored using the backup                                                                                                                                                               |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### View the last query to be restored
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Common Request
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                                                        |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                                                             |
-| restoreType  | Query | Enum   | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored. |
-
-#### If restoreType is `TIMESTAMP`
-
-| Name        | Type  | Format   | Required | Description                                           |
-|-------------|-------|----------|----------|-------------------------------------------------------|
-| restoreYmdt | Query | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### If restoreType is `BINLOG`
-
-| Name           | Type  | Format | Required | Description                                     |
-|----------------|-------|--------|----------|-------------------------------------------------|
-| backupId       | Query | UUID   | O        | Identifier of the backup to use for restoration |
-| binLogFileName | Query | String | O        | Binary log name to use for restoration          |
-| binLogPosition | Query | Number | O        | Binary log location to use for restoration      |
-
-#### Response
-
-| Name         | Type | Format   | Description                                      |
-|--------------|------|----------|--------------------------------------------------|
-| executedYmdt | Body | DateTime | Query executed date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | Last executed query                              |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### Restoration
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Common Request
-
-| Name                    | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                                      |
-|-------------------------|------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                                           |
-| restore                 | Body | Object  | O        | Restoration information object                                                                                                                                                                                                                                                                                   |
-| restore.restoreType     | Body | Enum    | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored.<br/>- `BACKUP`: Snapshot restoration type using a previously created backup |
-| dbInstanceName          | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description             | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                                           |
-| dbFlavorId              | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                                                                                                                                                                                         |
-| dbPort                  | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                                                 |
-| parameterGroupId        | Body | UUID    | O        | Parameter group identifier                                                                                                                                                                                                                                                                                       |
-| dbSecurityGroupIds      | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                                                                    |
-| userGroupIds            | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                                           |
-| useHighAvailability     | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                                           |
-| pingInterval            | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                   |
-| useDefaultNotification  | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                        |
-| network                 | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                                                                      |
-| network.subnetId        | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                                                                |
-| network.usePublicAccess | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                                        |
-| network.availabilityZone | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                                                   |
-| storage                 | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                                                                      |
-| storage.storageType     | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                                                 |
-| storage.storageSize     | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                                                 |
-| backup                  | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                                                       |
-| backup.backupPeriod     | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                |
-| backup.backupRetryCount | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                           |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                   |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                       |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour    |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                                                          |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                | Type | Format   | Required | Description                                                                                                                                                                             |
-|---------------------|------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
-
-| Name                          | Type | Format | Required | Description                                     |
-|-------------------------------|------|--------|----------|-------------------------------------------------|
-| restore.backupId              | Body | UUID   | O        | Identifier of the backup to use for restoration |
-| restore.binLog                | Body | Object | O        | Binary log information object                   |
-| restore.binLog.binLogFileName | Body | String | O        | Binary log name to use for restoration          |
-| restore.binLog.binLogPosition | Body | Number | O        | Binary log location to use for restoration      |
-
-* When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request when restoring from backup (if restoreType is `BACKUP`)
-
-| Name             | Type | Format | Required                       | Description                                     |
-|------------------|------|--------|--------------------------------|-------------------------------------------------|
-| restore.backupId | Body | UUID   | O (if restoreType is `BACKUP`) | Identifier of the backup to use for restoration |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-### Restore from Object Storage
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### Request
+#### Request Body
 
-| Name                     | Type | Format  | Required | Description                                                                                                             |
-|--------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------------|
-| restore                  | Body | Object  | O        | Restoration information object                                                                                          |
-| restore.tenantId         | Body | String  | O        | Tenant ID of object storage where backups are stored                                                                    |
-| restore.username         | Body | String  | O        | NHN Cloud account or IAM member ID                                                                                      |
-| restore.password         | Body | String  | O        | API password for object storage where backups are stored                                                                |
-| restore.targetContainer  | Body | String  | O        | Container for object storage where backups are stored                                                                   |
-| restore.objectPath       | Body | String  | O        | Backup path stored in container                                                                                         |
-| dbVersion                | Body | Enum    | O        | DB engine type                                                                                                          |
-| dbInstanceName           | Body | String  | O        | Master name to identify DB instances                                                                                    |
-| dbInstanceCandidateName  | Body | String  | X        | Candidate name to identify DB instances                                                                                 |
-| description              | Body | String  | X        | Additional information on DB instances                                                                                  |
-| dbFlavorId               | Body | UUID    | O        | Identifier of DB instance specifications                                                                                |
-| dbPort                   | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                        |
-| parameterGroupId         | Body | UUID    | O        | Parameter group identifier                                                                                              |
-| dbSecurityGroupIds       | Body | Array   | X        | DB security group identifiers                                                                                           |
-| userGroupIds             | Body | Array   | X        | User group identifiers                                                                                                  |
-| useHighAvailability      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| network                  | Body | Object  | O        | Network information objects                                                                                             |
-| network.subnetId         | Body | UUID    | O        | Subnet identifier                                                                                                       |
-| network.usePublicAccess  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                              |
-| network.availabilityZone | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                           |
-| storage                  | Body | Object  | O        | Storage information objects                                                                                             |
-| storage.storageType      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                         |
-| storage.storageSize      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                           |
-| backup                   | Body | Object  | O        | Backup information objects                                                                                              |
-| backup.backupPeriod      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                             |
-| backup.ftwrlWaitTimeout  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                         |
-| backup.backupRetryCount  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                          |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                         |
-|-----------------------|------|---------|----------|-------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier              |
-| useDeletionProtection | Body | Boolean | O        | Whether to protect against deletion |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port |
+| dbVersion | String | Y | DB engine type |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Identifier of the image |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.tenantId | String | Y | Tenant ID of object storage where backups are stored |
+| restore.username | String | Y | NHN Cloud account or IAM member ID |
+| restore.password | String | Y | API password for object storage where backups are stored |
+| restore.targetContainer | String | Y | Container of object storage where backups are stored |
+| restore.objectPath | String | Y | Path of backup stored in container |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### Delete DB Instance
+
+#### Request
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### Modify High Availability
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Request
-
-| Name                | Type | Format  | Required | Description                                                                                          |
-|---------------------|------|---------|----------|------------------------------------------------------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O        | DB instance identifier                                                                               |
-| useHighAvailability | Body | Boolean | O        | Whether to use high availability                                                                     |
-| pingInterval        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### Restart High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
-```
+### View DB Instance Details
 
 #### Request
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Pause High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Recover High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Separate High Availability
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Storage Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name          | Type | Format | Description                                                                                                |
-|---------------|------|--------|------------------------------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | Block Storage Type                                                                                         |
-| storageSize   | Body | Number | Block Storage Size (GB)                                                                                    |
-| storageStatus | Body | Enum   | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB instance identifier |
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceName | String | Name to identify DB instances |
+| description | String | Additional information on DB instances |
+| dbVersion | String | DB engine type |
+| dbPort | Number | DB port |
+| dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Enum | Current status of DB instance<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delay (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Enum | Current progress status of DB instance<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | Identifier of DB instance specifications |
+| parameterGroupId | UUID | Identifier of the parameter group applied to the DB instance |
+| dbSecurityGroupIds | Array | List of identifiers of DB security groups applied to the DB instance |
+| notificationGroupIds | Array | List of identifiers of notification groups applied to the DB instance |
+| useDeletionProtection | Boolean | Whether deletion protection is enabled for the DB instance |
+| supportAuthenticationPlugin | Boolean | Whether authentication plugin is supported |
+| needToApplyParameterGroup | Boolean | Whether the latest parameter group needs to be applied |
+| needMigration | Boolean | Whether migration is required |
+| supportDbVersionUpgrade | Boolean | Whether DB version upgrade is supported |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### Modify Storage Information
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### Modify DB Instance
 
 #### Request
 
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| storageSize       | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbVersion | String | N | DB engine version code |
+| useDummy | Boolean | N | Whether to use a dummy during DB version upgrade of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| executeBackup | Boolean | N | Whether to execute backup at the current point in time<br/>- Default: `false` |
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Whether to wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Whether to block write workload<br/>- Default: `false` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Backup DB Instance
+
+#### Request
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"backupName": "backupName"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupName | String | Y | Name to identify backups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### View Backup Information
 
+#### Request
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                              | Type | Format  | Description                |
-|-----------------------------------|------|---------|----------------------------|
-| backupPeriod                      | Body | Number  | Backup retention period    |
-| ftwrlWaitTimeout                  | Body | Number  | Query latency (sec)        |
-| backupRetryCount                  | Body | Number  | Number of backup retries   |
-| replicationRegion                 | Body | Enum    | Backup replication region  |
-| useBackupLock                     | Body | Boolean | Whether to use table lock  |
-| backupSchedules                   | Body | Array   | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime  | Body | String  | Backup started time        |
-| backupSchedules.backupWndDuration | Body | Enum    | Backup duration            |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| backupPeriod | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Number | Query latency (sec) |
+| backupRetryCount | Number | Number of backup retries |
+| replicationRegion | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Boolean | Whether to use table lock |
+| backupSchedules | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Backup started time |
+| backupSchedules.backupWndDuration | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### Modify Backup Information
 
+#### Request
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### Request
+#### Request Parameters
 
-| Name                              | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|-----------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                    |
-| backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| useBackupLock                     | Body | Boolean | X        | Whether to use table lock                                                                                                                                                                                                                                                 |
-| backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Boolean | N | Whether to use table lock |
+| backupSchedules | Array | N | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-### List Network Information
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
+### Export after Backing up DB Instance
 
 #### Request
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup is stored |
+| targetContainer | String | Y | Object storage container where backup is stored |
+| objectPath | String | Y | Backup path to be stored in container |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Change DB Image Meta for Testing
+
+#### Request
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                   | Type | Format | Description                                                                                                                                                                                                |
-|------------------------|------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | Availability zone where DB instance will be created                                                                                                                                                        |
-| subnet                 | Body | Object | Subnet object                                                                                                                                                                                              |
-| subnet.subnetId        | Body | UUID   | Subnet identifier                                                                                                                                                                                          |
-| subnet.subnetName      | Body | UUID   | Name to identify subnets                                                                                                                                                                                   |
-| subnet.subnetCidr      | Body | UUID   | CIDR of subnet                                                                                                                                                                                             |
-| endPoints              | Body | Array  | List of access information                                                                                                                                                                                 |
-| endPoints.domain       | Body | String | Domain                                                                                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP address                                                                                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | Access information type<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Network Information
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Request
-
-| Name            | Type | Format  | Required | Description                         |
-|-----------------|------|---------|----------|-------------------------------------|
-| dbInstanceId    | URL  | UUID    | O        | DB instance identifier              |
-| usePublicAccess | Body | Boolean | O        | External access is available or not |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Users
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                         | Type | Format   | Description                                                                                                                                                              |
-|------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB users                                                                                                                                                                 |
-| dbUsers.dbUserId             | Body | UUID     | DB user identifier                                                                                                                                                       |
-| dbUsers.dbUserName           | Body | String   | DB user account name                                                                                                                                                     |
-| dbUsers.host                 | Body | String   | DB user account host name                                                                                                                                                |
-| dbUsers.authorityType        | Body | Enum     | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| dbUsers.dbUserStatus         | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `UPDATING`: Modifying<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted                     |
-| dbUsers.authenticationPlugin | Body | Enum     | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                       |
-| dbUsers.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Create DB User
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserName           | Body | String | O        | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                                                                                |
-| dbPassword           | Body | String | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| host                 | Body | String | O        | DB user account host name<br/>- Example: `1.1.1.%`                                                                                                                       |
-| authorityType        | Body | Enum   | O        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB User
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserId             | URL  | UUID   | O        | DB user identifier                                                                                                                                                       |
-| dbPassword           | Body | String | X        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| authorityType        | Body | Enum   | X        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum    | X        | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB User
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbUserId     | URL  | UUID   | O        | DB user identifier     |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+This API does not return a response body.
 
 ---
 
 ### List DB Schema
 
+#### Request
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
 #### Response
 
-| Name                     | Type | Format   | Description                                                                                                                  |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB schema list                                                                                                               |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB schema identifier                                                                                                         |
-| dbSchemas.dbSchemaName   | Body | String   | DB schema name                                                                                                               |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB schema current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted |
-| dbSchemas.createdYmdt    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                           |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSchemas | Array | DB schema list |
+| dbSchemas.dbSchemaId | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | Created date and time |
 
 ---
 
 ### Create DB Schema
 
+#### Request
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### Request
+#### Request Parameters
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaName | Body | String | O        | DB schema name         |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### Delete DB Schema
 
+#### Request
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaId   | URL  | UUID   | O        | DB schema identifier   |
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### List DB Users
+
+#### Request
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbUsers | Array | DB users |
+| dbUsers.dbUserId | UUID | DB user identifier |
+| dbUsers.dbUserName | String | DB user account name |
+| dbUsers.host | String | DB user account host name |
+| dbUsers.authorityType | Enum | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| dbUsers.dbUserStatus | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | Created date and time |
+| dbUsers.updatedYmdt | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+---
+
+### Create DB User
+
+#### Request
+
+```http
+<!-- TERM-UNRESOLVED: DB 이미지 메타 (section "Change DB Image Meta for Testing" — no published EN precedent found for this term) -->
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | String | Y | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Enum | Y | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Delete DB User
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Modify DB User
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Enum | N | DB user permission type<br/>- CUSTOM: `custom permissions`<br/>- READ: `read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `all permissions` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Change DB Instance Deletion Protection Settings
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | Whether to protect against deletion |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Modify High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"useHighAvailability": false,
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | Whether to use high availability |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Pause High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Recover High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restart High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Separate High Availability
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
 ### List Log Files
 
+#### Request
+
 ```http
-GET /v3.0/db-instances/{dbInstanceId}/log-files
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                         |
-|--------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                              |
-| logFileTypes | Query | Array  | X        | Log File type list<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                                                                                                                                                                    |
-|----------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | Log File list                                                                                                                                                                                  |
-| logFiles.logFileName | Body | String   | Log File name                                                                                                                                                                                  |
-| logFiles.logFileType | Body | Enum     | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | Log File size(Byte)                                                                                                                                                                            |
-| logFiles.createdYmdt | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                             |
-
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| logFiles | Array | Log File list |
+| logFiles.logFileName | String | Log File name |
+| logFiles.logFileType | Enum | Log File type<br/>- `ERROR`<br/>- `BINLOG`<br/>- `GENERAL`<br/>- `SLOW_QUERY`<br/>- `AUDIT`<br/>- `BACKUP` |
+| logFiles.logFileSize | Number | Log File size(Byte) |
+| logFiles.createdYmdt | DateTime | Created date and time |
 
 ---
 
 ### Export Log File
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/log-files/export
-```
-
 #### Request
 
-| Name            | Type | Format | Required | Description                                              |
-|-----------------|------|--------|----------|----------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                   |
-| logFileNames    | Body | Array  | O        | Log File name list<br/>- Minimum size: `1`               |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store log file            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                       |
-| password        | Body | String | O        | API password for object storage where log file is stored |
-| targetContainer | Body | String | O        | Object storage container where log file is stored        |
-| objectPath      | Body | String | O        | Log file path to be stored in container                  |
+```http
+---
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | Log File name list |
+| tenantId | String | Y | Tenant ID of object storage to store log file<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where log file is stored |
+| targetContainer | String | Y | Object storage container where log file is stored |
+| objectPath | String | Y | Log file path to be stored in container |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### List Network Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"availabilityZone": "kr-pub-a",
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetName": "subnetName-example",
+},
+},
+{
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZone | String | Availability zone where DB instance will be created |
+| subnet | Object | Subnet object |
+| subnet.subnetId | UUID | Subnet identifier |
+| subnet.subnetName | String | Name to identify subnets |
+| subnet.subnetCidr | String | CIDR of subnet |
+| endPoints | Array | List of access information |
+| endPoints.domain | String | Domain |
+| endPoints.ipAddress | String | IP address |
+| endPoints.endPointType | String | Access information type |
+
+---
+
+### Modify Network Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | Whether external access is available |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Promote DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Replicate DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| network | Object | Y | Network information objects |
+| network.usePublicAccess | Boolean | N | Whether external access is available |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | N | Storage information objects |
+| storage.storageType | Enum | N | Data storage type |
+| storage.storageSize | Number | N | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | N | Backup information objects |
+| backup.backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock |
+| backup.backupSchedules | Array | N | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restart DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Boolean | N | Whether to execute backup at the current point in time<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Whether to wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Whether to block write workload<br/>- Default: `false` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### View Restoration Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### View the Last Query to Be Restored
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| executedYmdt | DateTime | Query execution date and time |
+| lastQuery | String | Last executed query |
+
+---
+
+### Restore DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+}
+}
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| imageId | UUID | N | Identifier of the image |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.restoreType | Enum | Y | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration using a restorable binary log location`<br/>- BACKUP: `Snapshot restoration using a previously created backup` |
+| restore.binLog.binLogFileName | String | N | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Object | N | Binary log location to use for restoration |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+
+#### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB instance restoration date and time |
+
+POST /v3.0/db-instances/{dbInstanceId}/restore
+
+#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+| restore.binLog | Object | N | Binary log information object to use for restoration |
+
+Restoration is possible only before the most recent restorable time queried through restoration information inquiry.
+
+#### Request when restoring from backup (if restoreType is `BACKUP`)
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Start DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Stop DB Instance
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### View Storage Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageType": "General SSD",
+"storageSize": 1,
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageType | Enum | Data storage type |
+| storageSize | Number | Data storage size (GB) |
+| storageStatus | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+
+---
+
+### Modify Storage Information
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | Data storage size (GB)<br/>- Maximum value: `2048` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
@@ -2341,629 +2941,755 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### Backup Status
 
-| Status       | Description             |
-|--------------|-------------------------|
-| `BACKING_UP` | Backup in progress      |
-| `COMPLETED`  | Backup is completed     |
-| `DELETING`   | Backup is being deleted |
-| `DELETED`    | Backup is deleted       |
-| `ERROR`      | Error occurred          |
+| Status | Description |
+|--------------|--------------|
+| `BACKING_UP` | Backup in progress |
+| `COMPLETED` | Backup is completed |
+| `DELETING` | Backup is being deleted |
+| `DELETED` | Backup is deleted |
+| `ERROR` | Error occurred |
 
 ### Retrieve Backup List
 
+#### Request
+
 ```http
-GET /v3.0/backups
+---
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                          |
-|--------------|-------|--------|----------|--------------------------------------------------------------------------------------|
-| page         | Query | Number | O        | Page to retrieve<br/>- Minimum value: `1`                                            |
-| size         | Query | Number | O        | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`            |
-| backupType   | Query | Enum   | X        | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X        | Original DB instance identifier                                                      |
-| dbVersion    | Query | Enum   | X        | DB engine type                                                                       |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                         |
-|----------------------|------|----------|-----------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                          |
-| backups              | Body | Array    | Backup list                                         |
-| backups.backupId     | Body | UUID     | Backup identifier                                   |
-| backups.backupName   | Body | String   | Name to identify backups                            |
-| backups.backupStatus | Body | Enum     | Backup current status                               |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                     |
-| backups.dbVersion    | Body | Enum     | DB engine type                                      |
-| backups.backupType   | Body | Enum     | Backup type                                         |
-| backups.backupSize   | Body | Number   | Backup size (Byte)                                  |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Export Backup
-
-```http
-POST /v3.0/backups/{backupId}/export
-```
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| backupId        | URL  | UUID   | O        | Backup identifier                                      |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                     |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-> [Caution]
-> To export a manual backup, the DB instance from which the backup originated must exist.
-
----
-
-### Restore Backup
-
-```http
-POST /v3.0/backups/{backupId}/restore
-```
-
-#### Request
-
-| Name                                     | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|------------------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O        | Backup identifier                                                                                                                                                                                                                                                         |
-| dbInstanceName                           | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                             |
-| dbInstanceCandidateName                  | Body | String  | X        | Candidate name to identify DB instances                                                                                                                                                                                                                                             |
-| description                              | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                    |
-| dbFlavorId                               | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                                                                                                                                                  |
-| dbPort                                   | Body | Integer | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                          |
-| parameterGroupId                         | Body | UUID    | O        | Parameter group identifier                                                                                                                                                                                                                                                |
-| dbSecurityGroupIds                       | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                             ||network|Body|Object|O|Network information objects|
-| userGroupIds                             | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                    |
-| useHighAvailability                      | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                     |
-| pingInterval                             | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                     |
-| useDefaultNotification                   | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                  |
-| useDeletionProtection                    | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                                                                                                                                                  | 
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Number of all backup lists |
+| backups | Array | Backup list |
+| backups.backupId | UUID | Backup identifier |
+| backups.backupName | String | Name to identify backups |
+| backups.backupStatus | Enum | Backup current status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | UUID | Original DB instance identifier |
+| backups.dbVersion | String | DB engine type |
+| backups.utilVersion | String | Utility version |
+| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | Backup size (Byte) |
+| backups.createdYmdt | DateTime | Created date and time |
+| backups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Delete Backup
 
+#### Request
+
 ```http
-DELETE /v3.0/backups/{backupId}
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name     | Type | Format | Required | Description       |
-|----------|------|--------|----------|-------------------|
-| backupId | URL  | UUID   | O        | Backup identifier |
-
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
-## DB Security Group
+### Export Backup
 
-### DB Security Group Progress
+#### Request
 
-| Status          | Description         |
-|-----------------|---------------------|
-| `NONE`          | No task in progress |
-| `CREATING_RULE` | Creating rules      |
-| `UPDATING_RULE` | Modifying rules     |
-| `DELETING_RULE` | Deleting rules      |
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of object storage to store backup<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where backup is stored |
+| targetContainer | String | Y | Object storage container where backup is stored |
+| objectPath | String | Y | Backup path to be stored in container |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Restore Backup
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | DB security group identifiers |
+| userGroupIds | Array | N | User group identifier list |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to protect against deletion<br/>- Default: `false` |
+| network | Object | Y | Network information objects |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information objects |
+| storage.storageType | Enum | Y | Block Storage Type |
+| storage.storageSize | Number | Y | Block Storage Size (GB)<br/>- Minimum value: `20` |
+| backup | Object | Y | Backup information objects |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup started time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hour`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+## DB Security Groups
+
+### DB Security Group Progress Status
+
+| Status | Description |
+|-----------------|--------------|
+| `NONE` | No operation in progress |
+| `CREATING_RULE` | Creating rule policy |
+| `UPDATING_RULE` | Modifying rule policy |
+| `DELETING_RULE` | Deleting rule policy |
 
 ### List DB Security Groups
 
-```http
-GET /v3.0/db-security-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                                 | Type | Format   | Description                                         |
-|--------------------------------------|------|----------|-----------------------------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB security groups                                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB security group identifier                        |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | Name to identify DB instances                       |
-| dbSecurityGroups.description         | Body | String   | Additional information on DB security group         |
-| dbSecurityGroups.progressStatus      | Body | Enum     | Current status of DB security group                 |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### List DB Security Group Details
-
-```http
-GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
-
 #### Response
 
-| Name                | Type | Format   | Description                                                                                                                                              |
-|---------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB security group identifier                                                                                                                             |
-| dbSecurityGroupName | Body | String   | Name to identify DB instances                                                                                                                            |
-| description         | Body | String   | Additional information on DB security group                                                                                                              |
-| progressStatus      | Body | Enum     | Current status of DB security group                                                                                                                      |
-| rules               | Body | Array    | DB security group rules                                                                                                                                  |
-| rules.ruleId        | Body | UUID     | DB security group rule identifier                                                                                                                        |
-| rules.description   | Body | String   | Additional information on DB security group rule                                                                                                         |
-| rules.direction     | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                |
-| rules.etherType     | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                         |
-| rules.port          | Body | Object   | Port object                                                                                                                                              |
-| rules.port.portType | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number   | Minimum port range                                                                                                                                       |
-| rules.port.maxPort  | Body | Number   | Maximum port range                                                                                                                                       |
-| rules.cidr          | Body | String   | Remote source for traffic to allow                                                                                                                       |
-| rules.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| rules.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-| createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB security group list |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroups.description | String | Additional information on the DB security group |
+| dbSecurityGroups.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rule`<br/>- UPDATING_RULE: `Modifying rule`<br/>- DELETING_RULE: `Deleting rule`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroups.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Security Group
 
-```http
-POST /v3.0/db-security-groups
-```
-
 #### Request
 
-| Name                | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|---------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O        | Name to identify DB instances                                                                                                                                                                                                    |
-| description         | Body | String | X        | Additional information on DB security group                                                                                                                                                                                      |
-| rules               | Body | Array  | O        | DB security group rules                                                                                                                                                                                                          |
-| rules.description   | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| rules.etherType     | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| rules.cidr          | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| rules.port.portType | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name              | Type | Format | Description                  |
-|-------------------|------|--------|------------------------------|
-| dbSecurityGroupId | Body | UUID   | DB security group identifier |
-
+```http
 ---
-
-### Modify DB Security Group
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name                | Type | Format | Required | Description                                 |
-|---------------------|------|--------|----------|---------------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O        | DB security group identifier                |
-| dbSecurityGroupName | Body | String | X        | Name to identify DB instances               |
-| description         | Body | String | X        | Additional information on DB security group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+{
+"description": "description-example",
+"description": "description-example",
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB security group<br/>- Maximum length: `100` |
+| rules | Array | Y | DB security group rule list |
+| rules.direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| rules.port | Object | Y | Port object |
+| rules.port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | Additional information on the security group rule |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
 
 ---
 
 ### Delete DB Security Group
 
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-### Create DB Security Group Rule
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+### List DB Security Group Details
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"description": "description-example",
+{
+{
+"description": "description-example",
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB security group |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroup.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroup.description | String | Additional information on the DB security group |
+| dbSecurityGroup.progressStatus | Enum | Current progress status of the DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rule`<br/>- UPDATING_RULE: `Modifying rule`<br/>- DELETING_RULE: `Deleting rule`<br/>- APPLYING_DEFAULT_RULE: `Applying default rule` |
+| dbSecurityGroup.rules | Array | DB security group rule list |
+| dbSecurityGroup.rules.ruleId | UUID | DB security group rule identifier |
+| dbSecurityGroup.rules.description | String | Additional information on the DB security group rule |
+| dbSecurityGroup.rules.direction | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| dbSecurityGroup.rules.etherType | Enum | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| dbSecurityGroup.rules.port | Object | Port object |
+| dbSecurityGroup.rules.port.portType | Enum | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| dbSecurityGroup.rules.port.minPort | Number | Minimum port range |
+| dbSecurityGroup.rules.port.maxPort | Number | Maximum port range |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | Modified date and time |
+| dbSecurityGroup.createdYmdt | DateTime | Created date and time |
+| dbSecurityGroup.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### Modify DB Security Group Rule
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
+### Modify DB Security Group
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O        | DB security group rule identifier                                                                                                                                                                                                |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
+```http
+---
+```
 
-> [Caution]
-> DB port cannot be set to transmit direction.
+#### Request Parameters
 
-<details><summary>Example</summary>
-<p>
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB security group<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+This API does not return a response body.
 
 ---
 
 ### Delete DB Security Group Rule
 
+#### Request
+
 ```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+---
 ```
 
-#### Request
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
-| Name              | Type  | Format | Required | Description                        |
-|-------------------|-------|--------|----------|------------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O        | DB security group identifier       |
-| ruleIds           | Query | Array  | O        | DB security group rule identifiers |
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Create DB Security Group Rule
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
+
+---
+
+### Modify DB Security Group Rule
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4 format`<br/>- IPV6: `IPv6 format` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port ranges (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receive port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on the DB security group rule<br/>- Maximum length: `200` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Job identifier |
 
 ---
 
@@ -2971,375 +3697,372 @@ This API does not require a request body.
 
 ### List Parameter Groups
 
-```http
-GET /v3.0/parameter-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-| Name      | Type  | Format | Required | Description    |
-|-----------|-------|--------|----------|----------------|
-| dbVersion | Query | Enum   | X        | DB engine type |
-
-#### Response
-
-| Name                                 | Type | Format   | Description                                                                                 |
-|--------------------------------------|------|----------|---------------------------------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                                            |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                                  |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                                           |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                   |
-| parameterGroups.dbVersion            | Body | Enum     | DB engine type                                                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                          |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                         |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
+```http
 ---
-
-### List Parameter Group Details
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                           |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | Parameter group identifier                                                                                                                            |
-| parameterGroupName            | Body | String   | Name to identify parameter groups                                                                                                                     |
-| description                   | Body | String   | Additional information on parameter group                                                                                                             |
-| dbVersion                     | Body | Enum     | DB engine type                                                                                                                                        |
-| parameterGroupStatus          | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply                                                           |
-| parameters                    | Body | Array    | Parameter list                                                                                                                                        |
-| parameters.parameterId        | Body | UUID     | Parameter identifier                                                                                                                                  |
-| parameters.parameterFileGroup | Body | Enum     | Parameter file group type<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                                                          |
-| parameters.parameterName      | Body | String   | Parameter name                                                                                                                                        |
-| parameters.fileParameterName  | Body | String   | Parameter file name                                                                                                                                   |
-| parameters.value              | Body | String   | Current value                                                                                                                                         |
-| parameters.defaultValue       | Body | String   | Default value                                                                                                                                         |
-| parameters.allowedValue       | Body | String   | Permitted values                                                                                                                                      |
-| parameters.updateType         | Body | Enum     | Modify type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable<br/>- `INIT_VARIABLE`: Only modifiable when DB instance is created |
-| parameters.applyType          | Body | Enum     | Apply type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All (restart required)                    |
-| createdYmdt                   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| updatedYmdt                   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                   |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroups | Array | Parameter groups |
+| parameterGroups.parameterGroupId | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | String | Name to identify parameter groups |
+| parameterGroups.description | String | Additional information on parameter group |
+| parameterGroups.dbVersion | String | DB engine type |
+| parameterGroups.parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Parameter Group
 
-```http
-POST /v3.0/parameter-groups
-```
-
 #### Request
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-| dbVersion          | Body | Enum   | O        | DB engine type                            |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
+```http
 ---
-
-### Copy Parameter Group
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
 ```
 
-#### Request
+#### Request Body
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
+{
+"description": "description-example",
+"description": "description-example",
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | String | Y | DB engine type |
 
 #### Response
 
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Modify Parameter Group
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | X        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
 
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Parameter
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Request
-
-| Name                           | Type | Format | Required | Description                |
-|--------------------------------|------|--------|----------|----------------------------|
-| parameterGroupId               | URL  | UUID   | O        | Parameter group identifier |
-| modifiedParameters             | Body | Array  | O        | Parameters to change       |
-| modifiedParameters.parameterId | Body | UUID   | O        | Parameter identifier       |
-| modifiedParameters.value       | Body | String | O        | Parameter value to change  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Reset Parameter Group
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Request
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Delete Parameter Group
 
-```http
-DELETE /v3.0/parameter-groups/{parameterGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### List Parameter Group Details
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+| parameterGroupName | String | Name to identify parameter groups |
+| description | String | Additional information on parameter group |
+| dbVersion | String | DB engine type |
+| parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Array | Parameter list |
+| parameters.parameterId | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | Parameter name |
+| parameters.fileParameterName | String | Parameter file name |
+| parameters.value | String | Current value |
+| parameters.defaultValue | String | Default value |
+| parameters.allowedValue | String | Permitted values |
+| parameters.updateType | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
+
+---
+
+### Modify Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+
+---
+
+### Modify Parameter
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | Parameters to change |
+| modifiedParameters.parameterId | UUID | Y | Parameter identifier |
+| modifiedParameters.value | String | Y | Parameter value to change |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
 
 ---
 
@@ -3347,232 +4070,223 @@ This API does not return a response body.
 
 ### List User Groups
 
-```http
-GET /v3.0/user-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                     | Type | Format   | Description                                         |
-|--------------------------|------|----------|-----------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                         |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                        |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### List User Group Details
-
-```http
-GET /v3.0/user-groups/{userGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
-
 #### Response
 
-| Name              | Type | Format   | Description                                                                                                                                            |
-|-------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                                                                  |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                                                           |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| members           | Body | Array    | Project member list                                                                                                                                    |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| userGroups.createdYmdt | DateTime | Created date and time |
+| userGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create User Group
 
-```http
-POST /v3.0/user-groups
-```
-
 #### Request
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupName | Body | String  | O        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | O        | Project member identifiers <br /> Ignored when `selectAllYN` is true        |
-| selectAllYN   | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name        | Type | Format | Description           |
-|-------------|------|--------|-----------------------|
-| userGroupId | Body | UUID   | User group identifier |
-
+```http
 ---
-
-### Modify User Group
-
-```http
-PUT /v3.0/user-groups/{userGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O        | User group identifier                                                       |
-| userGroupName | Body | String  | X        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | X        | Project member identifiers                                                  |
-| selectAllYN   | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | Y | Project member identifier list |
+| selectAllYN | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
 
 ---
 
 ### Delete User Group
 
-```http
-DELETE /v3.0/user-groups/{userGroupId}
-```
-
 #### Request
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
+---
+
+### View User Group Details
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"members": [
+{
+{
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
+| userGroupName | String | Name to identify user groups |
+| userGroupTypeCode | Enum | User group type<br/>- `ENTIRE`: User group including all project members<br/>- `INDIVIDUAL_MEMBER`: User group including specific project members |
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
+
+---
+
+### Modify User Group
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | N | Project member identifier list |
+| selectAllYN | Boolean | N | Whether to include all project members<br/>- Default: `false` |
+
+#### Response
+
+This API does not return a response body.
 
 ---
 
@@ -3580,363 +4294,319 @@ This API does not return a response body.
 
 ### List Notification Groups
 
-```http
-GET /v3.0/notification-groups
-```
-
 #### Request
 
-This API does not require a request body.
-
-#### Response
-
-| Name                                     | Type | Format   | Description                                         |
-|------------------------------------------|------|----------|-----------------------------------------------------|
-| notificationGroups                       | Body | Array    | Notification Groups                                 |
-| notificationGroups.notificationGroupId   | Body | UUID     | Notification group identifier                       |
-| notificationGroups.notificationGroupName | Body | String   | Name to identify notification groups                |
-| notificationGroups.notifyEmail           | Body | Boolean  | Whether to be notified by email                     |
-| notificationGroups.notifySms             | Body | Boolean  | Whether to be notified by SMS                       |
-| notificationGroups.isEnabled             | Body | Boolean  | Indicates whether the flavor is enabled             |
-| notificationGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| notificationGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### View Notification Group Details
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
-
 #### Response
 
-| Name                       | Type | Format   | Description                                         |
-|----------------------------|------|----------|-----------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                       |
-| notificationGroupName      | Body | String   | Name to identify notification groups                |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                     |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                       |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled             |
-| dbInstances                | Body | Array    | DB Instances to monitor                             |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                              |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                       |
-| userGroups                 | Body | Array    | User Groups                                         |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                        |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroups | Array | Notification group list |
+| notificationGroups.notificationGroupId | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Boolean | Whether enabled |
+| notificationGroups.createdYmdt | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Notification Group
 
-```http
-POST /v3.0/notification-groups
-```
-
 #### Request
 
-| Name                  | Type | Format  | Required | Description                                                 |
-|-----------------------|------|---------|----------|-------------------------------------------------------------|
-| notificationGroupName | Body | String  | O        | Name to identify notification groups                        |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email<br/>- Default: `true`         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS<br/>- Default: `true`           |
-| isEnabled             | Body | Boolean | X        | Whether enabled<br/>- Default: `true`                         |
-| dbInstanceIds         | Body | Array   | O        | DB instance identifiers to monitor                          |
-| userGroupIds          | Body | Array   | O        | User group identifiers                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name                | Type | Format | Description                   |
-|---------------------|------|--------|-------------------------------|
-| notificationGroupId | Body | UUID   | Notification group identifier |
-
+```http
 ---
-
-### Modify Notification Group
-
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### Request
+#### Request Body
 
-| Name                  | Type | Format  | Required | Description                             |
-|-----------------------|------|---------|----------|-----------------------------------------|
-| notificationGroupId   | URL  | UUID    | O        | Notification group identifier           |
-| notificationGroupName | Body | String  | X        | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled |
-| dbInstanceIds         | Body | Array   | X        | DB instance identifiers to monitor      |
-| userGroupIds          | Body | Array   | X        | User group identifiers                  |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+{
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Array | Y | Identifier list of DB instances to monitor |
+| userGroupIds | Array | Y | User group identifier list |
 
 #### Response
 
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
 
 ---
 
 ### Delete Notification Group
 
-```http
-DELETE /v3.0/notification-groups/{notificationGroupId}
-```
-
 #### Request
 
-This API does not require a request body.
+```http
+---
+```
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-## Monitoring
-
-### List Metric List
-
-```http
-GET /v3.0/metrics
-```
+### View Notification Group Details
 
 #### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                | Type | Format | Description          |
-|---------------------|------|--------|----------------------|
-| metrics             | Body | Array  | Metric List          |
-| metrics.measureName | Body | Enum   | Metric type to query |
-| metrics.unit        | Body | String | Measure unit         |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
+| notificationGroupName | String | Name to identify notification groups |
+| notifyEmail | Boolean | Whether to be notified by email |
+| notifySms | Boolean | Whether to be notified by SMS |
+| isEnabled | Boolean | Whether enabled |
+| dbInstances | Array | DB instance list to monitor |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| createdYmdt | DateTime | Created date and time |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
-### View stats
-
-```http
-GET /v3.0/metric-statistics
-```
+### Modify Notification Group
 
 #### Request
 
-| Name         | Type  | Format   | Required | Description                                      |
-|--------------|-------|----------|----------|--------------------------------------------------|
-| dbInstanceId | Query | UUID     | O        | DB instance identifier                           |
-| measureNames | Query | Array    | O        | Metric list to query<br/>- Minimum length: `1`   |
-| from         | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)   |
-| interval     | Query | Number   | X        | View interval                                    |
+```http
+---
+```
 
-#### Response
+#### Request Parameters
 
-| Name                              | Type | Format    | Description                 |
-|-----------------------------------|------|-----------|-----------------------------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.measureName      | Body | Enum      | Measure type                |
-| metricStatistics.unit             | Body | String    | Measure unit                |
-| metricStatistics.values           | Body | Array     | Measure values              |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time                |
-| metricStatistics.values.value     | Body | Object    | Measure value               |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Array | N | Identifier list of DB instances to monitor |
+| userGroupIds | Array | N | User group identifier list |
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+## Monitoring
+
+### View stats
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### List Metric List
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"measureName": "measureName-example",
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| metrics | Array | Metric list |
+| metrics.measureName | String | Metric type to query |
+| metrics.unit | String | Measure unit |
 
 ---
 
@@ -3944,137 +4614,340 @@ GET /v3.0/metric-statistics
 
 ### Event category
 
-Events can be categorized into categories, which are shown below.
+---
 
 | Event category | Description |
-|----------------|-------------|
-| ALL            | All         |
-| BACKUP         | Backups     |
-| DB_INSTANCE    | DB Instance |
-| JOB            | Jobs        |
-| TENANT         | Tenant      |
-| MONITORING     | Monitoring  |
-
-### List Events
-
-```http
-GET /v3.0/events
-```
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format   | Required | Description                                                                                                                                                         |
-|-------------------|-------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O        | Page to retrieve<br/>- Minimum value: `1`                                                                                                                           |
-| size              | Query | Number   | O        | Page size to retrieve<br/>- Minimum value: `1`<br/>- Maximum value: `100`                                                                                           |
-| from              | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                    |
-| to                | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| eventCategoryType | Query | Enum     | O        | Event category types to query<br/>- `ALL`: All<br/>- `INSTANCE`: DB instance<br/>- `BACKUP`: Backup<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `TENANT`: Tenant |
-| sourceId          | Query | String   | X        | Event target resource identifier                                                                                                                                    |
-| keyword           | Query | String   | X        | String keyword in event message                                                                                                                                     |
-| ascendingOrder    | Query | Enum     | X        | Event message sorting order<br/>- `ASC`: Ascending order<br/>- `DESC`: Descending order<br/>- Default value: `DESC`                                                       |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                               |
-|--------------------------|------|----------|-----------------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                    |
-| events                   | Body | Array    | Events                                                    |
-| events.eventCategoryType | Body | Enum     | Event category type                                       |
-| events.eventCode         | Body | Enum     | Occurred event type                                       |
-| events.sourceId          | Body | String   | Event source identifier                                   |
-| events.sourceName        | Body | String   | Name to identify event sources                            |
-| events.messages          | Body | Array    | Event messages                                            |
-| events.messages.langCode | Body | String   | Language code                                             |
-| events.messages.message  | Body | String   | Event Message                                             |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+|-------------|---------|
+| ALL | All |
+| BACKUP | Backup |
+| DB_INSTANCE | DB instance |
+| JOB | Job |
+| TENANT | Tenant |
+| MONITORING | Monitoring |
 
 ### List Subscribable Event Codes
 
+#### Request
+
 ```http
-GET /v3.0/event-codes
+Events can be categorized into categories, which are shown below.
 ```
 
-#### Request
+#### Request Body
 
 This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format | Description         |
-|------------------------------|------|--------|---------------------|
-| eventCodes                   | Body | Array  | Event Codes         |
-| eventCodes.eventCode         | Body | Enum   | Event Code          |
-| eventCodes.eventCategoryType | Body | Enum   | Event category type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"eventCode": "ENUM_VALUE",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventCodes | Array | Event code list |
+| eventCodes.eventCode | Enum | Event code |
+| eventCodes.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
+---
+
+### List Events
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+{
+{
+"langCode": "KO",
+}
+],
+],
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of events |
+| events | Array | Event list |
+| events.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | Occurred event type |
+| events.sourceId | UUID | Event source identifier |
+| events.sourceName | String | Name to identify event sources |
+| events.messages | Array | Event message list |
+| events.messages.langCode | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | Event message |
+| events.eventYmdt | DateTime | Event occurred date and time |
+
+---
+
+## Event Subscription
+
+### List Event Subscriptions
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+],
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of event subscriptions |
+| eventSubscriptions | Array | Event subscription list |
+| eventSubscriptions.eventSubscriptionId | UUID | Event subscription identifier |
+| eventSubscriptions.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | Name to identify the event subscription |
+| eventSubscriptions.enabled | Boolean | Whether enabled |
+| eventSubscriptions.notifyEmail | Boolean | Whether to send email notifications |
+| eventSubscriptions.notifySms | Boolean | Whether to send SMS notifications |
+| eventSubscriptions.eventCodes | Array | Event code list to subscribe to |
+| eventSubscriptions.sources | Array | Event source list to subscribe to |
+| eventSubscriptions.sources.sourceId | UUID | Event source identifier |
+| eventSubscriptions.sources.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | List of user group identifiers subscribed to the event |
+| eventSubscriptions.createdYmdt | DateTime | Created date and time |
+
+---
+
+### Create Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | Name to identify the event subscription |
+| enabled | Boolean | Y | Whether enabled |
+| notifyEmail | Boolean | Y | Whether to send email notifications |
+| notifySms | Boolean | Y | Whether to send SMS notifications |
+| eventCodes | Array | Y | Event code list to subscribe to |
+| sources | Array | Y | Event source list to subscribe to |
+| sources.sourceId | UUID | Y | Event source identifier |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | List of user group identifiers to subscribe to the event |
+
+#### Response
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | Event subscription identifier |
+
+---
+
+### Delete Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Modify Event Subscription
+
+#### Request
+
+```http
+---
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | Name to identify the event subscription |
+| enabled | Boolean | N | Whether enabled |
+| notifyEmail | Boolean | N | Whether to send email notifications |
+| notifySms | Boolean | N | Whether to send SMS notifications |
+| eventCodes | Array | N | Event code list to subscribe to |
+| sources | Array | N | Event source list to subscribe to |
+| sources.sourceId | UUID | Y | Event source identifier |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | List of user group identifiers to subscribe to the event |
+
+#### Response
+
+This API does not return a response body.
 
 ---

--- a/en/api-guide-v4.0-gov.md
+++ b/en/api-guide-v4.0-gov.md
@@ -58,33 +58,38 @@ The API responds with "200 OK" to all API requests. For more information on the 
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|--------------|----------|-----------------|--------|
+| MARIADB\_V10330  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10611  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10612  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10616  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10622  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10625  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V101107 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101108 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101113 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101116 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11407  | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11410  | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11806  | O        | O               | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
 
+
 ## Project Information
 
-### List Regions
+### List Project Members
 
 ```http
-GET /v4.0/project/regions
+GET /v4.0/project/members
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                     | Description         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | Query project information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Project.Get | List project members |
 
 #### Request
 
@@ -92,11 +97,63 @@ This API does not require a request body.
 
 #### Response
 
-| Name    | Type | Format | Description |
-|---------|------|--------|-------------|
-| regions | Body | Array  | Region list |
-| regions.regionCode | Body | Enum    | Region code<br/>- `KR1`: Korea (Pangyo) |
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                                                                 |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| members.memberName | Body | String | Project member name |
+| members.emailAddress | Body | String | Project member email address |
+| members.phoneNumber | Body | String | Project member phone number |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Regions
+
+```http
+GET /v4.0/project/regions
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Project.Get | List regions |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| regions | Body | Array | Region list |
+| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Body | Boolean | Whether the region is enabled |
 
 <details><summary>Example</summary>
 <p>
@@ -111,58 +168,7 @@ This API does not require a request body.
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### List Project Members
-
-```http
-GET /v4.0/project/members
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | Query project information |
-
-#### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name                 | Type | Format | Description                  |
-|----------------------|------|--------|------------------------------|
-| members              | Body | Array  | Project member list          |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name          |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile        |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "isEnabled": false
         }
     ]
 }
@@ -172,7 +178,6 @@ This API does not require a request body.
 </details>
 
 ---
-
 ## Specifications of DB Instance
 
 ### List DB Instance Specifications
@@ -183,8 +188,8 @@ GET /v4.0/db-flavors
 
 #### Required permissions
 
-| Permission Name                                       | Description               |
-|-------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbFlavor.List | List DB Instance Specifications |
 
 #### Request
@@ -193,13 +198,13 @@ This API does not require a request body.
 
 #### Response
 
-| Name                   | Type | Format | Description                              |
-|------------------------|------|--------|------------------------------------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications       |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications       |
-| dbFlavors.ram          | Body | Number | Memory size (MB)                         |
-| dbFlavors.vcpus        | Body | Number | CPU cores                                |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
+| dbFlavors.ram | Body | Number | Memory size (MB) |
+| dbFlavors.vcpus | Body | Number | CPU cores |
 
 <details><summary>Example</summary>
 <p>
@@ -213,9 +218,9 @@ This API does not require a request body.
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -237,9 +242,9 @@ GET /v4.0/network/subnets
 
 #### Required permissions
 
-| Permission Name                                     | Description        |
-|------------------------------------------|-----------|
-| RDSforMariaDB:Network.List | List subnets |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Network.List | List Subnets |
 
 #### Request
 
@@ -247,14 +252,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format  | Description              |
-|--------------------------|------|---------|--------------------------|
-| subnets                  | Body | Array   | Subnet list              |
-| subnets.subnetId         | Body | UUID    | Subnet identifier        |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet           |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway   |
-| subnets.availableIpCount | Body | Number  | Number of available IPs  |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| subnets | Body | Array | Subnet list |
+| subnets.subnetId | Body | UUID | Subnet identifier |
+| subnets.subnetName | Body | String | Name to identify subnets |
+| subnets.subnetCidr | Body | String | CIDR of subnet |
+| subnets.usingGateway | Body | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Body | Number | Number of available IPs |
 
 <details><summary>Example</summary>
 <p>
@@ -268,11 +273,11 @@ This API does not require a request body.
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
@@ -293,8 +298,8 @@ GET /v4.0/db-versions
 
 #### Required permissions
 
-| Permission Name                                        | Description          |
-|--------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbVersion.List | List DB Engines |
 
 #### Request
@@ -303,11 +308,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB engine list                                        |
-| dbVersions.dbVersion         | Body | String  | DB engine type                                        |
-| dbVersions.dbVersionName     | Body | String  | DB engine name                                        |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB engine list |
+| dbVersions.dbVersion | Body | String | DB engine type |
+| dbVersions.dbVersionName | Body | String | DB engine name |
 | dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
 
 <details><summary>Example</summary>
@@ -322,9 +327,9 @@ This API does not require a request body.
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
@@ -337,7 +342,7 @@ This API does not require a request body.
 
 ## Storage
 
-### List Storage Type
+### List Storage Types
 
 ```http
 GET /v4.0/storage-types
@@ -345,8 +350,8 @@ GET /v4.0/storage-types
 
 #### Required permissions
 
-| Permission Name                                      | Description                |
-|------------------------------------------|-------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Storage.List | List data storage types |
 
 #### Request
@@ -355,9 +360,9 @@ This API does not require a request body.
 
 #### Response
 
-| Name         | Type | Format | Description       |
-|--------------|------|--------|-------------------|
-| storageTypes | Body | Array  | Storage type list |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | Storage type list |
 
 <details><summary>Example</summary>
 <p>
@@ -408,29 +413,29 @@ GET /v4.0/jobs/{jobId}
 
 #### Required permissions
 
-| Permission Name                                 | Description          |
-|-------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Job.Get | List Task Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name  | Type | Format | Required | Description     |
-|-------|------|--------|----------|-----------------|
-| jobId | URL  | UUID   | O        | Task identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### Response
 
-| Name                           | Type | Format   | Description                                         |
-|--------------------------------|------|----------|-----------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                     |
-| jobStatus                      | Body | Enum     | Current task status                                 |
-| resourceRelations              | Body | Array    | Relevant resource list                              |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type                              |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                        |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Task identifier |
+| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | Relevant resource list |
+| resourceRelations.resourceType | Body | String | Relevant resource type |
+| resourceRelations.resourceId | Body | String | Relevant resource identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -442,16 +447,16 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -459,7 +464,6 @@ This API does not require a request body.
 </details>
 
 ---
-
 ## DB Instance Group
 
 ### List DB Instance Groups
@@ -470,9 +474,9 @@ GET /v4.0/db-instance-groups
 
 #### Required permissions
 
-| Permission Name                                              | Description               |
-|--------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.List | List DB Instances |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.List | List DB Instance Groups |
 
 #### Request
 
@@ -480,13 +484,13 @@ This API does not require a request body.
 
 #### Response
 
-| Name                               | Type | Format   | Description                                                                                                    |
-|------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB instance groups                                                                                             |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                   |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                             |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB instance group list |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -500,10 +504,10 @@ This API does not require a request body.
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -522,31 +526,30 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Required permissions
 
-| Permission Name                                             | Description               |
-|-------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.Get | List DB Instance Group Details |
-
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbInstanceGroupId | URL  | UUID   | O        | DB instance group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                             |
-|------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                          |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                                                |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                                              |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -558,17 +561,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -581,50 +584,50 @@ This API does not require a request body.
 
 ### DB Instance Status
 
-| Status             | Description                               |
-|--------------------|-------------------------------------------|
-| `AVAILABLE`        | DB instance is available                  |
-| `BEFORE_CREATE`    | Before DB instance is created             |
-| `STORAGE_FULL`     | Insufficient DB instance storage          |
-| `FAIL_TO_CREATE`   | Failed to create DB instance              |
-| `FAIL_TO_CONNECT`  | Failed to connect DB instance             |
-| `REPLICATION_STOP` | Replication of DB instance is stopped     |
-| `FAILOVER`         | High availability DB instance failed over |
-| `SHUTDOWN`         | DB instance is stopped                    |
-| `DELETED`          | DB instance is deleted                    |
+| Status | Description |
+|---------------------|------------------------------|
+| `AVAILABLE`         | DB instance is available |
+| `BEFORE_CREATE`     | Before DB instance is created |
+| `STORAGE_FULL`      | Insufficient DB instance storage |
+| `FAIL_TO_CREATE`    | Failed to create DB instance |
+| `FAIL_TO_CONNECT`   | Failed to connect DB instance |
+| `REPLICATION_STOP`  | Replication of DB instance is stopped |
+| `FAILOVER`          | High availability DB instance failed over |
+| `SHUTDOWN`          | DB instance is stopped |
+| `DELETED`           | DB instance is deleted |
 
 ### DB Instance Progress Status
 
-| Status                     | Description                      |
-|----------------------------|----------------------------------|
+| Status | Description |
+|----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up                       |
-| `CANCELING`                | Canceling                        |
-| `CREATING`                 | Creating                         |
-| `CREATING_SCHEMA`          | Creating DB schema	              |
-| `CREATING_USER`            | Creating user	                   |
-| `DELETING`                 | Deleting                         |
-| `DELETING_SCHEMA`          | Deleting DB schema               |
-| `DELETING_USER`            | Deleting user                    |
-| `EXPORTING_BACKUP`         | Exporting backup                 |
-| `FAILING_OVER`             | Under failover                   |
-| `MIGRATING`                | Under migration                  |
-| `MODIFYING`                | Under modification               |
-| `PREPARING`                | In preparation                   |
-| `PROMOTING`                | Promoting                        |
-| `REBUILDING`               | Rebuilding                       |
-| `REPAIRING`                | Recovering                       |
-| `REPLICATING`              | Replicating                      |
-| `RESTARTING`               | Restarting                       |
-| `RESTARTING_FORCIBLY`      | Force restarting                 |
-| `RESTORING`                | Restoring                        |
-| `STARTING`                 | Starting                         |
-| `STOPPING`                 | Stopping                         |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema          |
-| `SYNCING_USER`             | Synchronizing user	              |
-| `UPDATING_USER`            | Modifying user	                  |
+| `BACKING_UP`               | Backing up |
+| `CANCELING`                | Canceling |
+| `CREATING`                 | Creating |
+| `CREATING_SCHEMA`          | Creating DB schema |
+| `CREATING_USER`            | Creating user |
+| `DELETING`                 | Deleting |
+| `DELETING_SCHEMA`          | Deleting DB schema |
+| `DELETING_USER`            | Deleting user |
+| `EXPORTING_BACKUP`         | Exporting backup |
+| `FAILING_OVER`             | Under failover |
+| `MIGRATING`                | Under migration |
+| `MODIFYING`                | Under modification |
+| `PREPARING`                | In preparation |
+| `PROMOTING`                | Promoting |
+| `REBUILDING`               | Rebuilding |
+| `REPAIRING`                | Recovering |
+| `REPLICATING`              | Replicating |
+| `RESTARTING`               | Restarting |
+| `RESTARTING_FORCIBLY`      | Force restarting |
+| `RESTORING`                | Restoring |
+| `STARTING`                 | Starting |
+| `STOPPING`                 | Stopping |
+| `SYNCING_SCHEMA`           | Synchronizing DB schema |
+| `SYNCING_USER`             | Synchronizing user |
+| `UPDATING_USER`            | Modifying user |
 
-### List DB instances
+### List DB Instances
 
 ```http
 GET /v4.0/db-instances
@@ -632,8 +635,8 @@ GET /v4.0/db-instances
 
 #### Required permissions
 
-| Permission Name                                         | Description            |
-|---------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.List | List DB instances |
 
 #### Request
@@ -642,20 +645,20 @@ This API does not require a request body.
 
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                                             |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                                           |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbInstances.dbVersion         | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB instance list |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| dbInstances.description | Body | String | Additional information on DB instances |
+| dbInstances.dbVersion | Body | Enum | DB engine type |
+| dbInstances.dbPort | Body | Number | DB port |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Body | Enum | DB instance current progress status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | Created date and time |
+| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -669,19 +672,366 @@ This API does not require a request body.
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+### Create DB Instance
+
+```http
+POST /v4.0/db-instances
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | Create DB Instance |
+
+#### Common request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbVersion | Body | Enum | O | DB engine type |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| userGroupIds | Body | Array | X | User group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| authenticationPlugin | Body | Enum | X | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Data storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore DB Instance from Object Storage
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
+
+#### Common request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | O | DB port |
+| dbVersion | Body | Enum | O | DB engine type |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.tenantId | Body | String | O | Tenant ID of object storage where backups are stored |
+| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
+| restore.password | Body | String | O | API password for object storage where backups are stored |
+| restore.targetContainer | Body | String | O | Container for object storage where backups are stored |
+| restore.objectPath | Body | String | O | Backup path stored in container |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| userGroupIds | Body | Array | X | User group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Delete DB Instance
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | Delete DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| deleteAutoBackup | Body | Boolean | X | Whether to delete automated backups<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "deleteAutoBackup": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -698,43 +1048,43 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Get | List DB Instance Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                        | Type | Format   | Description                                                                                                                                                             |
-|-----------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstanceGroupId           | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstanceName              | Body | String   | Name to identify DB instances                                                                                                                                           |
-| description                 | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbVersion                   | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbPort                      | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus            | Body | Enum     | DB instance current status                                                                                                                                              |
-| progressStatus              | Body | Enum     | Current task status of DB instance                                                                                                                                      |
-| dbFlavorId                  | Body | UUID     | Identifier of DB instance specifications                                                                                                                                |
-| parameterGroupId            | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                                       |
-| dbSecurityGroupIds          | Body | Array    | DB security group identifiers applied to DB instance                                                                                                                    |
-| notificationGroupIds        | Body | Array    | Notification group identifiers applied to DB instance                                                                                                                   |
-| useDeletionProtection       | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                         |
-| useSlowQueryAnalysis        | Body | Boolean  | Whether to analyze slow queries                                                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | Whether to support authentication plugin                                                                                                                                |
-| needToApplyParameterGroup   | Body | Boolean  | Need to apply the latest parameter group                                                                                                                                |
-| needMigration               | Body | Boolean  | Need to migrate                                                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | Whether to support DB version upgrade                                                                                                                                   |
-| createdYmdt                 | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                 | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceName | Body | String | Name to identify DB instances |
+| description | Body | String | Additional information on DB instances |
+| dbVersion | Body | Enum | DB engine type |
+| dbPort | Body | Number | DB port |
+| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Body | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | Parameter group identifier applied to DB instance |
+| dbSecurityGroupIds | Body | Array | DB security group identifiers applied to DB instance |
+| notificationGroupIds | Body | Array | Notification group identifiers applied to DB instance |
+| useDeletionProtection | Body | Boolean | Whether to protect DB instance against deletion |
+| useSlowQueryAnalysis | Body | Boolean | Whether to analyze slow queries |
+| supportAuthenticationPlugin | Body | Boolean | Whether to support authentication plugin |
+| needToApplyParameterGroup | Body | Boolean | Need to apply the latest parameter group |
+| needMigration | Body | Boolean | Need to migrate |
+| supportDbVersionUpgrade | Body | Boolean | Whether to support DB version upgrade |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -746,135 +1096,36 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
     "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
+    "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
     "needToApplyParameterGroup": false,
     "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
-
----
-
-### Create DB Instance
-
-```http
-POST /v4.0/db-instances
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | Create DB Instance |
-
-#### Request
-
-| Name                    | Type | Format  | Required | Description                                                                                                           |
-|-------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName          | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName | Body | String  | O        | Candidate name to identify DB instances                                                                               |
-| description             | Body | String  | X        | Additional information on DB instances                                                                                |
-| dbFlavorId              | Body | UUID    | O        | Identifier of DB instance specifications                                                                              |
-| dbVersion               | Body | Enum    | O        | DB engine type                                                                                                        |
-| dbPort                  | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                      |
-| dbUserName              | Body | String  | O        | DB user account name                                                                                                  |
-| dbPassword              | Body | String  | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                        |
-| parameterGroupId        | Body | UUID    | O        | Parameter group identifier                                                                                            |
-| dbSecurityGroupIds      | Body | Array   | X        | DB security group identifiers                                                                                         |
-| userGroupIds            | Body | Array   | X        | User group identifiers                                                                                                |
-| useHighAvailability     | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval            | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType                | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                         |
-| useDefaultNotification  | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| useDeletionProtection   | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                              |
-| useSlowQueryAnalysis    | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                 |
-| authenticationPlugin                     | Body | Enum    | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| storage.storageAutoscale                     | Body | Object  | X  | Block Storage Auto Scaling Objects                                         |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | Whether to enable storage auto scaling                                     |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`        |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                           |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
 
 ---
 
@@ -886,1113 +1137,60 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                               | Description  |
-|-----------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
 
 #### Request
-
-| Name               | Type | Format  | Required | Description                                                                                                       |
-|--------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| dbInstanceName     | Body | String  | X        | Master name to identify DB instances                                                                              |
-| dbInstanceCandidateName| Body | String  | X        | Candidate name to identify DB instances                                                                               |
-| description        | Body | String  | X        | Additional information on DB instances                                                                            |
-| dbPort             | Body | Number  | X        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Whether to analyze slow queries |
-| dbFlavorId         | Body | UUID    | X        | Identifier of DB instance specifications                                                                          |
-| parameterGroupId   | Body | UUID    | X        | Parameter group identifier                                                                                        |
-| dbSecurityGroupIds | Body | Array   | X        | DB security group identifiers                                                                                     |
-| executeBackup      | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| useOnlineFailover  | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| waitReplicationDelay  | Body | Boolean | X  | Wait for replication lag to clear<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false` |
-| useReadOnly  | Body | Boolean | X  | Switch to read-only mode<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB instance
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | Delete DB instance |
-
-#### Request
-
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| deleteAutoBackup          | Body | Boolean  | X  | Delete automated backups<br/>- Default: `false` |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | Restart DB Instance |
-
-#### Request
-
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| executeBackup     | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| waitReplicationDelay     | Body | Boolean | X  | Wait for replication lag to clear<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false`                                         |
-| useReadOnly     | Body | Boolean | X  | Switch to read-only mode<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false`                                         |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-### Force Restart DB instance
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
-
-| Permission Name                                                 | Description               |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | Force Restart DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### Start DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
-
-| Permission Name                              | Description           |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Stop DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
-
-| Permission Name                                         | Description            |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | Stop DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Replicate DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description           |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
-
-#### Request
-
-| Name                                         | Type | Format  | Required | Description                                                                                                                 |
-|----------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O        | DB instance identifier                                                                                                      |
-| dbInstanceName                               | Body | String  | O        | Name to identify DB instances                                                                                               |
-| description                                  | Body | String  | X        | Additional information on DB instances                                                                                      |
-| dbFlavorId                                   | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                          |
-| dbPort                                       | Body | Number  | X        | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                  |
-| parameterGroupId                             | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                        |
-| dbSecurityGroupIds                           | Body | Array   | X        | DB security group identifiers<br/>- Default: Original DB instance value                                                     |
-| userGroupIds                                 | Body | Array   | X        | User group identifiers                                                                                                      |
-| useDefaultNotification                       | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                    |
-| useDeletionProtection                        | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                    |
-| useSlowQueryAnalysis                         | Body | Boolean | X        | Whether to analyze Slow query<br/>- Default: `true`                                                                                      |
-| network                                      | Body | Object  | O        | Network information objects                                                                                                 |
-| network.usePublicAccess                      | Body | Boolean | X        | External access is available or not<br/>- Default: Original DB instance value                                               |
-| network.availabilityZone                     | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                               |
-| storage                                      | Body | Object  | X        | Storage information objects                                                                                                 |    
-| storage.storageType                          | Body | Enum    | X        | Block Storage Type<br/>- Default: Original DB instance value<br/>- Example: `General SSD`                                   |
-| storage.storageSize                          | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`     |
-| storage.storageAutoscale                     | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                          |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                      |
-| storage.storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%)<br/>- Default: Original DB instance value<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Default: Original DB instance value<br/>- Maximum value: `4096`                        |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                  |
-| backup                                       | Body | Object  | X        | Backup information objects                                                                                                  |
-| backup.backupPeriod                          | Body | Number  | X        | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X        | Query latency (sec)<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `21600`         |
-| backup.backupRetryCount                      | Body | Number  | X        | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`       |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                 |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Promote DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | Promote DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Rebuild DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | Rebuild DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
----
-
-### View Restoration Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type | Format   | Description                                                                                                                                                                                                          |
-|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restorable time                                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restorable time                                                                                                                                                                                          |
-| restorableBackups                       | Body | Array    | List of restorable backups                                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                                                                          |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | Whether to use table lock                                                                                                                                                                                            |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                                                                          |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                                     |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>- `BACKING_UP`: Backup in progress<br/>- `COMPLETED`: Backup completed<br/>- `DELETING`: Backup being deleted<br/>- `DELETED`: Backup deleted<br/>- `ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DB engine type                                                                                                                                                                                                       |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                                                                                  |
-| restorableBackups.backup.binLogFileName | Body | String   | Binary log file name                                                                                                                                                                                                 |
-| restorableBackups.backup.binLogPosition | Body | Number   | Binary log file location                                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                                                                      |
-| restorableBackups.restorableBinLogs     | Body | Array    | Binary log names that can be restored using the backup                                                                                                                                                               |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### View the last query to be restored
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Common Request
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                                                        |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                                                             |
-| restoreType  | Query | Enum   | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored. |
-
-#### If restoreType is `TIMESTAMP`
-
-| Name        | Type  | Format   | Required | Description                                           |
-|-------------|-------|----------|----------|-------------------------------------------------------|
-| restoreYmdt | Query | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### If restoreType is `BINLOG`
-
-| Name           | Type  | Format | Required | Description                                     |
-|----------------|-------|--------|----------|-------------------------------------------------|
-| backupId       | Query | UUID   | O        | Identifier of the backup to use for restoration |
-| binLogFileName | Query | String | O        | Binary log name to use for restoration          |
-| binLogPosition | Query | Number | O        | Binary log location to use for restoration      |
-
-#### Response
-
-| Name         | Type | Format   | Description                                      |
-|--------------|------|----------|--------------------------------------------------|
-| executedYmdt | Body | DateTime | Query executed date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | Last executed query                              |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### Restoration
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
-
-#### Common Request
-
-| Name                                                | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                   |
-|-----------------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                        |
-| restore                                             | Body | Object  | O        | Restoration information object                                                                                                                                                                                                                                                                |
-| restore.restoreType                                 | Body | Enum    | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored.<br/>- `BACKUP`: Snapshot restoration type using a previously created backup |
-| dbInstanceName                                      | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                                          |
-| dbInstanceCandidateName                             | Body | String  | O        | Candidate name to identify DB instances<br/>- Required to use high availability                                                                                                                                                                                                                                    |
-| description                                         | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                        |
-| dbFlavorId                                          | Body | UUID    | X        | Identifier of DB instance specifications                                                                                                                                                                                                                                                      |
-| dbPort                                              | Body | Number  | X        | DB port<br/>- Default: Source DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                       |
-| parameterGroupId | Body | UUID    | X        | Parameter group identifier<br/>- Default: Source DB instance value                                                                                                                                                                                                                                        |
-| dbSecurityGroupIds                                  | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                                                 |
-| userGroupIds                                        | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                        |
-| useHighAvailability                                 | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                       |
-| pingType                                            | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                                                                                                                                                  |
-| useDefaultNotification                              | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                    |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                                       |
-| useSlowQueryAnalysis                                | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                                                                                                                                                                         |
-| network                                             | Body | Object  | X        | Network information objects                                                                                                                                                                                                                                                                   |
-| network.subnetId                                    | Body | UUID    | X        | Subnet identifier<br/>- Default: Source DB instance value                                                                                                                                                                                                                                                                             |
-| network.usePublicAccess                             | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                                    |
-| network.availabilityZone                            | Body | Enum    | X        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: Random selection                                                                                                                                                                                                                 |
-| storage                                             | Body | Object  | X        | Storage information objects                                                                                                                                                                                                                                                                   |
-| storage.storageType                                 | Body | Enum    | X        | Block Storage Type<br/>- Default: Source DB instance value<br/>- Example: `General SSD`                                                                                                                                                                                                                   |
-| storage.storageSize                                 | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Source DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                       |
-| storage.storageAutoscale                            | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                                                                                                                                                                            |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                                                                                                                                                                                    |
-| storage.storageAutoscale.threshold                  | Body | Number  | X        | Auto scale out conditions (%)<br/>- Default: Source DB instance value<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                                                                                                                                 |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Default: Source DB instance value<br/>- Maximum value: `4096`                                                                                                                                                                                                        |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Default: Source DB instance value<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                                                                                                                        |
-| backup                                              | Body | Object  | X        | Backup information objects                                                                                                                                                                                                                                                                    |
-| backup.backupPeriod                                 | Body | Number  | X        | Backup retention period<br/>- Default: Source DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                       |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                    |
-| backup.backupRetryCount                             | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                   |
-| backup.backupSchedules                              | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                       |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | X        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour    |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                | Type | Format   | Required | Description                                                                                                                                                                             |
-|---------------------|------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
-
-| Name                          | Type | Format | Required | Description                                     |
-|-------------------------------|------|--------|----------|-------------------------------------------------|
-| restore.backupId              | Body | UUID   | O        | Identifier of the backup to use for restoration |
-| restore.binLog                | Body | Object | O        | Binary log information object                   |
-| restore.binLog.binLogFileName | Body | String | O        | Binary log name to use for restoration          |
-| restore.binLog.binLogPosition | Body | Number | O        | Binary log location to use for restoration      |
-
-* When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request when restoring from backup (if restoreType is `BACKUP`)
-
-| Name             | Type | Format | Required                       | Description                                     |
-|------------------|------|--------|--------------------------------|-------------------------------------------------|
-| restore.backupId | Body | UUID   | O (if restoreType is `BACKUP`) | Identifier of the backup to use for restoration |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-### Restore from Object Storage
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
-
-#### Request
-
-| Name                                                | Type | Format  | Required | Description                                                                                                                                    |
-|-----------------------------------------------------|------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O        | Restoration information object                                                                                                                 |
-| restore.tenantId                                    | Body | String  | O        | Tenant ID of object storage where backups are stored                                                                                           |
-| restore.username                                    | Body | String  | O        | NHN Cloud account or IAM member ID                                                                                                             |
-| restore.password                                    | Body | String  | O        | API password for object storage where backups are stored                                                                                       |
-| restore.targetContainer                             | Body | String  | O        | Container for object storage where backups are stored                                                                                          |
-| restore.objectPath                                  | Body | String  | O        | Backup path stored in container                                                                                                                |
-| dbVersion                                           | Body | Enum    | O        | DB engine type                                                                                                                                 |
-| dbInstanceName                                      | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName                             | Body | String  | O        | Candidate name to identify DB instances                                                                               |
-| description                                         | Body | String  | X        | Additional information on DB instances                                                                                                         |
-| dbFlavorId                                          | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                       |
-| dbPort                                              | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                               |
-| parameterGroupId | Body | UUID    | O        | Parameter group identifier                                                                                                                     |
-| dbSecurityGroupIds                                  | Body | Array   | X        | DB security group identifiers                                                                                                                  |
-| userGroupIds                                        | Body | Array   | X        | User group identifiers                                                                                                                         |
-| useHighAvailability                                 | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                         |
-| pingInterval                                        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType                                            | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                     |
-| useDefaultNotification                              | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                      |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                        |
-| useSlowQueryAnalysis                                | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                                             |
-| network                                             | Body | Object  | O        | Network information objects                                                                                                                    |
-| network.subnetId                                    | Body | UUID    | O        | Subnet identifier                                                                                                                              |
-| network.usePublicAccess                             | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                      |
-| network.availabilityZone                            | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                 |
-| storage                                             | Body | Object  | O        | Storage information objects                                                                                                                    |
-| storage.storageType                                 | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                               |
-| storage.storageSize                                 | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                               |
-| storage.storageAutoscale                            | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                                                   |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                                                  |
-| storage.storageAutoscale.threshold                  | Body | Number  | X        | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                                                    |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                                                                                                              |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                                              |
-| backup                                              | Body | Object  | O        | Backup information objects                                                                                                                     |
-| backup.backupPeriod                                 | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                               |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                              |
-| backup.backupRetryCount                             | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                         |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                         |
-|-----------------------|------|---------|----------|-------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier              |
-| useDeletionProtection | Body | Boolean | O        | Whether to protect against deletion |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### High availability status
-
-| Status | Description |
-|----------------------------------|---------------------------------|
-| `CREATED` | High availability has been created |
-| `STABLE` | High availability is operating normally |
-| `PAUSING` | High availability is being paused |
-| `PAUSED` | High availability has been paused |
-| `PAUSED_DUE_TO_TASK` | High availability has been paused due to a task |
-| `DISABLE_MASTER_IN_REPLICATION` | High availability has been disabled due to detection of abnormal master replication |
-| `DISABLE_MHA_PROCESS` | The high availability process has been stopped |
-| `DISABLE_REPLICATION_STOP` | High availability has been disabled due to replication stoppage |
-| `DISABLE_REPLICATION_DELAY` | High availability has been disabled due to replication delay |
-| `MASTER_FAILURE_DETECTION` | A master failure has been detected |
-| `FAILOVER_STARTED` | Failover has started |
-| `FAILOVER_FAILED` | Failover has failed |
-| `FAILOVER_COMPLETED` | Failover has been completed |
-| `DELETED` | High availability has been deleted |
-
----
-
-### View High Availability Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
-
-| Permission | Description |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | View DB instance details |
-
-#### Request
-
-This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | Body | String | X | Candidate name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbVersion | Body | Enum | X | DB engine type |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries |
+| useDummy | Body | Boolean | X | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Switch to read-only mode<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### Response
 
 | Name | Type | Format | Description |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | Whether high availability is enabled |
-| haStatus | Body | Enum | High availability status |
-| pingInterval | Body | Number | Ping interval (seconds) |
-| pingType | Body | Enum | Ping type<br/>- `INSERT`<br/>- `SELECT` |
-
-<details><summary>Example</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
-
----
-
-### Modify High Availability
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | Modify high availability |
-
-#### Request
-
-| Name                | Type | Format  | Required | Description                                                                                          |
-|---------------------|------|---------|----------|------------------------------------------------------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O        | DB instance identifier                                                                               |
-| useHighAvailability | Body | Boolean | O        | Whether to use high availability                                                                     |
-| pingInterval        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType            | Body | Enum    | X        | Ping type when using high availability<br/>- `INSERT`<br/>- `SELECT`                                              |
-| dbInstanceCandidateName        | Body | String  | O  | Name to identify DB instances<br/>- Required for using high availability |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | Restart high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Pause High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | Pause high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Recover High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | Recover high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Separate High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | Separate high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Storage Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                            | Description           |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                 | Type | Format  | Description                                                                                                |
-|--------------------------------------|------|---------|------------------------------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | Block Storage Type                                                                                         |
-| storageSize                          | Body | Number  | Block Storage Size (GB)                                                                                    |
-| storageStatus                        | Body | Enum    | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-| storageAutoscale                     | Body | Object  | Block Storage Auto Scaling Objects                                                                         |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling                                                                     |
-| storageAutoscale.threshold           | Body | Number  | Auto scale out conditions (%)                                                                              |
-| storageAutoscale.maxStorageSize      | Body | Number  | Auto scaling maximum size (GB)                                                                             |
-| storageAutoscale.cooldownTime        | Body | Number  | Auto scaling cooldown time (minutes)                                                                       |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2004,54 +1202,12 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
-
----
-
-### Modify Storage Information
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                                 | Type | Format  | Required | Description                                                                                                       |
-|--------------------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| storageSize                          | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                            |
-| useOnlineFailover                    | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| storageAutoscale                     | Body | Object  | X        |Block Storage Auto Scaling Objects                                                                                                 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                     |
-| storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                       |
-| storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                                                                                 |
-| storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                 |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
 
 ---
 
@@ -2063,30 +1219,30 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Required permissions
 
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Backup Information |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                              | Type | Format  | Description                |
-|-----------------------------------|------|---------|----------------------------|
-| backupPeriod                      | Body | Number  | Backup retention period    |
-| ftwrlWaitTimeout                  | Body | Number  | Query latency (sec)        |
-| backupRetryCount                  | Body | Number  | Number of backup retries   |
-| replicationRegion                 | Body | Enum    | Backup replication region  |
-| useBackupLock                     | Body | Boolean | Whether to use table lock  |
-| backupSchedules                   | Body | Array   | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime  | Body | String  | Backup started time        |
-| backupSchedules.backupWndDuration | Body | Enum    | Backup duration            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Body | Number | Query latency (sec) |
+| backupRetryCount | Body | Number | Number of backup retries |
+| replicationRegion | Body | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Body | Boolean | Whether to use table lock |
+| backupSchedules | Body | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Body | Time | Backup started time |
+| backupSchedules.backupWndDuration | Body | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>Example</summary>
 <p>
@@ -2099,14 +1255,14 @@ This API does not require a request body.
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2114,7 +1270,6 @@ This API does not require a request body.
 
 </p>
 </details>
-
 
 ---
 
@@ -2126,34 +1281,38 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Backup Information |
 
 #### Request
 
-| Name                              | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|-----------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                    |
-| backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| useBackupLock                     | Body | Boolean | X        | Whether to use table lock                                                                                                                                                                                                                                                 |
-| backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Body | Boolean | X | Whether to use table lock |
+| backupSchedules | Body | Array | X | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2164,12 +1323,1378 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### View Binary Log List
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | View binary log list |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| binLogs | Body | Array | BinLog file list |
+| binLogs.binLogFileName | Body | String | BinLog file name |
+| binLogs.binLogFileSize | Body | Number | BinLog file size (Byte) |
+| binLogs.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "binLogs": [
+        {
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 ---
 
+### Delete Binary Log
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | Delete binary log |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| lastBinLogFileName | Body | String | O | Last BinLog file name to delete (delete all files prior to this file) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "lastBinLogFileName": "mysql-bin.000010"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### View Certificate File List
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.List | View certificate file list |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| certificates | Body | Array | Certificate file list |
+| certificates.fileName | Body | String | Certificate file name |
+| certificates.certificateType | Body | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Body | Number | Certificate file size (Byte) |
+| certificates.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "certificates": [
+        {
+            "fileName": "fileName-example",
+            "certificateType": "CA_FILE",
+            "fileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export Certificate File
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.Export | Export certificate file |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| certificateTypes | Body | Array | O | Certificate type list to upload |
+| tenantId | Body | String | O | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM account ID |
+| password | Body | String | O | API password for object storage where certificate file is stored |
+| targetContainer | Body | String | O | Object storage container where certificate file is stored |
+| objectPath | Body | String | O | Path of the certificate file to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "certificateTypes": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Schema
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | List DB schemas |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DB schema list |
+| dbSchemas.dbSchemaId | Body | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | Body | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Body | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Create DB Schema
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | Create DB schema |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbSchemaName | Body | String | O | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB Schema
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | Delete DB schema |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbSchemaId | URL | UUID | O | DB schema identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Users
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | List DB Users |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB users |
+| dbUsers.dbUserId | Body | UUID | DB user identifier |
+| dbUsers.dbUserName | Body | String | DB user account name |
+| dbUsers.host | Body | String | DB user account host name |
+| dbUsers.authorityType | Body | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | Created date and time |
+| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Body | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Body | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Create DB User
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | Create DB User |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | Body | String | O | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Body | Enum | O | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB User
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | Delete DB User |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB User
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | Modify DB User |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+| dbPassword | Body | String | X | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Body | Enum | X | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Change DB Instance Deletion Protection Settings
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Change DB Instance Deletion Protection Settings |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | Force Restart DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+This API does not return a response body.
+
+---
+### View High Availability Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View high availability information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | Whether high availability is enabled<br/>- Default: `false` |
+| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Body | Number | Ping interval (seconds) |
+| pingType | Body | String | Ping type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify High Availability
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | Modify high availability |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| useHighAvailability | Body | Boolean | O | Whether to use high availability |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+
+#### When Using High Availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Pause High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | Pause high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Repair High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | Repair high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | Restart high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Separate High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | Separate high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### List Log Files
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | List log files |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | Log file list |
+| logFiles.logFileName | Body | String | Log file name |
+| logFiles.logFileType | Body | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | Log file size (Byte) |
+| logFiles.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export Log File
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | Export log files |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | Log file name list |
+| tenantId | Body | String | O | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password for the object storage where log files are stored |
+| targetContainer | Body | String | O | Object storage container where log files are stored |
+| objectPath | Body | String | O | Path of the log file to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Log File Contents
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | View log file contents |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| logFileName | URL | UUID | O | Log file name |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| content | Body | String | Log file contents (maximum 65533 bytes) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+### List DB Instance Maintenances
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | List DB instance maintenances |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### Response
+
+| Name | In | Type | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of maintenances |
+| maintenances | Body | Array | List of maintenances |
+| maintenances.maintenanceId | Body | UUID | Maintenance ID |
+| maintenances.dbInstanceId | Body | UUID | DB instance ID |
+| maintenances.category | Body | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| maintenances.description | Body | String | Maintenance description |
+| maintenances.type | Body | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| maintenances.payload | Body | Object | Payload according to maintenance type |
+| maintenances.required | Body | Boolean | Whether the maintenance is required |
+| maintenances.deadlineYmdt | Body | DateTime | Datetime when the maintenance is forcibly applied |
+| maintenances.status | Body | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
+| maintenances.addedYmdt | Body | DateTime | Datetime when the maintenance was scheduled |
+| maintenances.executionStartedYmdt | Body | DateTime | Maintenance start datetime |
+| maintenances.executionCompletedYmdt | Body | DateTime | Maintenance end datetime |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Execute DB Instance Maintenance Now
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | Execute DB instance maintenance now |
+
+#### Request
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| configId | Body | String | O | Configuration ID |
+| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | Body | String | X | Maintenance description |
+| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | Body | String | O | Payload according to maintenance type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | In | Type | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Schedule DB Instance Maintenance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | Schedule DB instance maintenance |
+
+#### Request
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| configId | Body | String | O | Configuration ID |
+| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | Body | String | X | Maintenance description |
+| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | Body | String | O | Payload according to maintenance type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Delete DB Instance Maintenance
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | Delete DB instance maintenance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| maintenanceId | URL | UUID | O | Maintenance ID |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ### List Network Information
 
 ```http
@@ -2178,31 +2703,31 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Required permissions
 
-| Permission Name                                       | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | List Network Information |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                   | Type | Format | Description                                                                                                                                                                                                |
-|------------------------|------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | Availability zone where DB instance will be created                                                                                                                                                        |
-| subnet                 | Body | Object | Subnet object                                                                                                                                                                                              |
-| subnet.subnetId        | Body | UUID   | Subnet identifier                                                                                                                                                                                          |
-| subnet.subnetName      | Body | UUID   | Name to identify subnets                                                                                                                                                                                   |
-| subnet.subnetCidr      | Body | UUID   | CIDR of subnet                                                                                                                                                                                             |
-| endPoints              | Body | Array  | List of access information                                                                                                                                                                                 |
-| endPoints.domain       | Body | String | Domain                                                                                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP address                                                                                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | Access information type<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | Availability zone where DB instance will be created |
+| subnet | Body | Object | Subnet object |
+| subnet.subnetId | Body | UUID | Subnet identifier |
+| subnet.subnetName | Body | String | Name to identify subnets |
+| subnet.subnetCidr | Body | String | CIDR of subnet |
+| endPoints | Body | Array | List of access information |
+| endPoints.domain | Body | String | Domain |
+| endPoints.ipAddress | Body | String | IP address |
+| endPoints.endPointType | Body | String | Access information type |
 
 <details><summary>Example</summary>
 <p>
@@ -2216,15 +2741,15 @@ This API does not require a request body.
     },
     "availabilityZone": "kr-pub-a",
     "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2243,58 +2768,34 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Required permissions
 
-| Permission Name                               | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Network Information |
 
 #### Request
 
-| Name            | Type | Format  | Required | Description                         |
-|-----------------|------|---------|----------|-------------------------------------|
-| dbInstanceId    | URL  | UUID    | O        | DB instance identifier              |
-| usePublicAccess | Body | Boolean | O        | External access is available or not |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| usePublicAccess | Body | Boolean | O | External access is available or not |
 
-#### Response
+<details><summary>Example</summary>
+<p>
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Users
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
+```json
+{
+    "usePublicAccess": false
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                 | Description                  |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | List of users in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+</p>
+</details>
 
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                              |
-|------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB users                                                                                                                                                                 |
-| dbUsers.dbUserId             | Body | UUID     | DB user identifier                                                                                                                                                       |
-| dbUsers.dbUserName           | Body | String   | DB user account name                                                                                                                                                     |
-| dbUsers.host                 | Body | String   | DB user account host name                                                                                                                                                |
-| dbUsers.authorityType        | Body | Enum     | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| dbUsers.dbUserStatus         | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `UPDATING`: Modifying<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted                     |
-| dbUsers.authenticationPlugin | Body | Enum     | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                       |
-| dbUsers.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2306,15 +2807,365 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbUsers": [
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Promote DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | Promote DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Rebuild DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | Rebuild DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Replicate DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifier list |
+| userGroupIds | Body | Array | X | User group identifier list |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze Slow query<br/>- Default: `true` |
+| network | Body | Object | O | Network information object |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| storage | Body | Object | X | Storage information object |
+| storage.storageType | Body | Enum | X | Data storage type |
+| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | X | Backup information object |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock |
+| backup.backupSchedules | Body | Array | X | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | Restart DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Block write load<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Restoration Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Restoration Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
+| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
+| restorableBackups | Body | Array | List of restorable backups |
+| restorableBackups.backup | Body | Object | Backup information object |
+| restorableBackups.backup.backupId | Body | UUID | Backup identifier |
+| restorableBackups.backup.backupName | Body | String | Backup name |
+| restorableBackups.backup.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.backup.dbInstanceId | Body | UUID | Original DB instance identifier |
+| restorableBackups.backup.dbInstanceName | Body | String | Original DB instance name |
+| restorableBackups.backup.dbVersion | Body | Enum | DB engine type |
+| restorableBackups.backup.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | Backup size |
+| restorableBackups.backup.useBackupLock | Body | Boolean | Whether to use table lock |
+| restorableBackups.backup.failoverCount | Body | Number | Number of failovers |
+| restorableBackups.backup.binLogFileName | Body | String | Binary log file name |
+| restorableBackups.backup.binLogPosition | Body | Object | Binary log file location |
+| restorableBackups.backup.createdYmdt | Body | DateTime | Date and time of backup creation |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | Date and time of backup renewal |
+| restorableBackups.restorableBinLogs | Body | Array | Binary log names that can be restored using the backup |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
         {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
+            "backup": {
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "MYSQL_V8036",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
+            "restorableBinLogs": []
         }
     ]
 }
@@ -2325,153 +3176,32 @@ This API does not require a request body.
 
 ---
 
-### Create DB User
+### View the Last Query to Be Restored
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | Create users in DB instance |
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserName           | Body | String | O        | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                                                                                |
-| dbPassword           | Body | String | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| host                 | Body | String | O        | DB user account host name<br/>- Example: `1.1.1.%`                                                                                                                       |
-| authorityType        | Body | Enum   | O        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB User
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | Modify users in DB instance |
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                             |
-|----------------------|------|--------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                  |
-| dbUserId             | URL  | UUID   | O        | DB user identifier                                                                                                                                                      |
-| dbPassword           | Body | String | X        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                          |
-| authorityType        | Body | Enum   | X        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB User
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | Delete users in DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View the Last Query to Be Restored |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbUserId     | URL  | UUID   | O        | DB user identifier     |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Schema
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | List of schemas in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                                                                                                  |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB schema list                                                                                                               |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB schema identifier                                                                                                         |
-| dbSchemas.dbSchemaName   | Body | String   | DB schema name                                                                                                               |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB schema current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted |
-| dbSchemas.createdYmdt    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | Query executed date |
+| lastQuery | Body | String | Last executed query |
 
 <details><summary>Example</summary>
 <p>
@@ -2483,163 +3213,165 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+### Restore DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
+| dbPort | Body | Number | X | DB port |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Body | Object | X | Storage information object. If not specified, the storage settings of the source instance are applied. |
+| storage.storageType | Body | Enum | X | Storage type. If not specified, the storage type of the source instance is applied. |
+| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Body | Object | X | Network information object. If not specified, the network settings of the source instance are applied. |
+| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used. |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created. If not specified, randomly selected. |
+| backup | Body | Object | X | Backup information object. If not specified, the backup settings of the source instance are applied. |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | X | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.restoreType | Body | Enum | O | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
+| restore.binLog.binLogFileName | Body | String | X | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Body | Object | X | Binary log location to use for restoration |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
+| userGroupIds | Body | Array | X | User group identifier list |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+#### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry.
+
+#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+| restore.binLog | Body | Object | X | Binary log information object |
+
+When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
+
+#### Request when restoring from backup (if restoreType is `BACKUP`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
         }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Create DB Schema
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | Create schemas in DB instance |
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaName | Body | String | O        | DB schema name         |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB Schema
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | Delete schemas in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaId   | URL  | UUID   | O        | DB schema identifier   |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List Log Files
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | List of log files in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                         |
-|--------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                              |
-| logFileTypes | Query | Array  | X        | Log File type list<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### Response
-
-| Name                 | Type | Format   | Description                                                                                                                                                                                    |
-|----------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | Log File list                                                                                                                                                                                  |
-| logFiles.logFileName | Body | String   | Log File name                                                                                                                                                                                  |
-| logFiles.logFileType | Body | Enum     | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | Log File size(Byte)                                                                                                                                                                            |
-| logFiles.createdYmdt | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                             |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
     },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
         }
-    ]
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
 </p>
 </details>
 
----
-
-### View Log File contents
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### Required permissions
-
-| Permission Name                               | Description                           |
-|-----------------------------------------------|---------------------------------------|
-| RDSforMariaDB:DbInstanceLog.Get | View log file contents in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                    |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                         |
-| logFileName  | URL   | String | O        | Log File name                                                                                                                                                                                  |
-| logFileType  | Query | Enum   | O        | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### Response
 
-| Name    | Type | Format | Description                            |
-|---------|------|--------|----------------------------------------|
-| content | Body | String | Log File contents(maximum 65533 Bytes) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2651,7 +3383,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "content": "..."
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2660,84 +3392,31 @@ This API does not require a request body.
 
 ---
 
-### Export Log File
+### Start DB Instance
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+POST /v4.0/db-instances/{dbInstanceId}/start
 ```
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | Export log files in DB instance |
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                              |
-|-----------------|------|--------|----------|----------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                   |
-| logFileNames    | Body | Array  | O        | Log File name list<br/>- Minimum size: `1`               |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store log file            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                       |
-| password        | Body | String | O        | API password for object storage where log file is stored |
-| targetContainer | Body | String | O        | Object storage container where log file is stored        |
-| objectPath      | Body | String | O        | Log file path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View BinLog Lists
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
-
-#### Required Permission
-
-| Permission                                               | Description           |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | View BinLog lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | Start DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type    | Format      | Required | Description                                                                                   |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID    | O  | DB instance identifier                                                                         |
-| deletable    | Query | Boolean | X  | Show only deletable BinLogs<br/>- `true`: Exclude latest BinLog<br/>- `false`: All<br/>- Default: `false` |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                     | Type   | Format       | Description                                |
-|------------------------|------|----------|-----------------------------------|
-| binLogs                | Body | Array    | BinLog file list                      |
-| binLogs.binLogFileName | Body | String   | BinLog file name                      |
-| binLogs.binLogFileSize | Body | Number   | BinLog file size (Byte)                |
-| binLogs.createdYmdt    | Body | DateTime | Created at(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2749,13 +3428,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "binLogs": [
-        {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2764,40 +3437,31 @@ This API does not require a request body.
 
 ---
 
-### Delete BinLog
+### Stop DB Instance
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+POST /v4.0/db-instances/{dbInstanceId}/stop
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission                                                | Description        |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | Delete BinLog |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | Stop DB Instance |
 
 #### Request
 
-| Name                 | Type   | Format     | Required | Description                                     |
-|--------------------|------|--------|----|----------------------------------------|
-| dbInstanceId       | URL  | UUID   | O  | DB instance identifier                           |
-| lastBinLogFileName | Body | String | O  | Last BinLog file name to delete (delete all files prior to this file) |
+This API does not require a request body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "lastBinLogFileName": "mysql-bin.000010"
-}
-```
-
-</p>
-</details>
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2808,6 +3472,67 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Storage Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Storage Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageType | Body | String | Data storage type |
+| storageSize | Body | Number | Data storage size (GB) |
+| storageStatus | Body | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+| storageAutoscale | Body | Object | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling |
+| storageAutoscale.threshold | Body | Number | Auto scale out conditions (%) |
+| storageAutoscale.maxStorageSize | Body | Number | Auto scaling maximum size (GB) |
+| storageAutoscale.cooldownTime | Body | Number | Auto scaling cooldown time (minutes) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
     }
 }
 ```
@@ -2817,35 +3542,55 @@ This API does not return a response body.
 
 ---
 
-### View Certificate File Lists
+### Modify Storage Information
 
 ```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission                                                    | Description           |
-|--------------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceCertificate.List | View certificate file lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Storage Information |
 
-#### Request
+#### Common Request
 
-This API does not require a request body.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
+| storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling |
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                           |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
-| certificates                 | Body | Array    | Certificate file list                                                                    |
-| certificates.fileName        | Body | String   | Certificate file name                                                                    |
-| certificates.certificateType | Body | Enum     | Certificate type<br/>- `CA_FILE`: CA certificate<br/>- `CERT_FILE`: certificate<br/>- `KEY_FILE`: Secret key |
-| certificates.fileSize        | Body | Number   | Certificate file size (Byte)                                                              |
-| certificates.createdYmdt     | Body | DateTime | Created at(YYYY-MM-DDThh:mm:ss.SSSTZD)                                            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2857,14 +3602,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "certificates": [
-        {
-            "fileName": "ca.pem",
-            "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2872,57 +3610,6 @@ This API does not require a request body.
 </details>
 
 ---
-
-### Export a Certificate File
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
-#### Required Permission
-
-| Permission                                                      | Description          |
-|----------------------------------------------------------|-------------|
-| RDSforMariaDB:DbInstanceCertificate.Export | Export a certificate file |
-
-#### Request
-
-| Name               | Type   | Format     | Required | Description                                                                           |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
-| dbInstanceId     | URL  | UUID   | O  | DB instance identifier                                                                 |
-| certificateTypes | Body | Array  | O  | Certificate type to upload<br/>- `CA_FILE`: CA certificate<br/>- `CERT_FILE`: Certificate<br/>- `KEY_FILE`: Secret key |
-| tenantId         | Body | String | O  | Tenant ID of object storage to store certificate file                                                |
-| username         | Body | String | O  | NHN Cloud account or IAM account ID                                                    |
-| password         | Body | String | O  | API password for object storage where certificate file is stored                                              |
-| targetContainer  | Body | String | O  | Object storage container where certificate file is stored                                                  |
-| objectPath       | Body | String | O  |
-Certificate file path to be stored in container                                                         |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
----
-
 ## Backups
 
 ### Backup Status
@@ -2935,123 +3622,38 @@ Certificate file path to be stored in container                                 
 | `DELETED`    | Backup is deleted       |
 | `ERROR`      | Error occurred          |
 
-### View Backup Details
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### Required Permission
-
-| Permission                                    | Description       |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | View backup details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name       | Type  | Format   | Required | Description      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | Backup identifier |
-
-#### Response
-
-| Name                      | Type   | Format       | Description              |
-|-------------------------|------|----------|-----------------|
-| backup                  | Body | Object   | Back details        |
-| backup.backupId         | Body | UUID     | Backup identifier         |
-| backup.regionCode       | Body | Enum     | Region code           |
-| backup.backupName       | Body | String   | Name to identify backups |
-| backup.backupStatus     | Body | Enum     | Backup current status       |
-| backup.dbInstanceId     | Body | UUID     | Source DB instance identifier |
-| backup.dbInstanceName   | Body | String   | Source DB instance name  |
-| backup.dbVersion        | Body | Enum     | DB engine version        |
-| backup.backupType       | Body | Enum     | Backup type                             |
-| backup.backupMethodType | Body | Enum     | Backup method                             |
-| backup.backupFileType   | Body | Enum     | Backup file type                          |
-| backup.backupSize       | Body | Number   | Backup size (Byte)                      |
-| backup.isReplicable     | Body | Boolean  | Replicable                          |
-| backup.binLogFileName   | Body | String   | Binary log file name                       |
-| backup.binLogPosition   | Body | Number   | Binary log location                        |
-| backup.createdYmdt      | Body | DateTime | Created at (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt      | Body | DateTime | Updated at (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
 ### Retrieve Backup List
 
 ```http
 GET /v4.0/backups
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Backup.List | Retrieve Backup List |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.List | Retrieve backup list |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                          |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1`                                         |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                                                     |
-| backupType   | Query | Enum   | X        | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X        | Original DB instance identifier                                                      |
-| dbVersion    | Query | Enum   | X        | DB engine type                                                                       |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                         |
-|----------------------|------|----------|-----------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                          |
-| backups              | Body | Array    | Backup list                                         |
-| backups.backupId     | Body | UUID     | Backup identifier                                   |
-| backups.backupName   | Body | String   | Name to identify backups                            |
-| backups.backupStatus | Body | Enum     | Backup current status                               |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                     |
-| backups.dbVersion    | Body | Enum     | DB engine type                                      |
-| backups.backupType   | Body | Enum     | Backup type                                         |
-| backups.backupSize   | Body | Number   | Backup size (Byte)                                  |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of backup list entries |
+| backups | Body | Array | Backup list |
+| backups.backupId | Body | UUID | Backup identifier |
+| backups.backupName | Body | String | Name to identify the backup |
+| backups.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | Body | UUID | Source DB instance identifier |
+| backups.dbVersion | Body | Enum | DB engine type |
+| backups.utilVersion | Body | String | Utility version |
+| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | Backup size (Byte) |
+| backups.createdYmdt | Body | DateTime | Created date and time |
+| backups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3066,15 +3668,16 @@ This API does not require a request body.
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3091,91 +3694,184 @@ This API does not require a request body.
 POST /v4.0/backups
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Create | Create backup |
 
-#### Common Request
+#### Request
 
-| Name             | Type | Format | Required | Description                                                                                                             |
-|------------------|------|--------|----------|-------------------------------------------------------------------------------------------------------------------------|
-| backupName       | Body | String | O        | Backup name                                                                                                             |
-| backupMethodType | Body | Enum   | O        | Backup method type<br/>- `FULL`: Full backup<br/>- `INCREMENTAL`: Incremental backup <br/>- `SNAPSHOT`: Snapshot backup |
-
-#### If backupMethodType is `FULL`
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | Body | UUID   | O        | DB instance identifier |
-
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| baseBackupId | Body | UUID | X | Source backup identifier |
+| dbInstanceId | Body | UUID | X | DB instance identifier |
+| backupMethodType | Body | Enum | O | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-#### If backupMethodType is `INCREMENTAL`
-
-| Name         | Type | Format | Required | Description                |
-|--------------|------|--------|----------|----------------------------|
-| baseBackupId | Body | UUID   | O        | Baseline backup identifier |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-
-
-#### Snapshot Backup (if backupMethodType is `SNAPSHOT`)
-
-| Name           | Type   | Format   | Required | Description           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB instance identifier |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete Backup
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | Delete backup |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Backup Details
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | View backup details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| backup | Body | Object | Backup details |
+| backup.backupId | Body | UUID | Backup identifier |
+| backup.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| backup.backupName | Body | String | Name to identify the backup |
+| backup.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backup.dbInstanceId | Body | UUID | Source DB instance identifier |
+| backup.dbInstanceName | Body | String | Source DB instance name |
+| backup.dbVersion | Body | Enum | DB engine version |
+| backup.utilVersion | Body | String | Utility version |
+| backup.backupType | Body | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | Backup size (Byte) |
+| backup.isReplicable | Body | Boolean | Whether replication is possible |
+| backup.binLogFileName | Body | String | Binary log file name |
+| backup.binLogPosition | Body | Object | Binary log location |
+| backup.createdYmdt | Body | DateTime | Created date and time |
+| backup.updatedYmdt | Body | DateTime | Modified date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "MYSQL_V8036",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3185,33 +3881,33 @@ POST /v4.0/backups
 POST /v4.0/backups/{backupId}/export
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Export | Export backup |
 
 #### Request
 
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| backupId        | URL  | UUID   | O        | Backup identifier                                      |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                     |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password of the object storage where the backup will be stored |
+| targetContainer | Body | String | O | Object storage container where the backup will be stored |
+| objectPath | Body | String | O | Path of the backup to be stored in the container |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3220,9 +3916,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3232,72 +3945,97 @@ POST /v4.0/backups/{backupId}/export
 POST /v4.0/backups/{backupId}/restore
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Restore | Restore backup |
 
-#### Request
+#### Common Request
 
-| Name                                         | Type | Format  | Required | Description                                                                                                                               |
-|----------------------------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O        | Backup identifier                                                                                                                         |
-| dbInstanceName                               | Body | String  | O        | Master name to identify DB instances                                                                                                      |
-| dbInstanceCandidateName                      | Body | String  | X        | Candidate name to identify DB instances                                                                                                   |
-| description                                  | Body | String  | X        | Additional information on DB instances                                                                                                    |
-| dbFlavorId                                   | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                  |
-| dbPort                                       | Body | Integer | X        | DB port <br/> - Default: Source DB instance value     <br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                           |
-| parameterGroupId                             | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                |
-| dbSecurityGroupIds                           | Body | Array   | X        | DB security group identifiers                                                                                                             |
-| userGroupIds                                 | Body | Array   | X        | User group identifiers                                                                                                                    |
-| useHighAvailability                          | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                     |
-| pingInterval                                 | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                     |
-| pingType                                     | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                               |
-| useDefaultNotification                       | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                  |
-| useDeletionProtection                        | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                  | 
-| useSlowQueryAnalysis                         | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                     |
-| network                                      | Body | Object  | X        | Network information objects                                                                                                               |
-| network.subnetId                             | Body | UUID    | X        | Subnet identifier<br/>- Default: Original DB instance value                                                                                                                         |
-| network.usePublicAccess                      | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                  |
-| network.availabilityZone                     | Body | Enum    | X        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: Random selection                             |
-| storage                                      | Body | Object  | X        | Storage information objects                                                                                                               |
-| storage.storageType                          | Body | Enum    | X        | Block Storage Type <br/> - Default: Source DB instance value     <br/>- Example: `General SSD`                                            |
-| storage.storageSize                          | Body | Number  | X        | Block Storage Size (GB) <br/> - Default: Source DB instance value     <br/>- Minimum value: `20`<br/>- Maximum value: `2048`              |
-| storage.storageAutoscale                     | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                        |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling        <br/> - Default: Source DB instance value                                                   |
-| storage.storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%) <br/> - Default: Source DB instance value     <br/>- Minimum value: `50`<br/>- Maximum value: `95`          |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB) <br/> - Default: Source DB instance value     <br/>- Maximum value: `4096`                                 |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes) <br/> - Default: Source DB instance value     <br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-| backup                                       | Body | Object  | X        | Backup information objects                                                                                                                |
-| backup.backupPeriod                          | Body | Number  | X        | Backup retention period <br/> - Default: Source DB instance value     <br/>- Minimum value: `0`<br/>- Maximum value: `730`                |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                |
-| backup.backupRetryCount                      | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | DB instance specification identifier. If not specified, the source instance value is used |
+| dbPort | Body | Number | X | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the source instance value is used |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Body | Object | X | Network information object. If not specified, the source instance value is used |
+| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
+| storage | Body | Object | X | Storage information object. If not specified, the source instance value is used |
+| storage.storageType | Body | Enum | X | Storage type. If not specified, the source instance value is used |
+| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object. If not specified, the source instance value is used |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | X | Backup information object. If not specified, the source instance backup settings are used |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock. If not specified, the source instance value is used |
+| backup.backupSchedules | Body | Array | X | Backup schedule list. If not specified, the source instance value is used |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using High Availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
         "storageType": "General SSD",
-        "storageSize": 20
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -3313,50 +4051,38 @@ POST /v4.0/backups/{backupId}/restore
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
----
+<details><summary>Example</summary>
+<p>
 
-### Delete Backup
-
-```http
-DELETE /v4.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | Delete backup |
-
-#### Request
-
-This API does not require a request body.
-
-| Name     | Type | Format | Required | Description       |
-|----------|------|--------|----------|-------------------|
-| backupId | URL  | UUID   | O        | Backup identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+</p>
+</details>
 
 ---
-
 ## DB Security Group
 
 ### DB Security Group Progress
 
-| Status          | Description         |
-|-----------------|---------------------|
-| `NONE`          | No task in progress |
-| `CREATING_RULE` | Creating rules      |
-| `UPDATING_RULE` | Modifying rules     |
-| `DELETING_RULE` | Deleting rules      |
+| Status              | Description             |
+|---------------------|-------------------------|
+| `NONE`              | No task in progress     |
+| `CREATING_RULE`     | Creating rules          |
+| `UPDATING_RULE`     | Modifying rules         |
+| `DELETING_RULE`     | Deleting rules          |
 
 ### List DB Security Groups
 
@@ -3366,29 +4092,26 @@ GET /v4.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------------|----------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.List | List DB security groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|-------|----------|----|-------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1` |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                     |
 #### Response
 
-| Name                                 | Type | Format   | Description                                         |
-|--------------------------------------|------|----------|-----------------------------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB security groups                                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB security group identifier                        |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | Name to identify DB instances                       |
-| dbSecurityGroups.description         | Body | String   | Additional information on DB security group         |
-| dbSecurityGroups.progressStatus      | Body | Enum     | Current status of DB security group                 |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of DB security groups |
+| dbSecurityGroups | Body | Array | DB security groups |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | Name to identify the DB security group |
+| dbSecurityGroups.description | Body | String | Additional information on DB security group |
+| dbSecurityGroups.progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3400,102 +4123,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List DB Security Group Details
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | List DB security group details
- |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
-
-#### Response
-
-| Name                | Type | Format   | Description                                                                                                                                              |
-|---------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB security group identifier                                                                                                                             |
-| dbSecurityGroupName | Body | String   | Name to identify DB instances                                                                                                                            |
-| description         | Body | String   | Additional information on DB security group                                                                                                              |
-| progressStatus      | Body | Enum     | Current status of DB security group                                                                                                                      |
-| rules               | Body | Array    | DB security group rules                                                                                                                                  |
-| rules.ruleId        | Body | UUID     | DB security group rule identifier                                                                                                                        |
-| rules.description   | Body | String   | Additional information on DB security group rule                                                                                                         |
-| rules.direction     | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                |
-| rules.etherType     | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                         |
-| rules.port          | Body | Object   | Port object                                                                                                                                              |
-| rules.port.portType | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number   | Minimum port range                                                                                                                                       |
-| rules.port.maxPort  | Body | Number   | Maximum port range                                                                                                                                       |
-| rules.cidr          | Body | String   | Remote source for traffic to allow                                                                                                                       |
-| rules.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| rules.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-| createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
 }
 ```
 
@@ -3512,46 +4150,44 @@ POST /v4.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Create | Create DB security group |
 
 #### Request
 
-| Name                | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|---------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O        | Name to identify DB instances                                                                                                                                                                                                    |
-| description         | Body | String | X        | Additional information on DB security group                                                                                                                                                                                      |
-| rules               | Body | Array  | O        | DB security group rules                                                                                                                                                                                                          |
-| rules.description   | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| rules.etherType     | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| rules.cidr          | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| rules.port.portType | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+| rules | Body | Array | O | DB security group rules |
+| rules.direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Body | Object | O | Port object |
+| rules.port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | Additional information on DB security group rule |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
@@ -3562,48 +4198,9 @@ POST /v4.0/db-security-groups
 
 #### Response
 
-| Name              | Type | Format | Description                  |
-|-------------------|------|--------|------------------------------|
-| dbSecurityGroupId | Body | UUID   | DB security group identifier |
-
----
-
-### Modify DB Security Group
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | Modify DB security group |
-
-#### Request
-
-| Name                | Type | Format | Required | Description                                 |
-|---------------------|------|--------|----------|---------------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O        | DB security group identifier                |
-| dbSecurityGroupName | Body | String | X        | Name to identify DB instances               |
-| description         | Body | String | X        | Additional information on DB security group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DB security group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -3614,13 +4211,13 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
 
 ---
 
@@ -3632,21 +4229,66 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Delete | Delete DB security group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List DB Security Group Details
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | List DB security group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DB security group identifier |
+| dbSecurityGroupName | Body | String | Name to identify the DB security group |
+| description | Body | String | Additional information on DB security group |
+| progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| rules | Body | Array | DB security group rules |
+| rules.ruleId | Body | UUID | DB security group rule identifier |
+| rules.description | Body | String | Additional information on DB security group rule |
+| rules.direction | Body | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Body | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Body | Object | Port object |
+| rules.port.portType | Body | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Body | Number | Minimum port range |
+| rules.port.maxPort | Body | Number | Maximum port range |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | Created date and time |
+| rules.updatedYmdt | Body | DateTime | Modified date and time |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3657,7 +4299,114 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Security Group
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | Modify DB security group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Delete DB Security Group Rule
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | Delete DB security group rule |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -3674,26 +4423,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Required permissions
 
-| Permission Name                                        | Description           |
-|--------------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Create | Create DB security group rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to specified port value. The `minPort` and `maxPort` values must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Body | Object | O | Port object |
+| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 <details><summary>Example</summary>
 <p>
@@ -3703,11 +4449,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3716,9 +4463,26 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3730,27 +4494,24 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Required permissions
 
-| Permission Name                                        | Description           |
-|--------------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Modify | Modify DB security group rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O        | DB security group rule identifier                                                                                                                                                                                                |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to specified port value. The `minPort` and `maxPort` values must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Body | Object | O | Port object |
+| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 <details><summary>Example</summary>
 <p>
@@ -3760,9 +4521,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "DB_PORT"
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3771,42 +4535,29 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
----
+<details><summary>Example</summary>
+<p>
 
-### Delete DB Security Group Rule
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | Delete DB security group rule |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format | Required | Description                        |
-|-------------------|-------|--------|----------|------------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O        | DB security group identifier       |
-| ruleIds           | Query | Array  | O        | DB security group rule identifiers |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+</p>
+</details>
 
 ---
-
-## Parameter group
+## Parameter Groups
 
 ### List Parameter Groups
 
@@ -3816,30 +4567,28 @@ GET /v4.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.List | List parameter groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name      | Type  | Format | Required | Description    |
-|-----------|-------|--------|----------|----------------|
-| dbVersion | Query | Enum   | X        | DB engine type |
-
 #### Response
 
-| Name                                 | Type | Format   | Description                                                                                 |
-|--------------------------------------|------|----------|---------------------------------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                                            |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                                  |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                                           |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                   |
-| parameterGroups.dbVersion            | Body | Enum     | DB engine type                                                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                          |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of parameter groups |
+| parameterGroups | Body | Array | Parameter groups |
+| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
+| parameterGroups.description | Body | String | Additional information on parameter group |
+| parameterGroups.dbVersion | Body | Enum | DB engine type |
+| parameterGroups.parameterGroupType | Body | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3851,15 +4600,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3867,88 +4618,6 @@ This API does not require a request body.
 
 </p>
 </details>
-
-
----
-
-### List Parameter Group Details
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | List parameter group details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-| Name                          | Type | Format   | Description                                                                                                                                           |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | Parameter group identifier                                                                                                                            |
-| parameterGroupName            | Body | String   | Name to identify parameter groups                                                                                                                     |
-| description                   | Body | String   | Additional information on parameter group                                                                                                             |
-| dbVersion                     | Body | Enum     | DB engine type                                                                                                                                        |
-| parameterGroupStatus          | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply                                                           |
-| parameters                    | Body | Array    | Parameter list                                                                                                                                        |
-| parameters.parameterId        | Body | UUID     | Parameter identifier                                                                                                                                  |
-| parameters.parameterFileGroup | Body | Enum     | Parameter file group type<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                                                          |
-| parameters.parameterName      | Body | String   | Parameter name                                                                                                                                        |
-| parameters.fileParameterName  | Body | String   | Parameter file name                                                                                                                                   |
-| parameters.value              | Body | String   | Current value                                                                                                                                         |
-| parameters.defaultValue       | Body | String   | Default value                                                                                                                                         |
-| parameters.allowedValue       | Body | String   | Permitted values                                                                                                                                      |
-| parameters.updateType         | Body | Enum     | Modify type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable<br/>- `INIT_VARIABLE`: Only modifiable when DB instance is created |
-| parameters.applyType          | Body | Enum     | Apply type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All (restart required)                    |
-| createdYmdt                   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| updatedYmdt                   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                   |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
 
 ---
 
@@ -3960,25 +4629,26 @@ POST /v4.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Create | Create parameter group |
 
 #### Request
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-| dbVersion          | Body | Enum   | O        | DB engine type                            |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | Body | Enum | O | DB engine type |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -3987,88 +4657,9 @@ POST /v4.0/parameter-groups
 
 #### Response
 
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Copy Parameter Group
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | Copy parameter group |
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Modify Parameter Group
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | X        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4079,107 +4670,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Parameter
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
-
-#### Request
-
-| Name                           | Type | Format | Required | Description                |
-|--------------------------------|------|--------|----------|----------------------------|
-| parameterGroupId               | URL  | UUID   | O        | Parameter group identifier |
-| modifiedParameters             | Body | Array  | O        | Parameters to change       |
-| modifiedParameters.parameterId | Body | UUID   | O        | Parameter identifier       |
-| modifiedParameters.value       | Body | String | O        | Parameter value to change  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Reset Parameter Group
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | Reset parameter group |
-
-#### Request
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4196,21 +4688,65 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Delete | Delete parameter group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List Parameter Group Details
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | List parameter group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroupName | Body | String | Name to identify parameter groups |
+| description | Body | String | Additional information on parameter group |
+| dbVersion | Body | Enum | DB engine type |
+| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Body | Array | Parameter list |
+| parameters.parameterId | Body | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Body | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | Parameter name |
+| parameters.fileParameterName | Body | String | Parameter file name |
+| parameters.value | Body | String | Current value |
+| parameters.defaultValue | Body | String | Default value |
+| parameters.allowedValue | Body | String | Permitted values |
+| parameters.updateType | Body | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4221,7 +4757,27 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4230,6 +4786,172 @@ This API does not return a response body.
 
 ---
 
+### Modify Parameter Group
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | Copy parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Parameter
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | Parameters to change |
+| modifiedParameters.parameterId | Body | UUID | O | Parameter identifier |
+| modifiedParameters.value | Body | String | O | Parameter value to change |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | Reset parameter group |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## User Group
 
 ### List User Groups
@@ -4240,8 +4962,8 @@ GET /v4.0/user-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.List | List user groups |
 
 #### Request
@@ -4250,13 +4972,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format   | Description                                         |
-|--------------------------|------|----------|-----------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                         |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                        |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of user groups |
+| userGroups | Body | Array | User group list |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| userGroups.createdYmdt | Body | DateTime | Created date and time |
+| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4268,74 +4991,15 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List User Group Details
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | List user group details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
-
-#### Response
-
-| Name              | Type | Format   | Description                                                                                                                                            |
-|-------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                                                                  |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                                                           |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| members           | Body | Array    | Project member list                                                                                                                                    |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4352,34 +5016,26 @@ POST /v4.0/user-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Create | Create user group |
 
 #### Request
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupName | Body | String  | O        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | O        | Project member identifiers <br /> Ignored when `selectAll` is true          |
-| selectAll     | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | O | List of project member identifiers |
+| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4388,52 +5044,9 @@ POST /v4.0/user-groups
 
 #### Response
 
-| Name        | Type | Format | Description           |
-|-------------|------|--------|-----------------------|
-| userGroupId | Body | UUID   | User group identifier |
-
----
-
-### Modify User Group
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | Modify user group|
-
-#### Request
-
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O        | User group identifier                                                       |
-| userGroupName | Body | String  | X        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | X        | Project member identifiers                                                  |
-| selectAll     | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4444,7 +5057,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4461,19 +5075,55 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Delete | Delete user group |
 
 #### Request
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List User Group Details
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | List user group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
+| userGroupName | Body | String | Name to identify user groups |
+| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4484,7 +5134,17 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4493,6 +5153,46 @@ This API does not return a response body.
 
 ---
 
+### Modify User Group
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | Modify user group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | X | List of project member identifiers |
+| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## Notification Group
 
 ### List Notification Groups
@@ -4503,8 +5203,8 @@ GET /v4.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.List | List notification groups |
 
 #### Request
@@ -4513,16 +5213,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type | Format   | Description                                         |
-|------------------------------------------|------|----------|-----------------------------------------------------|
-| notificationGroups                       | Body | Array    | Notification Groups                                 |
-| notificationGroups.notificationGroupId   | Body | UUID     | Notification group identifier                       |
-| notificationGroups.notificationGroupName | Body | String   | Name to identify notification groups                |
-| notificationGroups.notifyEmail           | Body | Boolean  | Whether to be notified by email                     |
-| notificationGroups.notifySms             | Body | Boolean  | Whether to be notified by SMS                       |
-| notificationGroups.isEnabled             | Body | Boolean  | Indicates whether the flavor is enabled             |
-| notificationGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| notificationGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | Notification group list |
+| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Body | Boolean | Whether enabled |
+| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4536,90 +5236,15 @@ This API does not require a request body.
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### View Notification Group Details
-
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | List notification groups |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
-
-#### Response
-
-| Name                       | Type | Format   | Description                                         |
-|----------------------------|------|----------|-----------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                       |
-| notificationGroupName      | Body | String   | Name to identify notification groups                |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                     |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                       |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled             |
-| dbInstances                | Body | Array    | DB Instances to monitor                             |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                              |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                       |
-| userGroups                 | Body | Array    | User Groups                                         |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                        |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
 }
 ```
 
@@ -4636,83 +5261,32 @@ POST /v4.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                      | Description           |
-|------------------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Create | Create notification group |
 
 #### Request
 
-| Name                  | Type | Format  | Required | Description                                                 |
-|-----------------------|------|---------|----------|-------------------------------------------------------------|
-| notificationGroupName | Body | String  | O        | Name to identify notification groups                        |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email<br/>- Default: `true`         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS<br/>- Default: `true`           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled<br/>- Default: `true` |
-| dbInstanceIds         | Body | Array   | O        | DB instance identifiers to monitor                          |
-| userGroupIds          | Body | Array   | O        | User group identifiers                                      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Body | Array | O | List of DB instance identifiers to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name                | Type | Format | Description                   |
-|---------------------|------|--------|-------------------------------|
-| notificationGroupId | Body | UUID   | Notification group identifier |
-
----
-
-### Modify Notification Group
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | Modify notification group |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                             |
-|-----------------------|------|---------|----------|-----------------------------------------|
-| notificationGroupId   | URL  | UUID    | O        | Notification group identifier           |
-| notificationGroupName | Body | String  | X        | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled |
-| dbInstanceIds         | Body | Array   | X        | DB instance identifiers to monitor      |
-| userGroupIds          | Body | Array   | X        | User group identifiers                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
+    "notificationGroupName": "notificationGroupName",
     "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
@@ -4721,7 +5295,9 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4732,7 +5308,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4749,21 +5326,61 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### Required permissions
 
-| Permission Name                                      | Description           |
-|------------------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Delete | Delete notification group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### View Notification Group Details
+
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | View notification group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroupName | Body | String | Name to identify notification groups |
+| notifyEmail | Body | Boolean | Whether to be notified by email |
+| notifySms | Body | Boolean | Whether to be notified by SMS |
+| isEnabled | Body | Boolean | Whether enabled |
+| dbInstances | Body | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| userGroups | Body | Array | User group list |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4774,7 +5391,26 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4783,7 +5419,75 @@ This API does not return a response body.
 
 ---
 
+### Modify Notification Group
+
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | Modify notification group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Body | Array | X | List of DB instance identifiers to monitor |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## Monitoring
+
+### View Stats
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Metric.List | View stats |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
 
 ### List Metric List
 
@@ -4793,9 +5497,9 @@ GET /v4.0/metrics
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | List metric information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Metric.List | List metric list |
 
 #### Request
 
@@ -4803,11 +5507,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                | Type | Format | Description          |
-|---------------------|------|--------|----------------------|
-| metrics             | Body | Array  | Metric List          |
-| metrics.measureName | Body | Enum   | Metric type to query |
-| metrics.unit        | Body | String | Measure unit         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric list |
+| metrics.measureName | Body | String | Metric type to query |
+| metrics.unit | Body | String | Measure unit |
 
 <details><summary>Example</summary>
 <p>
@@ -4821,74 +5525,8 @@ This API does not require a request body.
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### View stats
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | List metric information |
-
-#### Request
-
-| Name         | Type  | Format   | Required | Description                                      |
-|--------------|-------|----------|----------|--------------------------------------------------|
-| dbInstanceId | Query | UUID     | O        | DB instance identifier                           |
-| measureNames | Query | Array    | O        | Metric list to query<br/>- Minimum length: `1`   |
-| from         | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)   |
-| interval     | Query | Number   | X        | View interval                                    |
-
-#### Response
-
-| Name                              | Type | Format    | Description                 |
-|-----------------------------------|------|-----------|-----------------------------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.measureName      | Body | Enum      | Measure type                |
-| metricStatistics.unit             | Body | String    | Measure unit                |
-| metricStatistics.values           | Body | Array     | Measure values              |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time                |
-| metricStatistics.values.value     | Body | Object    | Measure value               |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
@@ -4905,102 +5543,14 @@ GET /v4.0/metric-statistics
 
 Events can be categorized into categories, which are shown below.
 
-| Event category | Description |
-|----------------|-------------|
-| ALL            | All         |
-| BACKUP         | Backups     |
-| DB_INSTANCE    | DB Instance |
-| JOB            | Jobs        |
-| TENANT         | Tenant      |
-| MONITORING     | Monitoring  |
-
-### List Events
-
-```http
-GET /v4.0/events
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | List Events |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format   | Required | Description                                                                                                                                                         |
-|-------------------|-------|----------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1`                                                                                                         |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                                                                                                                             |
-| from              | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                    |
-| to                | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| eventCategoryType | Query | Enum     | O        | Event category types to query<br/>- `ALL`: All<br/>- `INSTANCE`: DB instance<br/>- `BACKUP`: Backup<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `TENANT`: Tenant |
-| sourceId          | Query | String   | X        | Event target resource identifier                                                                                                                                    |
-| keyword           | Query | String   | X        | String keyword in event message                                                                                                                                     |
-| ascendingOrder    | Query | Enum     | X        | Event message sorting order<br/>- `ASC`: Ascending order<br/>- `DESC`: Descending order<br/>- Default: `DESC`                                                       |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                               |
-|--------------------------|------|----------|-----------------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                    |
-| events                   | Body | Array    | Events                                                    |
-| events.eventCategoryType | Body | Enum     | Event category type                                       |
-| events.eventCode         | Body | Enum     | Occurred event type                                       |
-| events.sourceId          | Body | String   | Event source identifier                                   |
-| events.sourceName        | Body | String   | Name to identify event sources                            |
-| events.messages          | Body | Array    | Event messages                                            |
-| events.messages.langCode | Body | String   | Language code                                             |
-| events.messages.message  | Body | String   | Event Message                                             |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+| Event category    | Description      |
+|-------------|---------|
+| ALL         | All      |
+| BACKUP      | Backup      |
+| DB_INSTANCE | DB instance |
+| JOB         | Job      |
+| TENANT      | Tenant     |
+| MONITORING  | Monitoring    |
 
 ### List Subscribable Event Codes
 
@@ -5010,9 +5560,9 @@ GET /v4.0/event-codes
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | List Events |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Event.List | List subscribable event codes |
 
 #### Request
 
@@ -5020,11 +5570,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format | Description         |
-|------------------------------|------|--------|---------------------|
-| eventCodes                   | Body | Array  | Event Codes         |
-| eventCodes.eventCode         | Body | Enum   | Event Code          |
-| eventCodes.eventCategoryType | Body | Enum   | Event category type |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | Event code list |
+| eventCodes.eventCode | Body | Enum | Event code |
+| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>Example</summary>
 <p>
@@ -5038,8 +5588,73 @@ This API does not require a request body.
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Events
+
+```http
+GET /v4.0/events
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Event.List | List events |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of events |
+| events | Body | Array | Event list |
+| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | Occurred event type |
+| events.sourceId | Body | UUID | Event source identifier |
+| events.sourceName | Body | String | Name to identify event sources |
+| events.messages | Body | Array | Event messages |
+| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | Event message |
+| events.eventYmdt | Body | DateTime | Event occurred date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5059,28 +5674,22 @@ GET /v4.0/event-subscriptions
 
 #### Required Permission
 
-| Permission                                                    | Description            |
-|---------------------------------------------------------|---------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.List | List event subscriptions |
 
 #### Request
 
-| Name                | Type    | Format       | Required | Description                                       |
-|-------------------|-------|----------|----|------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1` |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20             |
-| eventSubscriptionId    | Query | UUID   | X  | Event subscription identifier                              |
-| eventSubscriptionName  | Query | String | X  | Name to identify event subscription                      |
-| userGroupId            | Query | UUID   | X  | User group identifier                              |
+This API does not require a request body.
 
 #### Response
 
-| Name                                            | Type   | Format       | Description                       |
-|-----------------------------------------------|------|----------|--------------------------|
-| totalCounts                                   | Body | Number   | Total number of event subscriptions           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of event subscriptions |
 | eventSubscriptions | Body | Array | List of event subscriptions |
 | eventSubscriptions.eventSubscriptionId | Body | UUID | Event subscription identifier |
-| eventSubscriptions.eventCategoryType | Body | Enum | Event category type |
+| eventSubscriptions.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | A name that identifies the event subscription |
 | eventSubscriptions.enabled | Body | Boolean | Whether to activate |
 | eventSubscriptions.notifyEmail | Body | Boolean | Whether to send emails |
@@ -5088,9 +5697,9 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.eventCodes | Body | Array | List of event codes to subscribe to |
 | eventSubscriptions.sources | Body | Array | List of event sources to subscribe to |
 | eventSubscriptions.sources.sourceId | Body | UUID | Identifier of the event source |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | List of identifiers of user groups subscribing to the event |
-| eventSubscriptions.createdYmdt                | Body | DateTime | Created at                    |
+| eventSubscriptions.createdYmdt | Body | DateTime | Created at |
 
 <details><summary>Example</summary>
 <p>
@@ -5105,25 +5714,23 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
             "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
+            "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
                 }
             ],
             "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
+                "550e8400-e29b-41d4-a716-446655440000"
             ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5142,47 +5749,43 @@ POST /v4.0/event-subscriptions
 
 #### Required Permission
 
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Create | Create an event subscription |
 
 #### Request
 
-| Name                      | Type | Format  | Required | Description                                                           |
-|---------------------------|------|---------|----------|-----------------------------------------------------------------------|
-| eventCategoryType         | Body | Enum    | O        | Event category type                                                   |
-| eventSubscriptionName     | Body | String  | O        | A name that identifies the event subscription - maximum length: `100` |
-| enabled                   | Body | Boolean | O        | Whether to enable                                                     |
-| notifyEmail               | Body | Boolean | O        | Whether to send emails                                                |
-| notifySms                 | Body | Boolean | O        | Whether to send SMS messages                                          |
-| eventCodes                | Body | Array   | O        | List of event codes to subscribe to                                   |
-| sources                   | Body | Array   | O        | List of event sources to subscribe to                                 |
-| sources.sourceId          | Body | UUID    | O        | Identifier of the event source                                        |
-| sources.eventCategoryType | Body | Enum    | O        | Event category type                                                   |
-| userGroupIds              | Body | Array   | O        | List of identifiers of user groups to subscribe to                    |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | A name that identifies the event subscription |
+| enabled | Body | Boolean | O | Whether to activate |
+| notifyEmail | Body | Boolean | O | Whether to send emails |
+| notifySms | Body | Boolean | O | Whether to send SMS messages |
+| eventCodes | Body | Array | O | List of event codes to subscribe to |
+| sources | Body | Array | O | List of event sources to subscribe to |
+| sources.sourceId | Body | UUID | O | Identifier of the event source |
+| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | O | List of identifiers of user groups to subscribe to |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5191,9 +5794,9 @@ POST /v4.0/event-subscriptions
 
 #### Response
 
-| Name                    | Type   | Format   | Description          |
-|-----------------------|------|------|-------------|
-| eventSubscriptionId   | Body | UUID | Event subscription identifier | 
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventSubscriptionId | Body | UUID | Event subscription identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -5205,86 +5808,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify an Event Subscription
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### Required Permission
-
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
-
-#### Request
-
-| Name                      | Type | Format  | Required | Description                                           |
-|---------------------------|------|---------|----------|-------------------------------------------------------|
-| eventSubscriptionId       | URL  | UUID    | O        | Event subscription identifier                         |
-| eventCategoryType         | Body | Enum    | X        | Event category type                                   |
-| eventSubscriptionName     | Body | String  | X        | A name that identifies the event subscription         |
-| enabled                   | Body | Boolean | X        | Whether to enable                                     |
-| notifyEmail               | Body | Boolean | X        | Whether to send an email                              |
-| notifySms                 | Body | Boolean | X        | Whether to send an SMS                                |
-| eventCodes                | Body | Array   | X        | A list of event codes to subscribe to                 |
-| sources                   | Body | Array   | X        | A list of event sources to subscribe to               |
-| sources.sourceId          | Body | UUID    | X        | Event source identifier                               |
-| sources.eventCategoryType | Body | Enum    | X        | Event category type                                   |
-| userGroupIds              | Body | Array   | X        | A list of identifiers for user groups to subscribe to |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5301,19 +5825,108 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### Required Permission
 
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | Delete an event subscription |
 
 #### Request
 
-| Name                    | Type  | Format   | Required | Description          |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId   | URL | UUID | O  | Event subscription identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### Modify an Event Subscription
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | A name that identifies the event subscription |
+| enabled | Body | Boolean | X | Whether to activate |
+| notifyEmail | Body | Boolean | X | Whether to send emails |
+| notifySms | Body | Boolean | X | Whether to send SMS messages |
+| eventCodes | Body | Array | X | List of event codes to subscribe to |
+| sources | Body | Array | X | List of event sources to subscribe to |
+| sources.sourceId | Body | UUID | O | Identifier of the event source |
+| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | List of identifiers of user groups to subscribe to |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+## Availability Zone
+
+### List Availability Zones
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | List availability zones |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | List of availability zones |
+| availabilityZones.availabilityZoneName | Body | String | Availability zone name |
+| availabilityZones.zoneState | Body | Object | Availability zone status |
+| availabilityZones.zoneState.available | Body | Boolean | Whether the availability zone is available |
 
 <details><summary>Example</summary>
 <p>
@@ -5324,7 +5937,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "availabilityZones": [
+        {
+            "availabilityZoneName": "availabilityZoneName-example",
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
 }
 ```
 

--- a/en/api-guide-v4.0-gov.md
+++ b/en/api-guide-v4.0-gov.md
@@ -1,91 +1,108 @@
-## Database > RDS for MariaDB > API Guide
+## RDS for MariaDB API Guide
+
+**Database > RDS for MariaDB > API v4.0 Guide**
 
 ## RDS for MariaDB API Common Information
 
 ### API Endpoint
 
 | Region | Endpoint |
-|--------|----------|
+|------|----------|
 | Korea (Pangyo) region | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
+
 
 ### Authentication and Authorization
 
 RDS for MariaDB uses User Access Key tokens for authentication and authorization when making API calls. The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key. For more information on issuing and using User Access Key tokens, please refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 The issued token must be included in the request header along with the Appkey.
 
-| Name                | Type   | Format | Required | Description                                           |
-|---------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | Appkey of RDS for MariaDB or integrated Appkey for project |
-| X-NHN-AUTHORIZATION | Header | String | O  | Bearer type token issued with the Public API                           |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | Appkey of RDS for MariaDB or integrated Appkey for project |
+| X-NHN-AUTHORIZATION | Header | String | Y | Bearer type token issued with the Public API |
 
 In addition, the APIs you can call are limited based on the project member role. You can grant permissions separately for `RDS for MariaDB ADMIN` and `RDS for MariaDB VIEWER`.
 
 * `RDS for MariaDB ADMIN permission holders` can use all available features as before.
 * `RDS for MariaDB VIEWER permission holders` can use read-only feature.
-    * Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
-    * But, notification group and user group-related features are available.
+* Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
+* But, notification group and user group-related features are available.
 
 If an API request fails to authenticate or is not authorized, the following error occurs.
 
-| resultCode | resultMessage | Description            |
-|------------|---------------|------------------------|
-| 80401      | Unauthorized  | Failed to authenticate |
-| 80403      | Forbidden     | Unauthorized.          |
+| resultCode | resultMessage | Description |
+|------------|---------------|-----|
+| 80401 | Unauthorized | Failed to authenticate |
+| 80403 | Forbidden | Unauthorized. |
 
 ### Common Response Information
 
 The API responds with "200 OK" to all API requests. For more information on the response results, see Response Body Header.
 
-#### Response Body
+<details>
+  <summary><strong>Successful Response</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### Field
-| Name          | Format  | Description                                              |
-|---------------|---------|----------------------------------------------------------|
-| resultCode    | Number  | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
-| resultMessage | String  | Result message                                           |
-| isSuccessful  | Boolean | Successful or not                                        |
+</details>
 
+<details>
+  <summary><strong>Failure Response</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| resultCode | Number | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
+| resultMessage | String | Result message |
+| isSuccessful | Boolean | Successful or not |
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|--------------|----------|-----------------|--------|
-| MARIADB\_V10330  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10611  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10612  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10616  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10622  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10625  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V101107 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101108 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101113 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101116 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11407  | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11410  | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11806  | O        | O               | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
-
 
 ## Project Information
 
 ### List Project Members
 
-```http
-GET /v4.0/project/members
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -93,51 +110,52 @@ GET /v4.0/project/members
 
 #### Request
 
+```http
+GET /v4.0/project/members
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| members | Body | Array | Project member list |
-| members.memberId | Body | UUID | Project member identifier |
-| members.memberName | Body | String | Project member name |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber | Body | String | Project member phone number |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| members.memberName | String | Project member name |
+| members.emailAddress | String | Project member email address |
+| members.phoneNumber | String | Project member phone number |
 
 ---
 
 ### List Regions
 
-```http
-GET /v4.0/project/regions
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -145,48 +163,50 @@ GET /v4.0/project/regions
 
 #### Request
 
+```http
+GET /v4.0/project/regions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| regions | Body | Array | Region list |
-| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
-| regions.isEnabled | Body | Boolean | Whether the region is enabled |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| regions | Array | Region list |
+| regions.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Boolean | Whether the region is enabled |
+
 ---
+
 ## Specifications of DB Instance
 
 ### List DB Instance Specifications
 
-```http
-GET /v4.0/db-flavors
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -194,41 +214,46 @@ GET /v4.0/db-flavors
 
 #### Request
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | List of DB instance specifications |
-| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
-| dbFlavors.ram | Body | Number | Memory size (MB) |
-| dbFlavors.vcpus | Body | Number | CPU cores |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbFlavorName": "dbFlavorName-example",
-            "ram": 1,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbFlavors | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | String | Name of DB instance specifications |
+| dbFlavors.ram | Number | Memory size (MB) |
+| dbFlavors.vcpus | Number | CPU cores |
 
 ---
 
@@ -236,11 +261,7 @@ This API does not require a request body.
 
 ### List Subnets
 
-```http
-GET /v4.0/network/subnets
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -248,43 +269,48 @@ GET /v4.0/network/subnets
 
 #### Request
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| subnets | Body | Array | Subnet list |
-| subnets.subnetId | Body | UUID | Subnet identifier |
-| subnets.subnetName | Body | String | Name to identify subnets |
-| subnets.subnetCidr | Body | String | CIDR of subnet |
-| subnets.usingGateway | Body | Boolean | Whether to use gateway |
-| subnets.availableIpCount | Body | Number | Number of available IPs |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| subnets | Array | Subnet list |
+| subnets.subnetId | UUID | Subnet identifier |
+| subnets.subnetName | String | Name to identify subnets |
+| subnets.subnetCidr | String | CIDR of subnet |
+| subnets.usingGateway | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Number | Number of available IPs |
 
 ---
 
@@ -292,11 +318,7 @@ This API does not require a request body.
 
 ### List DB Engines
 
-```http
-GET /v4.0/db-versions
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -304,39 +326,44 @@ GET /v4.0/db-versions
 
 #### Request
 
+```http
+GET /v4.0/db-versions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB engine list |
-| dbVersions.dbVersion | Body | String | DB engine type |
-| dbVersions.dbVersionName | Body | String | DB engine name |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MYSQL_V8036",
-            "dbVersionName": "dbVersionName-example",
-            "restorableFromObs": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbVersions | Array | DB engine list |
+| dbVersions.dbVersion | String | DB engine type |
+| dbVersions.dbVersionName | String | DB engine name |
+| dbVersions.restorableFromObs | Boolean | Restoring backup from object storage available or not |
 
 ---
 
@@ -344,11 +371,7 @@ This API does not require a request body.
 
 ### List Storage Types
 
-```http
-GET /v4.0/storage-types
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -356,33 +379,38 @@ GET /v4.0/storage-types
 
 #### Request
 
+```http
+GET /v4.0/storage-types
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | Storage type list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageTypes | Array | Storage type list |
 
 ---
 
@@ -390,28 +418,24 @@ This API does not require a request body.
 
 ### Task Status
 
-| Status Name        | Description                           |
-|--------------------|---------------------------------------|
-| `PREPARING`        | Task in preparation                   |
-| `READY`            | Task in ready                         |
-| `RUNNING`          | Task in progress                      |
-| `COMPLETED`        | Task completed                        |
-| `REGISTERED`       | Task registered                       |
-| `WAIT_TO_REGISTER` | Task waiting to register              |
-| `INTERRUPTED`      | Task being interrupted                |
-| `CANCELED`         | Task canceled                         |
-| `FAILED`           | Task failed                           |
-| `ERROR`            | Error occurred while task in progress |
-| `DELETED`          | Task deleted                          |
-| `FAIL_TO_READY`    | Failed to get ready for task          |
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | Task in preparation |
+| `READY` | Task in ready |
+| `RUNNING` | Task in progress |
+| `COMPLETED` | Task completed |
+| `REGISTERED` | Task registered |
+| `WAIT_TO_REGISTER` | Task waiting to register |
+| `INTERRUPTED` | Task being interrupted |
+| `CANCELED` | Task canceled |
+| `FAILED` | Task failed |
+| `ERROR` | Error occurred while task in progress |
+| `DELETED` | Task deleted |
+| `FAIL_TO_READY` | Failed to get ready for task |
 
 ### List Task Details
 
-```http
-GET /v4.0/jobs/{jobId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -419,60 +443,64 @@ GET /v4.0/jobs/{jobId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Task identifier |
-| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | Relevant resource list |
-| resourceRelations.resourceType | Body | String | Relevant resource type |
-| resourceRelations.resourceId | Body | String | Relevant resource identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+| jobStatus | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | Relevant resource list |
+| resourceRelations.resourceType | String | Relevant resource type |
+| resourceRelations.resourceId | String | Relevant resource identifier |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
+
 ---
+
 ## DB Instance Group
 
 ### List DB Instance Groups
 
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -480,51 +508,52 @@ GET /v4.0/db-instance-groups
 
 #### Request
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB instance group list |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB instance group list |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstanceGroups.createdYmdt | DateTime | Created at |
+| dbInstanceGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### List DB Instance Group Details
 
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -532,51 +561,58 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
-| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstances | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -586,54 +622,50 @@ This API does not require a request body.
 
 | Status | Description |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DB instance is available |
-| `BEFORE_CREATE`     | Before DB instance is created |
-| `STORAGE_FULL`      | Insufficient DB instance storage |
-| `FAIL_TO_CREATE`    | Failed to create DB instance |
-| `FAIL_TO_CONNECT`   | Failed to connect DB instance |
-| `REPLICATION_STOP`  | Replication of DB instance is stopped |
-| `FAILOVER`          | High availability DB instance failed over |
-| `SHUTDOWN`          | DB instance is stopped |
-| `DELETED`           | DB instance is deleted |
+| `AVAILABLE` | DB instance is available |
+| `BEFORE_CREATE` | Before DB instance is created |
+| `STORAGE_FULL` | Insufficient DB instance storage |
+| `FAIL_TO_CREATE` | Failed to create DB instance |
+| `FAIL_TO_CONNECT` | Failed to connect DB instance |
+| `REPLICATION_STOP` | Replication of DB instance is stopped |
+| `FAILOVER` | High availability DB instance failed over |
+| `SHUTDOWN` | DB instance is stopped |
+| `DELETED` | DB instance is deleted |
 
 ### DB Instance Progress Status
 
 | Status | Description |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up |
-| `CANCELING`                | Canceling |
-| `CREATING`                 | Creating |
-| `CREATING_SCHEMA`          | Creating DB schema |
-| `CREATING_USER`            | Creating user |
-| `DELETING`                 | Deleting |
-| `DELETING_SCHEMA`          | Deleting DB schema |
-| `DELETING_USER`            | Deleting user |
-| `EXPORTING_BACKUP`         | Exporting backup |
-| `FAILING_OVER`             | Under failover |
-| `MIGRATING`                | Under migration |
-| `MODIFYING`                | Under modification |
-| `PREPARING`                | In preparation |
-| `PROMOTING`                | Promoting |
-| `REBUILDING`               | Rebuilding |
-| `REPAIRING`                | Recovering |
-| `REPLICATING`              | Replicating |
-| `RESTARTING`               | Restarting |
-| `RESTARTING_FORCIBLY`      | Force restarting |
-| `RESTORING`                | Restoring |
-| `STARTING`                 | Starting |
-| `STOPPING`                 | Stopping |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema |
-| `SYNCING_USER`             | Synchronizing user |
-| `UPDATING_USER`            | Modifying user |
+| `BACKING_UP` | Backing up |
+| `CANCELING` | Canceling |
+| `CREATING` | Creating |
+| `CREATING_SCHEMA` | Creating DB schema |
+| `CREATING_USER` | Creating user |
+| `DELETING` | Deleting |
+| `DELETING_SCHEMA` | Deleting DB schema |
+| `DELETING_USER` | Deleting user |
+| `EXPORTING_BACKUP` | Exporting backup |
+| `FAILING_OVER` | Under failover |
+| `MIGRATING` | Under migration |
+| `MODIFYING` | Under modification |
+| `PREPARING` | In preparation |
+| `PROMOTING` | Promoting |
+| `REBUILDING` | Rebuilding |
+| `REPAIRING` | Recovering |
+| `REPLICATING` | Replicating |
+| `RESTARTING` | Restarting |
+| `RESTARTING_FORCIBLY` | Force restarting |
+| `RESTORING` | Restoring |
+| `STARTING` | Starting |
+| `STOPPING` | Stopping |
+| `SYNCING_SCHEMA` | Synchronizing DB schema |
+| `SYNCING_USER` | Synchronizing user |
+| `UPDATING_USER` | Modifying user |
 
 ### List DB Instances
 
-```http
-GET /v4.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -641,356 +673,359 @@ GET /v4.0/db-instances
 
 #### Request
 
+```http
+GET /v4.0/db-instances
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB instance list |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| dbInstances.description | Body | String | Additional information on DB instances |
-| dbInstances.dbVersion | Body | Enum | DB engine type |
-| dbInstances.dbPort | Body | Number | DB port |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| dbInstances.progressStatus | Body | Enum | DB instance current progress status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | Created date and time |
-| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstances | Array | DB instance list |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| dbInstances.description | String | Additional information on DB instances |
+| dbInstances.dbVersion | String | DB engine type |
+| dbInstances.dbPort | Number | DB port |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | Created at |
+| dbInstances.updatedYmdt | DateTime | Modified date and time |
+
 ---
+
 ### Create DB Instance
 
-```http
-POST /v4.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | Create DB Instance |
 
-#### Common request
+#### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbVersion | Body | Enum | O | DB engine type |
-| dbPort | Body | Number | O | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
-| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| userGroupIds | Body | Array | X | User group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| authenticationPlugin | Body | Enum | X | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Data storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+POST /v4.0/db-instances
+```
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-#### When using storage auto scaling
-
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE",
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 1800,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbVersion | String | Y | DB engine type |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| authenticationPlugin | Enum | N | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Object | Y | Network information object |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information object |
+| storage.storageType | Enum | Y | Data storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | Y | Backup information object |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restore DB Instance from Object Storage
 
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
 
-#### Common request
+#### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbPort | Body | Number | O | DB port |
-| dbVersion | Body | Enum | O | DB engine type |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.tenantId | Body | String | O | Tenant ID of object storage where backups are stored |
-| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
-| restore.password | Body | String | O | API password for object storage where backups are stored |
-| restore.targetContainer | Body | String | O | Container for object storage where backups are stored |
-| restore.objectPath | Body | String | O | Backup path stored in container |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| userGroupIds | Body | Array | X | User group identifiers |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-#### When using storage auto scaling
-
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "MYSQL_V8036",
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port |
+| dbVersion | String | Y | DB engine type |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information object |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Object | Y | Network information object |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information object |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.tenantId | String | Y | Tenant ID of object storage where backups are stored |
+| restore.username | String | Y | NHN Cloud account or IAM member ID |
+| restore.password | String | Y | API password for object storage where backups are stored |
+| restore.targetContainer | String | Y | Container for object storage where backups are stored |
+| restore.objectPath | String | Y | Backup path stored in container |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Delete DB Instance
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -998,55 +1033,60 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| deleteAutoBackup | Body | Boolean | X | Whether to delete automated backups<br/>- Default: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "deleteAutoBackup": false
+"deleteAutoBackup": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | Whether to delete automated backups<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Instance Details
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1054,88 +1094,91 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceName | Body | String | Name to identify DB instances |
-| description | Body | String | Additional information on DB instances |
-| dbVersion | Body | Enum | DB engine type |
-| dbPort | Body | Number | DB port |
-| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| progressStatus | Body | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | Parameter group identifier applied to DB instance |
-| dbSecurityGroupIds | Body | Array | DB security group identifiers applied to DB instance |
-| notificationGroupIds | Body | Array | Notification group identifiers applied to DB instance |
-| useDeletionProtection | Body | Boolean | Whether to protect DB instance against deletion |
-| useSlowQueryAnalysis | Body | Boolean | Whether to analyze slow queries |
-| supportAuthenticationPlugin | Body | Boolean | Whether to support authentication plugin |
-| needToApplyParameterGroup | Body | Boolean | Need to apply the latest parameter group |
-| needMigration | Body | Boolean | Need to migrate |
-| supportDbVersionUpgrade | Body | Boolean | Whether to support DB version upgrade |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": false,
-    "supportAuthenticationPlugin": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": false,
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB instance identifier |
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceName | String | Name to identify DB instances |
+| description | String | Additional information on DB instances |
+| dbVersion | String | DB engine type |
+| dbPort | Number | DB port |
+| dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | Identifier of DB instance specifications |
+| parameterGroupId | UUID | Parameter group identifier applied to DB instance |
+| dbSecurityGroupIds | Array | DB security group identifiers applied to DB instance |
+| notificationGroupIds | Array | Notification group identifiers applied to DB instance |
+| useDeletionProtection | Boolean | Whether to protect DB instance against deletion |
+| useSlowQueryAnalysis | Boolean | Whether to analyze slow queries |
+| supportAuthenticationPlugin | Boolean | Whether to support authentication plugin |
+| needToApplyParameterGroup | Boolean | Need to apply the latest parameter group |
+| needMigration | Boolean | Need to migrate |
+| supportDbVersionUpgrade | Boolean | Whether to support DB version upgrade |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Instance
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1143,81 +1186,86 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | X | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| dbInstanceCandidateName | Body | String | X | Candidate name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbVersion | Body | Enum | X | DB engine type |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries |
-| useDummy | Body | Boolean | X | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
-| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
-| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
-| useReadOnly | Body | Boolean | X | Switch to read-only mode<br/>- Default: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "useSlowQueryAnalysis": false,
-    "useDummy": false,
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useSlowQueryAnalysis": false,
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbVersion | String | N | DB engine type |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries |
+| useDummy | Boolean | N | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| executeBackup | Boolean | N | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Block write load<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Backup Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1225,61 +1273,64 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | Backup retention period (days) |
-| ftwrlWaitTimeout | Body | Number | Query latency (sec) |
-| backupRetryCount | Body | Number | Number of backup retries |
-| replicationRegion | Body | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
-| useBackupLock | Body | Boolean | Whether to use table lock |
-| backupSchedules | Body | Array | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime | Body | Time | Backup started time |
-| backupSchedules.backupWndDuration | Body | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1,
-    "backupRetryCount": 1,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| backupPeriod | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Number | Query latency (sec) |
+| backupRetryCount | Number | Number of backup retries |
+| replicationRegion | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| useBackupLock | Boolean | Whether to use table lock |
+| backupSchedules | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### Modify Backup Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1287,148 +1338,167 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
-| useBackupLock | Body | Boolean | X | Whether to use table lock |
-| backupSchedules | Body | Array | X | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupPeriod": 0,
-    "ftwrlWaitTimeout": 0,
-    "backupRetryCount": 0,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| useBackupLock | Boolean | N | Whether to use table lock |
+| backupSchedules | Array | N | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### View Binary Log List
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
+---
+
+### View Binary Log List
 
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceBinLog.List | View binary log list |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLog file list |
-| binLogs.binLogFileName | Body | String | BinLog file name |
-| binLogs.binLogFileSize | Body | Number | BinLog file size (Byte) |
-| binLogs.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "binLogs": [
-        {
-            "binLogFileName": "binLogFileName-example",
-            "binLogFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"binLogs": [
+{
+"binLogFileName": "binLogFileName-example",
+"binLogFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| binLogs | Array | BinLog file list |
+| binLogs.binLogFileName | String | BinLog file name |
+| binLogs.binLogFileSize | Number | BinLog file size (Byte) |
+| binLogs.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Delete Binary Log
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceBinLog.Purge | Delete binary log |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | Last BinLog file name to delete (delete all files prior to this file) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "lastBinLogFileName": "mysql-bin.000010"
+"lastBinLogFileName": "mysql-bin.000010"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | Last BinLog file name to delete (delete all files prior to this file) |
 
 #### Response
 
@@ -1438,291 +1508,306 @@ This API does not return a response body.
 
 ### View Certificate File List
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.List | View certificate file list |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| certificates | Body | Array | Certificate file list |
-| certificates.fileName | Body | String | Certificate file name |
-| certificates.certificateType | Body | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | Certificate file size (Byte) |
-| certificates.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "certificates": [
-        {
-            "fileName": "fileName-example",
-            "certificateType": "CA_FILE",
-            "fileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"certificates": [
+{
+"fileName": "fileName-example",
+"certificateType": "CA_FILE",
+"fileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| certificates | Array | Certificate file list |
+| certificates.fileName | String | Certificate file name |
+| certificates.certificateType | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | Certificate file size (Byte) |
+| certificates.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Export Certificate File
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.Export | Export certificate file |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| certificateTypes | Body | Array | O | Certificate type list to upload |
-| tenantId | Body | String | O | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM account ID |
-| password | Body | String | O | API password for object storage where certificate file is stored |
-| targetContainer | Body | String | O | Object storage container where certificate file is stored |
-| objectPath | Body | String | O | Path of the certificate file to be stored in the container |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "certificateTypes": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"certificateTypes": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | Certificate type list to upload |
+| tenantId | String | Y | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where certificate file is stored |
+| targetContainer | String | Y | Object storage container where certificate file is stored |
+| objectPath | String | Y | Path of the certificate file to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Schema
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.List | List DB schemas |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DB schema list |
-| dbSchemas.dbSchemaId | Body | UUID | DB schema identifier |
-| dbSchemas.dbSchemaName | Body | String | DB schema name |
-| dbSchemas.dbSchemaStatus | Body | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSchemaName": "dbSchemaName-example",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSchemas | Array | DB schema list |
+| dbSchemas.dbSchemaId | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Create DB Schema
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.Create | Create DB schema |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbSchemaName | Body | String | O | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSchemaName": "dbSchemaName-example"
+"dbSchemaName": "dbSchemaName-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete DB Schema
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.Delete | Delete DB schema |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbSchemaId | URL | UUID | O | DB schema identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbSchemaId | URL | UUID | Y | DB schema identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Users
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1730,65 +1815,68 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB users |
-| dbUsers.dbUserId | Body | UUID | DB user identifier |
-| dbUsers.dbUserName | Body | String | DB user account name |
-| dbUsers.host | Body | String | DB user account host name |
-| dbUsers.authorityType | Body | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | Created date and time |
-| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
-| dbUsers.authenticationPlugin | Body | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| dbUsers.tlsOption | Body | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "host": "192.168.0.1",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "authenticationPlugin": "NATIVE",
-            "tlsOption": "NONE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbUsers | Array | DB users |
+| dbUsers.dbUserId | UUID | DB user identifier |
+| dbUsers.dbUserName | String | DB user account name |
+| dbUsers.host | String | DB user account host name |
+| dbUsers.authorityType | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| dbUsers.dbUserStatus | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | Created at |
+| dbUsers.updatedYmdt | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 ---
 
 ### Create DB User
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1796,65 +1884,70 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
-| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| host | Body | String | O | DB user account host name<br/>- Maximum length: `45` |
-| authorityType | Body | Enum | O | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "host": "192.168.0.1",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | String | Y | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Enum | Y | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete DB User
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1862,45 +1955,48 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify DB User
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1908,62 +2004,67 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
-| dbPassword | Body | String | X | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| authorityType | Body | Enum | X | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbPassword": "dbPassword",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Enum | N | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Change DB Instance Deletion Protection Settings
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1971,22 +2072,32 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | Whether to enable deletion protection |
 
 #### Response
 
@@ -1996,11 +2107,7 @@ This API does not return a response body.
 
 ### Force Restart DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2008,24 +2115,29 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### View High Availability Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2033,114 +2145,122 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | Whether high availability is enabled<br/>- Default: `false` |
-| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
-| pingInterval | Body | Number | Ping interval (seconds) |
-| pingType | Body | String | Ping type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": false,
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "pingType": "pingType-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"useHighAvailability": false,
+"haStatus": "CREATED",
+"pingInterval": 1,
+"pingType": "pingType-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| useHighAvailability | Boolean | Whether to use high availability<br/>- Default: `false` |
+| haStatus | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Number | Ping interval (seconds) |
+| pingType | String | Ping type |
 
 ---
 
 ### Modify High Availability
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | Modify high availability |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| useHighAvailability | Body | Boolean | O | Whether to use high availability |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"pingInterval": 1
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | Whether to use high availability |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
 
 #### When Using High Availability
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "useHighAvailability": false,
-    "pingInterval": 1
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Pause High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2148,44 +2268,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Repair High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2193,44 +2316,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2238,44 +2364,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Separate High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2283,43 +2412,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### List Log Files
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2327,55 +2460,58 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | Log file list |
-| logFiles.logFileName | Body | String | Log file name |
-| logFiles.logFileType | Body | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | Log file size (Byte) |
-| logFiles.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "logFileName-example",
-            "logFileType": "ERROR",
-            "logFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"logFiles": [
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"logFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| logFiles | Array | Log file list |
+| logFiles.logFileName | String | Log file name |
+| logFiles.logFileType | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | Log file size (Byte) |
+| logFiles.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Export Log File
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2383,65 +2519,70 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | Log file name list |
-| tenantId | Body | String | O | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM member ID |
-| password | Body | String | O | API password for the object storage where log files are stored |
-| targetContainer | Body | String | O | Object storage container where log files are stored |
-| objectPath | Body | String | O | Path of the log file to be stored in the container |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "logFileNames": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"logFileNames": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | Log file name list |
+| tenantId | String | Y | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for the object storage where log files are stored |
+| targetContainer | String | Y | Object storage container where log files are stored |
+| objectPath | String | Y | Path of the log file to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Log File Contents
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2449,44 +2590,48 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| logFileName | URL | UUID | O | Log file name |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| logFileName | URL | UUID | Y | Log file name |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| content | Body | String | Log file contents (maximum 65533 bytes) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "content-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"content": "content-example"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| content | String | Log file contents (maximum 65533 bytes) |
+
 ---
+
 ### List DB Instance Maintenances
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2494,79 +2639,82 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| Name | In | Type | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | In | Type | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of maintenances |
-| maintenances | Body | Array | List of maintenances |
-| maintenances.maintenanceId | Body | UUID | Maintenance ID |
-| maintenances.dbInstanceId | Body | UUID | DB instance ID |
-| maintenances.category | Body | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| maintenances.description | Body | String | Maintenance description |
-| maintenances.type | Body | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| maintenances.payload | Body | Object | Payload according to maintenance type |
-| maintenances.required | Body | Boolean | Whether the maintenance is required |
-| maintenances.deadlineYmdt | Body | DateTime | Datetime when the maintenance is forcibly applied |
-| maintenances.status | Body | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
-| maintenances.addedYmdt | Body | DateTime | Datetime when the maintenance was scheduled |
-| maintenances.executionStartedYmdt | Body | DateTime | Maintenance start datetime |
-| maintenances.executionCompletedYmdt | Body | DateTime | Maintenance end datetime |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "maintenances": [
-        {
-            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "category": "USER",
-            "description": "description-example",
-            "type": "UPDATE_DB_INSTANCE",
-            "payload": {
-            },
-            "required": false,
-            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
-            "status": "PENDING",
-            "executionType": "SCHEDULED",
-            "addedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"maintenances": [
+{
+"maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": {
+},
+"required": false,
+"deadlineYmdt": "2023-12-31T15:00:00+09:00",
+"status": "PENDING",
+"executionType": "SCHEDULED",
+"addedYmdt": "2023-12-31T15:00:00+09:00",
+"executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+"executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of maintenances |
+| maintenances | Array | List of maintenances |
+| maintenances.maintenanceId | UUID | Maintenance ID |
+| maintenances.dbInstanceId | UUID | DB instance ID |
+| maintenances.category | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| maintenances.description | String | Maintenance description |
+| maintenances.type | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| maintenances.payload | Object | Payload according to maintenance type |
+| maintenances.required | Boolean | Whether the maintenance is required |
+| maintenances.deadlineYmdt | DateTime | Datetime when the maintenance is forcibly applied |
+| maintenances.status | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
+| maintenances.addedYmdt | DateTime | Datetime when the maintenance was scheduled |
+| maintenances.executionStartedYmdt | DateTime | Maintenance start datetime |
+| maintenances.executionCompletedYmdt | DateTime | Maintenance end datetime |
 
 ---
 
 ### Execute DB Instance Maintenance Now
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2574,63 +2722,68 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### Request
 
-| Name | In | Type | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| configId | Body | String | O | Configuration ID |
-| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| description | Body | String | X | Maintenance description |
-| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| payload | Body | String | O | Payload according to maintenance type |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| configId | String | Y | Configuration ID |
+| category | Enum | Y | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | String | N | Maintenance description |
+| type | Enum | Y | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | String | Y | Payload according to maintenance type |
 
 #### Response
 
-| Name | In | Type | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Schedule DB Instance Maintenance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2638,30 +2791,40 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### Request
 
-| Name | In | Type | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| configId | Body | String | O | Configuration ID |
-| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| description | Body | String | X | Maintenance description |
-| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| payload | Body | String | O | Payload according to maintenance type |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| configId | String | Y | Configuration ID |
+| category | Enum | Y | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | String | N | Maintenance description |
+| type | Enum | Y | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | String | Y | Payload according to maintenance type |
 
 #### Response
 
@@ -2671,11 +2834,7 @@ This API does not return a response body.
 
 ### Delete DB Instance Maintenance
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2683,25 +2842,30 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| Name | In | Type | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| maintenanceId | URL | UUID | O | Maintenance ID |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| maintenanceId | URL | UUID | Y | Maintenance ID |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### List Network Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2709,64 +2873,67 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | Availability zone where DB instance will be created |
-| subnet | Body | Object | Subnet object |
-| subnet.subnetId | Body | UUID | Subnet identifier |
-| subnet.subnetName | Body | String | Name to identify subnets |
-| subnet.subnetCidr | Body | String | CIDR of subnet |
-| endPoints | Body | Array | List of access information |
-| endPoints.domain | Body | String | Domain |
-| endPoints.ipAddress | Body | String | IP address |
-| endPoints.endPointType | Body | String | Access information type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24"
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24"
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZone | String | Availability zone where DB instance will be created |
+| subnet | Object | Subnet object |
+| subnet.subnetId | UUID | Subnet identifier |
+| subnet.subnetName | String | Name to identify subnets |
+| subnet.subnetCidr | String | CIDR of subnet |
+| endPoints | Array | List of access information |
+| endPoints.domain | String | Domain |
+| endPoints.ipAddress | String | IP address |
+| endPoints.endPointType | String | Access information type |
 
 ---
 
 ### Modify Network Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2774,55 +2941,60 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| usePublicAccess | Body | Boolean | O | External access is available or not |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | External access is available or not |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Promote DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2830,44 +3002,47 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Rebuild DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2875,166 +3050,175 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Replicate DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifier list |
-| userGroupIds | Body | Array | X | User group identifier list |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze Slow query<br/>- Default: `true` |
-| network | Body | Object | O | Network information object |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| storage | Body | Object | X | Storage information object |
-| storage.storageType | Body | Enum | X | Data storage type |
-| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | X | Backup information object |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock |
-| backup.backupSchedules | Body | Array | X | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using storage auto scaling
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Object | Y | Network information object |
+| network.usePublicAccess | Boolean | N | External access is available or not |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | N | Storage information object |
+| storage.storageType | Enum | N | Data storage type |
+| storage.storageSize | Number | N | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | N | Backup information object |
+| backup.backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock |
+| backup.backupSchedules | Array | N | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3042,61 +3226,66 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
-| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
-| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
-| useReadOnly | Body | Boolean | X | Block write load<br/>- Default: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useOnlineFailover": false,
-    "executeBackup": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Boolean | N | Whether to execute backup at this time<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Block write load<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Restoration Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3104,85 +3293,88 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
-| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
-| restorableBackups | Body | Array | List of restorable backups |
-| restorableBackups.backup | Body | Object | Backup information object |
-| restorableBackups.backup.backupId | Body | UUID | Backup identifier |
-| restorableBackups.backup.backupName | Body | String | Backup name |
-| restorableBackups.backup.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | Original DB instance identifier |
-| restorableBackups.backup.dbInstanceName | Body | String | Original DB instance name |
-| restorableBackups.backup.dbVersion | Body | Enum | DB engine type |
-| restorableBackups.backup.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | Backup size |
-| restorableBackups.backup.useBackupLock | Body | Boolean | Whether to use table lock |
-| restorableBackups.backup.failoverCount | Body | Number | Number of failovers |
-| restorableBackups.backup.binLogFileName | Body | String | Binary log file name |
-| restorableBackups.backup.binLogPosition | Body | Object | Binary log file location |
-| restorableBackups.backup.createdYmdt | Body | DateTime | Date and time of backup creation |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | Date and time of backup renewal |
-| restorableBackups.restorableBinLogs | Body | Array | Binary log names that can be restored using the backup |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "550e8400-e29b-41d4-a716-446655440000",
-                "backupName": "backupName-example",
-                "backupStatus": "BACKING_UP",
-                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-                "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "MYSQL_V8036",
-                "backupType": "AUTO",
-                "backupSize": 1,
-                "useBackupLock": false,
-                "failoverCount": 1,
-                "binLogFileName": "binLogFileName-example",
-                "binLogPosition": {
-                },
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            },
-            "restorableBinLogs": []
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"backupType": "AUTO",
+"backupSize": 1,
+"useBackupLock": false,
+"failoverCount": 1,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+},
+"restorableBinLogs": []
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | Oldest restorable time |
+| latestRestorableYmdt | DateTime | Most recent restorable time |
+| restorableBackups | Array | List of restorable backups |
+| restorableBackups.backup | Object | Backup information object |
+| restorableBackups.backup.backupId | UUID | Backup identifier |
+| restorableBackups.backup.backupName | String | Backup name |
+| restorableBackups.backup.backupStatus | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.backup.dbInstanceId | UUID | Source DB instance identifier |
+| restorableBackups.backup.dbInstanceName | String | Source DB instance name |
+| restorableBackups.backup.dbVersion | String | DB engine type |
+| restorableBackups.backup.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | Backup size |
+| restorableBackups.backup.useBackupLock | Boolean | Whether to use table lock |
+| restorableBackups.backup.failoverCount | Number | Number of failovers |
+| restorableBackups.backup.binLogFileName | String | Binary log file name |
+| restorableBackups.backup.binLogPosition | Object | Binary log file location |
+| restorableBackups.backup.createdYmdt | DateTime | Date and time of backup creation |
+| restorableBackups.backup.updatedYmdt | DateTime | Date and time of backup renewal |
+| restorableBackups.restorableBinLogs | Array | Binary log names that can be restored using the backup |
 
 ---
 
 ### View the Last Query to Be Restored
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3190,215 +3382,224 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | Query executed date |
-| lastQuery | Body | String | Last executed query |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-12-31T15:00:00+09:00",
-    "lastQuery": "lastQuery-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+"lastQuery": "lastQuery-example"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| executedYmdt | DateTime | Query executed date |
+| lastQuery | String | Last executed query |
+
 ---
+
 ### Restore DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
-| dbPort | Body | Number | X | DB port |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| storage | Body | Object | X | Storage information object. If not specified, the storage settings of the source instance are applied. |
-| storage.storageType | Body | Enum | X | Storage type. If not specified, the storage type of the source instance is applied. |
-| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| network | Body | Object | X | Network information object. If not specified, the network settings of the source instance are applied. |
-| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used. |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created. If not specified, randomly selected. |
-| backup | Body | Object | X | Backup information object. If not specified, the backup settings of the source instance are applied. |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | X | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.restoreType | Body | Enum | O | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
-| restore.binLog.binLogFileName | Body | String | X | Binary log name to use for restoration |
-| restore.binLog.binLogPosition | Body | Object | X | Binary log location to use for restoration |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
-| userGroupIds | Body | Array | X | User group identifier list |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+<details>
+  <summary><strong>Example Code</strong></summary>
 
-#### When using storage auto scaling
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+}
+}
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
+| dbPort | Number | N | DB port |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | N | Storage information object. If not specified, the storage settings of the source instance are applied. |
+| storage.storageType | Enum | N | Storage type. If not specified, the storage type of the source instance is applied. |
+| storage.storageSize | Number | N | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Object | N | Network information object. If not specified, the network settings of the source instance are applied. |
+| network.subnetId | UUID | N | Subnet identifier. If not specified, the source instance value is used. |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created. If not specified, randomly selected. |
+| backup | Object | N | Backup information object. If not specified, the backup settings of the source instance are applied. |
+| backup.backupPeriod | Number | N | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | N | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.restoreType | Enum | Y | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
+| restore.binLog.binLogFileName | String | N | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Object | N | Binary log location to use for restoration |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | UUID | N | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
+| dbSecurityGroupIds | Array | N | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
 
 Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry.
 
 #### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
-| restore.binLog | Body | Object | X | Binary log information object |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+| restore.binLog | Object | N | Binary log information object |
 
 When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
 
 #### Request when restoring from backup (if restoreType is `BACKUP`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "TIMESTAMP",
-        "binLog": {
-            "binLogFileName": "binLogFileName-example",
-            "binLogPosition": {
-            }
-        }
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Start DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3406,44 +3607,47 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Stop DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3451,44 +3655,47 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Storage Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3496,139 +3703,148 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageType | Body | String | Data storage type |
-| storageSize | Body | Number | Data storage size (GB) |
-| storageStatus | Body | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
-| storageAutoscale | Body | Object | Data storage auto scaling object |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling |
-| storageAutoscale.threshold | Body | Number | Auto scale out conditions (%) |
-| storageAutoscale.maxStorageSize | Body | Number | Auto scaling maximum size (GB) |
-| storageAutoscale.cooldownTime | Body | Number | Auto scaling cooldown time (minutes) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED",
-    "storageAutoscale": {
-        "useStorageAutoscale": false,
-        "threshold": 1,
-        "maxStorageSize": 1,
-        "cooldownTime": 1
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED",
+"storageAutoscale": {
+"useStorageAutoscale": false,
+"threshold": 1,
+"maxStorageSize": 1,
+"cooldownTime": 1
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageType | String | Data storage type |
+| storageSize | Number | Data storage size (GB) |
+| storageStatus | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+| storageAutoscale | Object | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Boolean | Whether to enable storage auto scaling |
+| storageAutoscale.threshold | Number | Auto scale out conditions (%) |
+| storageAutoscale.maxStorageSize | Number | Auto scaling maximum size (GB) |
+| storageAutoscale.cooldownTime | Number | Auto scaling cooldown time (minutes) |
 
 ---
 
 ### Modify Storage Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | Modify Storage Information |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
-| storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using storage auto scaling
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "storageSize": 1,
-    "storageAutoscale": {
-        "useStorageAutoscale": false
-    }
+"storageSize": 1,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | Data storage size (GB)<br/>- Maximum value: `2048` |
+| storageAutoscale | Object | N | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Backups
 
 ### Backup Status
 
-| Status       | Description             |
-|--------------|-------------------------|
-| `BACKING_UP` | Backup in progress      |
-| `COMPLETED`  | Backup is completed     |
-| `DELETING`   | Backup is being deleted |
-| `DELETED`    | Backup is deleted       |
-| `ERROR`      | Error occurred          |
+| Status | Description |
+|--------------|--------------|
+| `BACKING_UP` | Backup in progress |
+| `COMPLETED` | Backup is completed |
+| `DELETING` | Backup is being deleted |
+| `DELETED` | Backup is deleted |
+| `ERROR` | Error occurred |
 
 ### Retrieve Backup List
 
-```http
-GET /v4.0/backups
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3636,65 +3852,66 @@ GET /v4.0/backups
 
 #### Request
 
+```http
+GET /v4.0/backups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of backup list entries |
-| backups | Body | Array | Backup list |
-| backups.backupId | Body | UUID | Backup identifier |
-| backups.backupName | Body | String | Name to identify the backup |
-| backups.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| backups.dbInstanceId | Body | UUID | Source DB instance identifier |
-| backups.dbVersion | Body | Enum | DB engine type |
-| backups.utilVersion | Body | String | Utility version |
-| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | Backup size (Byte) |
-| backups.createdYmdt | Body | DateTime | Created date and time |
-| backups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "MYSQL_V8036",
-            "utilVersion": "utilVersion-example",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of backup list entries |
+| backups | Array | Backup list |
+| backups.backupId | UUID | Backup identifier |
+| backups.backupName | String | Name to identify the backup |
+| backups.backupStatus | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | UUID | Source DB instance identifier |
+| backups.dbVersion | String | DB engine type |
+| backups.utilVersion | String | Utility version |
+| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | Backup size (Byte) |
+| backups.createdYmdt | DateTime | Created at |
+| backups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Backup
 
-```http
-POST /v4.0/backups
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3702,60 +3919,60 @@ POST /v4.0/backups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| baseBackupId | Body | UUID | X | Source backup identifier |
-| dbInstanceId | Body | UUID | X | DB instance identifier |
-| backupMethodType | Body | Enum | O | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupName": "backupName",
-    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "backupMethodType": "FULL"
+"backupName": "backupName",
+"baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"backupMethodType": "FULL"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupName | String | Y | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| baseBackupId | UUID | N | Source backup identifier |
+| dbInstanceId | UUID | N | DB instance identifier |
+| backupMethodType | Enum | Y | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete Backup
 
-```http
-DELETE /v4.0/backups/{backupId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3763,44 +3980,47 @@ DELETE /v4.0/backups/{backupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Backup Details
 
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3808,80 +4028,83 @@ GET /v4.0/backups/{backupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| backup | Body | Object | Backup details |
-| backup.backupId | Body | UUID | Backup identifier |
-| backup.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
-| backup.backupName | Body | String | Name to identify the backup |
-| backup.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| backup.dbInstanceId | Body | UUID | Source DB instance identifier |
-| backup.dbInstanceName | Body | String | Source DB instance name |
-| backup.dbVersion | Body | Enum | DB engine version |
-| backup.utilVersion | Body | String | Utility version |
-| backup.backupType | Body | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | Backup size (Byte) |
-| backup.isReplicable | Body | Boolean | Whether replication is possible |
-| backup.binLogFileName | Body | String | Binary log file name |
-| backup.binLogPosition | Body | Object | Binary log location |
-| backup.createdYmdt | Body | DateTime | Created date and time |
-| backup.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "550e8400-e29b-41d4-a716-446655440000",
-        "regionCode": "KR1",
-        "backupName": "backupName-example",
-        "backupStatus": "BACKING_UP",
-        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "MYSQL_V8036",
-        "utilVersion": "utilVersion-example",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XBSTREAM",
-        "backupSize": 1,
-        "isReplicable": false,
-        "binLogFileName": "binLogFileName-example",
-        "binLogPosition": {
-        },
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"regionCode": "KR1",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupMethodType": "FULL",
+"backupFileType": "XBSTREAM",
+"backupSize": 1,
+"isReplicable": false,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| backup | Object | Backup details |
+| backup.backupId | UUID | Backup identifier |
+| backup.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| backup.backupName | String | Name to identify the backup |
+| backup.backupStatus | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backup.dbInstanceId | UUID | Source DB instance identifier |
+| backup.dbInstanceName | String | Source DB instance name |
+| backup.dbVersion | String | DB engine version |
+| backup.utilVersion | String | Utility version |
+| backup.backupType | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | Backup size (Byte) |
+| backup.isReplicable | Boolean | Whether replication is possible |
+| backup.binLogFileName | String | Binary log file name |
+| backup.binLogPosition | Object | Binary log location |
+| backup.createdYmdt | DateTime | Created at |
+| backup.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Export Backup
 
-```http
-POST /v4.0/backups/{backupId}/export
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3889,208 +4112,219 @@ POST /v4.0/backups/{backupId}/export
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM member ID |
-| password | Body | String | O | API password of the object storage where the backup will be stored |
-| targetContainer | Body | String | O | Object storage container where the backup will be stored |
-| objectPath | Body | String | O | Path of the backup to be stored in the container |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password of the object storage where the backup will be stored |
+| targetContainer | String | Y | Object storage container where the backup will be stored |
+| objectPath | String | Y | Path of the backup to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restore Backup
 
-```http
-POST /v4.0/backups/{backupId}/restore
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | Restore backup |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | DB instance specification identifier. If not specified, the source instance value is used |
-| dbPort | Body | Number | X | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
-| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the source instance value is used |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| network | Body | Object | X | Network information object. If not specified, the source instance value is used |
-| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used |
-| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
-| storage | Body | Object | X | Storage information object. If not specified, the source instance value is used |
-| storage.storageType | Body | Enum | X | Storage type. If not specified, the source instance value is used |
-| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object. If not specified, the source instance value is used |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | X | Backup information object. If not specified, the source instance backup settings are used |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock. If not specified, the source instance value is used |
-| backup.backupSchedules | Body | Array | X | Backup schedule list. If not specified, the source instance value is used |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | DB instance specification identifier. If not specified, the source instance value is used |
+| dbPort | Number | N | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier. If not specified, the source instance value is used |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Object | N | Network information object. If not specified, the source instance value is used |
+| network.subnetId | UUID | N | Subnet identifier. If not specified, the source instance value is used |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
+| storage | Object | N | Storage information object. If not specified, the source instance value is used |
+| storage.storageType | Enum | N | Storage type. If not specified, the source instance value is used |
+| storage.storageSize | Number | N | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object. If not specified, the source instance value is used |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | N | Backup information object. If not specified, the source instance backup settings are used |
+| backup.backupPeriod | Number | N | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock. If not specified, the source instance value is used |
+| backup.backupSchedules | Array | N | Backup schedule list. If not specified, the source instance value is used |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
 
 #### When Using High Availability
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
 
 #### When Using Storage Auto Scaling
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## DB Security Group
 
 ### DB Security Group Progress
 
-| Status              | Description             |
-|---------------------|-------------------------|
-| `NONE`              | No task in progress     |
-| `CREATING_RULE`     | Creating rules          |
-| `UPDATING_RULE`     | Modifying rules         |
-| `DELETING_RULE`     | Deleting rules          |
+| Status | Description |
+|-----------------|--------------|
+| `NONE` | No task in progress |
+| `CREATING_RULE` | Creating rules |
+| `UPDATING_RULE` | Modifying rules |
+| `DELETING_RULE` | Deleting rules |
 
 ### List DB Security Groups
 
-```http
-GET /v4.0/db-security-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4098,57 +4332,58 @@ GET /v4.0/db-security-groups
 
 #### Request
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of DB security groups |
-| dbSecurityGroups | Body | Array | DB security groups |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB security group identifier |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | Name to identify the DB security group |
-| dbSecurityGroups.description | Body | String | Additional information on DB security group |
-| dbSecurityGroups.progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | Created date and time |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of DB security groups |
+| dbSecurityGroups | Array | DB security groups |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroups.description | String | Additional information on DB security group |
+| dbSecurityGroups.progressStatus | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| dbSecurityGroups.createdYmdt | DateTime | Created at |
+| dbSecurityGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Security Group
 
-```http
-POST /v4.0/db-security-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4156,78 +4391,78 @@ POST /v4.0/db-security-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
-| rules | Body | Array | O | DB security group rules |
-| rules.direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| rules.etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| rules.port | Body | Object | O | Port object |
-| rules.port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| rules.port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| rules.port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | Additional information on DB security group rule |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 3306,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB security group<br/>- Maximum length: `100` |
+| rules | Array | Y | DB security group rules |
+| rules.direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Object | Y | Port object |
+| rules.port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | Additional information on DB security group rule |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
 
 ---
 
 ### Delete DB Security Group
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4235,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4249,11 +4492,7 @@ This API does not return a response body.
 
 ### List DB Security Group Details
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4261,82 +4500,85 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
-| dbSecurityGroupName | Body | String | Name to identify the DB security group |
-| description | Body | String | Additional information on DB security group |
-| progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
-| rules | Body | Array | DB security group rules |
-| rules.ruleId | Body | UUID | DB security group rule identifier |
-| rules.description | Body | String | Additional information on DB security group rule |
-| rules.direction | Body | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| rules.etherType | Body | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| rules.port | Body | Object | Port object |
-| rules.port.portType | Body | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| rules.port.minPort | Body | Number | Minimum port range |
-| rules.port.maxPort | Body | Number | Maximum port range |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | Created date and time |
-| rules.updatedYmdt | Body | DateTime | Modified date and time |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
-        {
-            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description-example",
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroupName | String | Name to identify the DB security group |
+| description | String | Additional information on DB security group |
+| progressStatus | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| rules | Array | DB security group rules |
+| rules.ruleId | UUID | DB security group rule identifier |
+| rules.description | String | Additional information on DB security group rule |
+| rules.direction | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Object | Port object |
+| rules.port.portType | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | Minimum port range |
+| rules.port.maxPort | Number | Maximum port range |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | Created at |
+| rules.updatedYmdt | DateTime | Modified date and time |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Security Group
 
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4344,24 +4586,34 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB security group<br/>- Maximum length: `100` |
 
 #### Response
 
@@ -4371,11 +4623,7 @@ This API does not return a response body.
 
 ### Delete DB Security Group Rule
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4383,45 +4631,48 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Create DB Security Group Rule
 
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4429,70 +4680,75 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| port | Body | Object | O | Port object |
-| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify DB Security Group Rule
 
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4500,72 +4756,78 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| port | Body | Object | O | Port object |
-| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Parameter Groups
 
 ### List Parameter Groups
 
-```http
-GET /v4.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4573,61 +4835,62 @@ GET /v4.0/parameter-groups
 
 #### Request
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of parameter groups |
-| parameterGroups | Body | Array | Parameter groups |
-| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
-| parameterGroups.description | Body | String | Additional information on parameter group |
-| parameterGroups.dbVersion | Body | Enum | DB engine type |
-| parameterGroups.parameterGroupType | Body | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
-| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "parameterGroupType": "USER",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupType": "USER",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of parameter groups |
+| parameterGroups | Array | Parameter groups |
+| parameterGroups.parameterGroupId | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | String | Name to identify parameter groups |
+| parameterGroups.description | String | Additional information on parameter group |
+| parameterGroups.dbVersion | String | DB engine type |
+| parameterGroups.parameterGroupType | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | DateTime | Created at |
+| parameterGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Parameter Group
 
-```http
-POST /v4.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4635,58 +4898,58 @@ POST /v4.0/parameter-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
-| dbVersion | Body | Enum | O | DB engine type |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | String | Y | DB engine type |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Delete Parameter Group
 
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4694,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4708,11 +4979,7 @@ This API does not return a response body.
 
 ### List Parameter Group Details
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4720,79 +4987,82 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroupName | Body | String | Name to identify parameter groups |
-| description | Body | String | Additional information on parameter group |
-| dbVersion | Body | Enum | DB engine type |
-| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameters | Body | Array | Parameter list |
-| parameters.parameterId | Body | UUID | Parameter identifier |
-| parameters.parameterFileGroup | Body | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | Parameter name |
-| parameters.fileParameterName | Body | String | Parameter file name |
-| parameters.value | Body | String | Current value |
-| parameters.defaultValue | Body | String | Default value |
-| parameters.allowedValue | Body | String | Permitted values |
-| parameters.updateType | Body | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterFileGroup": "CLIENT",
-            "parameterName": "parameterName-example",
-            "fileParameterName": "fileParameterName-example",
-            "value": "value-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+"parameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+"applyType": "BOTH"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+| parameterGroupName | String | Name to identify parameter groups |
+| description | String | Additional information on parameter group |
+| dbVersion | String | DB engine type |
+| parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Array | Parameter list |
+| parameters.parameterId | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | Parameter name |
+| parameters.fileParameterName | String | Parameter file name |
+| parameters.value | String | Current value |
+| parameters.defaultValue | String | Default value |
+| parameters.allowedValue | String | Permitted values |
+| parameters.updateType | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Parameter Group
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4800,24 +5070,34 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
 
 #### Response
 
@@ -4827,11 +5107,7 @@ This API does not return a response body.
 
 ### Copy Parameter Group
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4839,57 +5115,62 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Modify Parameter
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4897,29 +5178,39 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | Parameters to change |
-| modifiedParameters.parameterId | Body | UUID | O | Parameter identifier |
-| modifiedParameters.value | Body | String | O | Parameter value to change |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "value": "value-example"
-        }
-    ]
+"modifiedParameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"value": "value-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | Parameters to change |
+| modifiedParameters.parameterId | UUID | Y | Parameter identifier |
+| modifiedParameters.value | String | Y | Parameter value to change |
 
 #### Response
 
@@ -4929,11 +5220,7 @@ This API does not return a response body.
 
 ### Reset Parameter Group
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4941,26 +5228,31 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### Request
 
-This API does not require a request body.
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## User Group
 
 ### List User Groups
 
-```http
-GET /v4.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4968,53 +5260,54 @@ GET /v4.0/user-groups
 
 #### Request
 
+```http
+GET /v4.0/user-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of user groups |
-| userGroups | Body | Array | User group list |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| userGroups.createdYmdt | Body | DateTime | Created date and time |
-| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of user groups |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| userGroups.createdYmdt | DateTime | Created at |
+| userGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create User Group
 
-```http
-POST /v4.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5022,58 +5315,58 @@ POST /v4.0/user-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | Name to identify user groups |
-| memberIds | Body | Array | O | List of project member identifiers |
-| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | Y | List of project member identifiers |
+| selectAll | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
 
 ---
 
 ### Delete User Group
 
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5081,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5095,11 +5396,7 @@ This API does not return a response body.
 
 ### List User Group Details
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5107,59 +5404,62 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-| userGroupName | Body | String | Name to identify user groups |
-| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | Project member list |
-| members.memberId | Body | UUID | Project member identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"userGroupTypeCode": "ENTIRE",
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
+| userGroupName | String | Name to identify user groups |
+| userGroupTypeCode | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify User Group
 
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5167,41 +5467,48 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | Name to identify user groups |
-| memberIds | Body | Array | X | List of project member identifiers |
-| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | N | List of project member identifiers |
+| selectAll | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Notification Group
 
 ### List Notification Groups
 
-```http
-GET /v4.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5209,57 +5516,58 @@ GET /v4.0/notification-groups
 
 #### Request
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | Notification group list |
-| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
-| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
-| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
-| notificationGroups.isEnabled | Body | Boolean | Whether enabled |
-| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
-| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroups": [
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroups | Array | Notification group list |
+| notificationGroups.notificationGroupId | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Boolean | Whether to activate |
+| notificationGroups.createdYmdt | DateTime | Created at |
+| notificationGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Notification Group
 
-```http
-POST /v4.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5267,64 +5575,64 @@ POST /v4.0/notification-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
-| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `true` |
-| dbInstanceIds | Body | Array | O | List of DB instance identifiers to monitor |
-| userGroupIds | Body | Array | O | List of user group identifiers |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Array | Y | List of DB instance identifiers to monitor |
+| userGroupIds | Array | Y | List of user group identifiers |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
 
 ---
 
 ### Delete Notification Group
 
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5332,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5346,11 +5662,7 @@ This API does not return a response body.
 
 ### View Notification Group Details
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5358,74 +5670,77 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroupName | Body | String | Name to identify notification groups |
-| notifyEmail | Body | Boolean | Whether to be notified by email |
-| notifySms | Body | Boolean | Whether to be notified by SMS |
-| isEnabled | Body | Boolean | Whether enabled |
-| dbInstances | Body | Array | List of DB instances to monitor |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| userGroups | Body | Array | User group list |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example"
+}
+],
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
+| notificationGroupName | String | Name to identify notification groups |
+| notifyEmail | Boolean | Whether to be notified by email |
+| notifySms | Boolean | Whether to be notified by SMS |
+| isEnabled | Boolean | Whether to activate |
+| dbInstances | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Notification Group
 
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5433,53 +5748,66 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | Name to identify notification groups |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
-| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `false` |
-| dbInstanceIds | Body | Array | X | List of DB instance identifiers to monitor |
-| userGroupIds | Body | Array | X | List of user group identifiers |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Array | N | List of DB instance identifiers to monitor |
+| userGroupIds | Array | N | List of user group identifiers |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Monitoring
 
 ### View Stats
 
-```http
-GET /v4.0/metric-statistics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:Metric.List | View stats |
 
 #### Request
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### Request Body
 
 This API does not require a request body.
 
@@ -5491,11 +5819,7 @@ This API does not return a response body.
 
 ### List Metric List
 
-```http
-GET /v4.0/metrics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5503,37 +5827,42 @@ GET /v4.0/metrics
 
 #### Request
 
+```http
+GET /v4.0/metrics
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric list |
-| metrics.measureName | Body | String | Metric type to query |
-| metrics.unit | Body | String | Measure unit |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "measureName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"metrics": [
+{
+"measureName": "measureName-example",
+"unit": "unit-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| metrics | Array | Metric list |
+| metrics.measureName | String | Metric type to query |
+| metrics.unit | String | Measure unit |
 
 ---
 
@@ -5543,22 +5872,18 @@ This API does not require a request body.
 
 Events can be categorized into categories, which are shown below.
 
-| Event category    | Description      |
+| Event category | Description |
 |-------------|---------|
-| ALL         | All      |
-| BACKUP      | Backup      |
+| ALL | All |
+| BACKUP | Backup |
 | DB_INSTANCE | DB instance |
-| JOB         | Job      |
-| TENANT      | Tenant     |
-| MONITORING  | Monitoring    |
+| JOB | Job |
+| TENANT | Tenant |
+| MONITORING | Monitoring |
 
 ### List Subscribable Event Codes
 
-```http
-GET /v4.0/event-codes
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5566,47 +5891,48 @@ GET /v4.0/event-codes
 
 #### Request
 
+```http
+GET /v4.0/event-codes
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | Event code list |
-| eventCodes.eventCode | Body | Enum | Event code |
-| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventCodes": [
+{
+"eventCode": "ENUM_VALUE",
+"eventCategoryType": "ALL"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventCodes | Array | Event code list |
+| eventCodes.eventCode | Enum | Event code |
+| eventCodes.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### List Events
 
-```http
-GET /v4.0/events
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5614,228 +5940,239 @@ GET /v4.0/events
 
 #### Request
 
+```http
+GET /v4.0/events
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of events |
-| events | Body | Array | Event list |
-| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | Occurred event type |
-| events.sourceId | Body | UUID | Event source identifier |
-| events.sourceName | Body | String | Name to identify event sources |
-| events.messages | Body | Array | Event messages |
-| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | Event message |
-| events.eventYmdt | Body | DateTime | Event occurred date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"events": [
+{
+"eventCategoryType": "ALL",
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+"messages": [
+{
+"langCode": "KO",
+"message": "message-example"
+}
+],
+"eventYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of events |
+| events | Array | Event list |
+| events.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | Occurred event type |
+| events.sourceId | UUID | Identifier of the event source |
+| events.sourceName | String | Name to identify event sources |
+| events.messages | Array | Event messages |
+| events.messages.langCode | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | Event message |
+| events.eventYmdt | DateTime | Event occurred date and time |
+
 ---
+
 ## Event Subscription
 
 ### List Event Subscriptions
 
-```http
-GET /v4.0/event-subscriptions
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.List | List event subscriptions |
 
 #### Request
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of event subscriptions |
-| eventSubscriptions | Body | Array | List of event subscriptions |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | Event subscription identifier |
-| eventSubscriptions.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | A name that identifies the event subscription |
-| eventSubscriptions.enabled | Body | Boolean | Whether to activate |
-| eventSubscriptions.notifyEmail | Body | Boolean | Whether to send emails |
-| eventSubscriptions.notifySms | Body | Boolean | Whether to send SMS messages |
-| eventSubscriptions.eventCodes | Body | Array | List of event codes to subscribe to |
-| eventSubscriptions.sources | Body | Array | List of event sources to subscribe to |
-| eventSubscriptions.sources.sourceId | Body | UUID | Identifier of the event source |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | List of identifiers of user groups subscribing to the event |
-| eventSubscriptions.createdYmdt | Body | DateTime | Created at |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "eventSubscriptions": [
-        {
-            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL",
-            "eventSubscriptionName": "eventSubscriptionName-example",
-            "enabled": false,
-            "notifyEmail": false,
-            "notifySms": false,
-            "eventCodes": [],
-            "sources": [
-                {
-                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-                    "eventCategoryType": "ALL"
-                }
-            ],
-            "userGroupIds": [
-                "550e8400-e29b-41d4-a716-446655440000"
-            ],
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"eventSubscriptions": [
+{
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of event subscriptions |
+| eventSubscriptions | Array | List of event subscriptions |
+| eventSubscriptions.eventSubscriptionId | UUID | Event subscription identifier |
+| eventSubscriptions.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | A name that identifies the event subscription |
+| eventSubscriptions.enabled | Boolean | Whether to activate |
+| eventSubscriptions.notifyEmail | Boolean | Whether to send emails |
+| eventSubscriptions.notifySms | Boolean | Whether to send SMS messages |
+| eventSubscriptions.eventCodes | Array | List of event codes to subscribe to |
+| eventSubscriptions.sources | Array | List of event sources to subscribe to |
+| eventSubscriptions.sources.sourceId | UUID | Identifier of the event source |
+| eventSubscriptions.sources.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | List of identifiers of user groups subscribing to the event |
+| eventSubscriptions.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Create an Event Subscription
 
-```http
-POST /v4.0/event-subscriptions
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Create | Create an event subscription |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | A name that identifies the event subscription |
-| enabled | Body | Boolean | O | Whether to activate |
-| notifyEmail | Body | Boolean | O | Whether to send emails |
-| notifySms | Body | Boolean | O | Whether to send SMS messages |
-| eventCodes | Body | Array | O | List of event codes to subscribe to |
-| sources | Body | Array | O | List of event sources to subscribe to |
-| sources.sourceId | Body | UUID | O | Identifier of the event source |
-| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | List of identifiers of user groups to subscribe to |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | A name that identifies the event subscription |
+| enabled | Boolean | Y | Whether to activate |
+| notifyEmail | Boolean | Y | Whether to send emails |
+| notifySms | Boolean | Y | Whether to send SMS messages |
+| eventCodes | Array | Y | List of event codes to subscribe to |
+| sources | Array | Y | List of event sources to subscribe to |
+| sources.sourceId | UUID | Y | Identifier of the event source |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | List of identifiers of user groups to subscribe to |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | Event subscription identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | Event subscription identifier |
 
 ---
 
 ### Delete an Event Subscription
 
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | Delete an event subscription |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5845,55 +6182,61 @@ This API does not return a response body.
 
 ### Modify an Event Subscription
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | A name that identifies the event subscription |
-| enabled | Body | Boolean | X | Whether to activate |
-| notifyEmail | Body | Boolean | X | Whether to send emails |
-| notifySms | Body | Boolean | X | Whether to send SMS messages |
-| eventCodes | Body | Array | X | List of event codes to subscribe to |
-| sources | Body | Array | X | List of event sources to subscribe to |
-| sources.sourceId | Body | UUID | O | Identifier of the event source |
-| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | List of identifiers of user groups to subscribe to |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | A name that identifies the event subscription |
+| enabled | Boolean | N | Whether to activate |
+| notifyEmail | Boolean | N | Whether to send emails |
+| notifySms | Boolean | N | Whether to send SMS messages |
+| eventCodes | Array | N | List of event codes to subscribe to |
+| sources | Array | N | List of event sources to subscribe to |
+| sources.sourceId | UUID | Y | Identifier of the event source |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | List of identifiers of user groups to subscribe to |
 
 #### Response
 
@@ -5905,51 +6248,52 @@ This API does not return a response body.
 
 ### List Availability Zones
 
-```http
-GET /v4.0/availability-zones
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:AvailabilityZone.List | List availability zones |
 
 #### Request
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | List of availability zones |
-| availabilityZones.availabilityZoneName | Body | String | Availability zone name |
-| availabilityZones.zoneState | Body | Object | Availability zone status |
-| availabilityZones.zoneState.available | Body | Boolean | Whether the availability zone is available |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "availabilityZoneName": "availabilityZoneName-example",
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZones": [
+{
+"availabilityZoneName": "availabilityZoneName-example",
+"zoneState": {
+"available": false
+}
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZones | Array | List of availability zones |
+| availabilityZones.availabilityZoneName | String | Availability zone name |
+| availabilityZones.zoneState | Object | Availability zone status |
+| availabilityZones.zoneState.available | Boolean | Whether the availability zone is available |
 
 ---

--- a/en/api-guide-v4.0.md
+++ b/en/api-guide-v4.0.md
@@ -58,33 +58,38 @@ The API responds with "200 OK" to all API requests. For more information on the 
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|--------------|----------|-----------------|--------|
+| MARIADB\_V10330  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10611  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10612  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10616  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10622  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V10625  | X        | X               | NATIVE, ED25519 |
+| MARIADB\_V101107 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101108 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101113 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V101116 | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11407  | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11410  | O        | O               | NATIVE, ED25519 |
+| MARIADB\_V11806  | O        | O               | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
 
+
 ## Project Information
 
-### List Regions
+### List Project Members
 
 ```http
-GET /v4.0/project/regions
+GET /v4.0/project/members
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                     | Description         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | Query project information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Project.Get | List project members |
 
 #### Request
 
@@ -92,11 +97,63 @@ This API does not require a request body.
 
 #### Response
 
-| Name    | Type | Format | Description |
-|---------|------|--------|-------------|
-| regions | Body | Array  | Region list |
-| regions.regionCode | Body | Enum    | Region code<br/>- `KR1`: Korea (Pangyo) |
-| regions.isEnabled  | Body | Boolean | Whether to enable a region                                                                 |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| members.memberName | Body | String | Project member name |
+| members.emailAddress | Body | String | Project member email address |
+| members.phoneNumber | Body | String | Project member phone number |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Regions
+
+```http
+GET /v4.0/project/regions
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Project.Get | List regions |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| regions | Body | Array | Region list |
+| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Body | Boolean | Whether the region is enabled |
 
 <details><summary>Example</summary>
 <p>
@@ -111,58 +168,7 @@ This API does not require a request body.
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### List Project Members
-
-```http
-GET /v4.0/project/members
-```
-
-#### Required permissions
-
-| Permission Name                                      | Description         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | Query project information |
-
-#### Request
-
-This API does not require a request body.
-
-#### Response
-
-| Name                 | Type | Format | Description                  |
-|----------------------|------|--------|------------------------------|
-| members              | Body | Array  | Project member list          |
-| members.memberId     | Body | UUID   | Project member identifier    |
-| members.memberName   | Body | String | Project member name          |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber  | Body | String | Project member mobile        |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "Hong Gildong",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "isEnabled": false
         }
     ]
 }
@@ -172,7 +178,6 @@ This API does not require a request body.
 </details>
 
 ---
-
 ## Specifications of DB Instance
 
 ### List DB Instance Specifications
@@ -183,8 +188,8 @@ GET /v4.0/db-flavors
 
 #### Required permissions
 
-| Permission Name                                       | Description               |
-|-------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbFlavor.List | List DB Instance Specifications |
 
 #### Request
@@ -193,13 +198,13 @@ This API does not require a request body.
 
 #### Response
 
-| Name                   | Type | Format | Description                              |
-|------------------------|------|--------|------------------------------------------|
-| dbFlavors              | Body | Array  | List of DB instance specifications       |
-| dbFlavors.dbFlavorId   | Body | UUID   | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications       |
-| dbFlavors.ram          | Body | Number | Memory size (MB)                         |
-| dbFlavors.vcpus        | Body | Number | CPU cores                                |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
+| dbFlavors.ram | Body | Number | Memory size (MB) |
+| dbFlavors.vcpus | Body | Number | CPU cores |
 
 <details><summary>Example</summary>
 <p>
@@ -213,9 +218,9 @@ This API does not require a request body.
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -237,9 +242,9 @@ GET /v4.0/network/subnets
 
 #### Required permissions
 
-| Permission Name                                     | Description        |
-|------------------------------------------|-----------|
-| RDSforMariaDB:Network.List | List subnets |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Network.List | List Subnets |
 
 #### Request
 
@@ -247,14 +252,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format  | Description              |
-|--------------------------|------|---------|--------------------------|
-| subnets                  | Body | Array   | Subnet list              |
-| subnets.subnetId         | Body | UUID    | Subnet identifier        |
-| subnets.subnetName       | Body | String  | Name to identify subnets |
-| subnets.subnetCidr       | Body | String  | CIDR of subnet           |
-| subnets.usingGateway     | Body | Boolean | Whether to use gateway   |
-| subnets.availableIpCount | Body | Number  | Number of available IPs  |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| subnets | Body | Array | Subnet list |
+| subnets.subnetId | Body | UUID | Subnet identifier |
+| subnets.subnetName | Body | String | Name to identify subnets |
+| subnets.subnetCidr | Body | String | CIDR of subnet |
+| subnets.usingGateway | Body | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Body | Number | Number of available IPs |
 
 <details><summary>Example</summary>
 <p>
@@ -268,11 +273,11 @@ This API does not require a request body.
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
@@ -293,8 +298,8 @@ GET /v4.0/db-versions
 
 #### Required permissions
 
-| Permission Name                                        | Description          |
-|--------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbVersion.List | List DB Engines |
 
 #### Request
@@ -303,11 +308,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format  | Description                                           |
-|------------------------------|------|---------|-------------------------------------------------------|
-| dbVersions                   | Body | Array   | DB engine list                                        |
-| dbVersions.dbVersion         | Body | String  | DB engine type                                        |
-| dbVersions.dbVersionName     | Body | String  | DB engine name                                        |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB engine list |
+| dbVersions.dbVersion | Body | String | DB engine type |
+| dbVersions.dbVersionName | Body | String | DB engine name |
 | dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
 
 <details><summary>Example</summary>
@@ -322,9 +327,9 @@ This API does not require a request body.
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
@@ -337,7 +342,7 @@ This API does not require a request body.
 
 ## Storage
 
-### List Storage Type
+### List Storage Types
 
 ```http
 GET /v4.0/storage-types
@@ -345,8 +350,8 @@ GET /v4.0/storage-types
 
 #### Required permissions
 
-| Permission Name                                      | Description                |
-|------------------------------------------|-------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Storage.List | List data storage types |
 
 #### Request
@@ -355,9 +360,9 @@ This API does not require a request body.
 
 #### Response
 
-| Name         | Type | Format | Description       |
-|--------------|------|--------|-------------------|
-| storageTypes | Body | Array  | Storage type list |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | Storage type list |
 
 <details><summary>Example</summary>
 <p>
@@ -408,29 +413,29 @@ GET /v4.0/jobs/{jobId}
 
 #### Required permissions
 
-| Permission Name                                 | Description          |
-|-------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Job.Get | List Task Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name  | Type | Format | Required | Description     |
-|-------|------|--------|----------|-----------------|
-| jobId | URL  | UUID   | O        | Task identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### Response
 
-| Name                           | Type | Format   | Description                                         |
-|--------------------------------|------|----------|-----------------------------------------------------|
-| jobId                          | Body | UUID     | Task identifier                                     |
-| jobStatus                      | Body | Enum     | Current task status                                 |
-| resourceRelations              | Body | Array    | Relevant resource list                              |
-| resourceRelations.resourceType | Body | Enum     | Relevant resource type                              |
-| resourceRelations.resourceId   | Body | UUID     | Relevant resource identifier                        |
-| createdYmdt                    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                    | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Task identifier |
+| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | Relevant resource list |
+| resourceRelations.resourceType | Body | String | Relevant resource type |
+| resourceRelations.resourceId | Body | String | Relevant resource identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -442,16 +447,16 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -459,7 +464,6 @@ This API does not require a request body.
 </details>
 
 ---
-
 ## DB Instance Group
 
 ### List DB Instance Groups
@@ -470,9 +474,9 @@ GET /v4.0/db-instance-groups
 
 #### Required permissions
 
-| Permission Name                                              | Description               |
-|--------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.List | List DB Instances |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.List | List DB Instance Groups |
 
 #### Request
 
@@ -480,13 +484,13 @@ This API does not require a request body.
 
 #### Response
 
-| Name                               | Type | Format   | Description                                                                                                    |
-|------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB instance groups                                                                                             |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                   |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                             |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB instance group list |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -500,10 +504,10 @@ This API does not require a request body.
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -522,31 +526,30 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Required permissions
 
-| Permission Name                                             | Description               |
-|-------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.Get | List DB Instance Group Details |
-
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbInstanceGroupId | URL  | UUID   | O        | DB instance group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                             |
-|------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| replicationType              | Body | Enum     | DB instance group replication type<br/>- `STANDALONE`: Standalone<br/>- `HIGH_AVAILABILITY`: High availability                                                          |
-| dbInstances                  | Body | Array    | DB instances belong to DB instance group                                                                                                                                |
-| dbInstances.dbInstanceId     | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceType   | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB instance current status                                                                                                                                              |
-| createdYmdt                  | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                  | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -558,17 +561,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -581,50 +584,50 @@ This API does not require a request body.
 
 ### DB Instance Status
 
-| Status             | Description                               |
-|--------------------|-------------------------------------------|
-| `AVAILABLE`        | DB instance is available                  |
-| `BEFORE_CREATE`    | Before DB instance is created             |
-| `STORAGE_FULL`     | Insufficient DB instance storage          |
-| `FAIL_TO_CREATE`   | Failed to create DB instance              |
-| `FAIL_TO_CONNECT`  | Failed to connect DB instance             |
-| `REPLICATION_STOP` | Replication of DB instance is stopped     |
-| `FAILOVER`         | High availability DB instance failed over |
-| `SHUTDOWN`         | DB instance is stopped                    |
-| `DELETED`          | DB instance is deleted                    |
+| Status | Description |
+|---------------------|------------------------------|
+| `AVAILABLE`         | DB instance is available |
+| `BEFORE_CREATE`     | Before DB instance is created |
+| `STORAGE_FULL`      | Insufficient DB instance storage |
+| `FAIL_TO_CREATE`    | Failed to create DB instance |
+| `FAIL_TO_CONNECT`   | Failed to connect DB instance |
+| `REPLICATION_STOP`  | Replication of DB instance is stopped |
+| `FAILOVER`          | High availability DB instance failed over |
+| `SHUTDOWN`          | DB instance is stopped |
+| `DELETED`           | DB instance is deleted |
 
 ### DB Instance Progress Status
 
-| Status                     | Description                      |
-|----------------------------|----------------------------------|
+| Status | Description |
+|----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up                       |
-| `CANCELING`                | Canceling                        |
-| `CREATING`                 | Creating                         |
-| `CREATING_SCHEMA`          | Creating DB schema	              |
-| `CREATING_USER`            | Creating user	                   |
-| `DELETING`                 | Deleting                         |
-| `DELETING_SCHEMA`          | Deleting DB schema               |
-| `DELETING_USER`            | Deleting user                    |
-| `EXPORTING_BACKUP`         | Exporting backup                 |
-| `FAILING_OVER`             | Under failover                   |
-| `MIGRATING`                | Under migration                  |
-| `MODIFYING`                | Under modification               |
-| `PREPARING`                | In preparation                   |
-| `PROMOTING`                | Promoting                        |
-| `REBUILDING`               | Rebuilding                       |
-| `REPAIRING`                | Recovering                       |
-| `REPLICATING`              | Replicating                      |
-| `RESTARTING`               | Restarting                       |
-| `RESTARTING_FORCIBLY`      | Force restarting                 |
-| `RESTORING`                | Restoring                        |
-| `STARTING`                 | Starting                         |
-| `STOPPING`                 | Stopping                         |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema          |
-| `SYNCING_USER`             | Synchronizing user	              |
-| `UPDATING_USER`            | Modifying user	                  |
+| `BACKING_UP`               | Backing up |
+| `CANCELING`                | Canceling |
+| `CREATING`                 | Creating |
+| `CREATING_SCHEMA`          | Creating DB schema |
+| `CREATING_USER`            | Creating user |
+| `DELETING`                 | Deleting |
+| `DELETING_SCHEMA`          | Deleting DB schema |
+| `DELETING_USER`            | Deleting user |
+| `EXPORTING_BACKUP`         | Exporting backup |
+| `FAILING_OVER`             | Under failover |
+| `MIGRATING`                | Under migration |
+| `MODIFYING`                | Under modification |
+| `PREPARING`                | In preparation |
+| `PROMOTING`                | Promoting |
+| `REBUILDING`               | Rebuilding |
+| `REPAIRING`                | Recovering |
+| `REPLICATING`              | Replicating |
+| `RESTARTING`               | Restarting |
+| `RESTARTING_FORCIBLY`      | Force restarting |
+| `RESTORING`                | Restoring |
+| `STARTING`                 | Starting |
+| `STOPPING`                 | Stopping |
+| `SYNCING_SCHEMA`           | Synchronizing DB schema |
+| `SYNCING_USER`             | Synchronizing user |
+| `UPDATING_USER`            | Modifying user |
 
-### List DB instances
+### List DB Instances
 
 ```http
 GET /v4.0/db-instances
@@ -632,8 +635,8 @@ GET /v4.0/db-instances
 
 #### Required permissions
 
-| Permission Name                                         | Description            |
-|---------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.List | List DB instances |
 
 #### Request
@@ -642,20 +645,20 @@ This API does not require a request body.
 
 #### Response
 
-| Name                          | Type | Format   | Description                                                                                                                                                             |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB instances                                                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstances.dbInstanceName    | Body | String   | Name to identify DB instances                                                                                                                                           |
-| dbInstances.description       | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbInstances.dbVersion         | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbInstances.dbPort            | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.progressStatus    | Body | Enum     | DB instance current status                                                                                                                                              |
-| dbInstances.createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| dbInstances.updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB instance list |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| dbInstances.description | Body | String | Additional information on DB instances |
+| dbInstances.dbVersion | Body | Enum | DB engine type |
+| dbInstances.dbPort | Body | Number | DB port |
+| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Body | Enum | DB instance current progress status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | Created date and time |
+| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -669,19 +672,366 @@ This API does not require a request body.
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+### Create DB Instance
+
+```http
+POST /v4.0/db-instances
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | Create DB Instance |
+
+#### Common request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbVersion | Body | Enum | O | DB engine type |
+| dbPort | Body | Number | O | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| userGroupIds | Body | Array | X | User group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| authenticationPlugin | Body | Enum | X | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Data storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restore DB Instance from Object Storage
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
+
+#### Common request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
+| dbPort | Body | Number | O | DB port |
+| dbVersion | Body | Enum | O | DB engine type |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Body | Object | O | Storage information objects |
+| storage.storageType | Body | Enum | O | Storage type |
+| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Body | Object | O | Network information objects |
+| network.subnetId | Body | UUID | O | Subnet identifier |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| backup | Body | Object | O | Backup information objects |
+| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.tenantId | Body | String | O | Tenant ID of object storage where backups are stored |
+| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
+| restore.password | Body | String | O | API password for object storage where backups are stored |
+| restore.targetContainer | Body | String | O | Container for object storage where backups are stored |
+| restore.objectPath | Body | String | O | Backup path stored in container |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | Body | UUID | O | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| userGroupIds | Body | Array | X | User group identifiers |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Delete DB Instance
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | Delete DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| deleteAutoBackup | Body | Boolean | X | Whether to delete automated backups<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "deleteAutoBackup": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -698,43 +1048,43 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Get | List DB Instance Details |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                        | Type | Format   | Description                                                                                                                                                             |
-|-----------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB instance identifier                                                                                                                                                  |
-| dbInstanceGroupId           | Body | UUID     | DB instance group identifier                                                                                                                                            |
-| dbInstanceName              | Body | String   | Name to identify DB instances                                                                                                                                           |
-| description                 | Body | String   | Additional information on DB instances                                                                                                                                  |
-| dbVersion                   | Body | Enum     | DB engine type                                                                                                                                                          |
-| dbPort                      | Body | Number   | DB port                                                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB instance role type<br/>- `MASTER`: Master<br/>- `FAILED_MASTER`: Failed over master<br/>- `CANDIDATE_MASTER`: Candidate master<br/>- `READ_ONLY_SLAVE`: Read replica |
-| dbInstanceStatus            | Body | Enum     | DB instance current status                                                                                                                                              |
-| progressStatus              | Body | Enum     | Current task status of DB instance                                                                                                                                      |
-| dbFlavorId                  | Body | UUID     | Identifier of DB instance specifications                                                                                                                                |
-| parameterGroupId            | Body | UUID     | Parameter group identifier applied to DB instance                                                                                                                       |
-| dbSecurityGroupIds          | Body | Array    | DB security group identifiers applied to DB instance                                                                                                                    |
-| notificationGroupIds        | Body | Array    | Notification group identifiers applied to DB instance                                                                                                                   |
-| useDeletionProtection       | Body | Boolean  | Whether to protect DB instance against deletion                                                                                                                         |
-| useSlowQueryAnalysis        | Body | Boolean  | Whether to analyze slow queries                                                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | Whether to support authentication plugin                                                                                                                                |
-| needToApplyParameterGroup   | Body | Boolean  | Need to apply the latest parameter group                                                                                                                                |
-| needMigration               | Body | Boolean  | Need to migrate                                                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | Whether to support DB version upgrade                                                                                                                                   |
-| createdYmdt                 | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| updatedYmdt                 | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                     |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstanceGroupId | Body | UUID | DB instance group identifier |
+| dbInstanceName | Body | String | Name to identify DB instances |
+| description | Body | String | Additional information on DB instances |
+| dbVersion | Body | Enum | DB engine type |
+| dbPort | Body | Number | DB port |
+| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Body | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | Parameter group identifier applied to DB instance |
+| dbSecurityGroupIds | Body | Array | DB security group identifiers applied to DB instance |
+| notificationGroupIds | Body | Array | Notification group identifiers applied to DB instance |
+| useDeletionProtection | Body | Boolean | Whether to protect DB instance against deletion |
+| useSlowQueryAnalysis | Body | Boolean | Whether to analyze slow queries |
+| supportAuthenticationPlugin | Body | Boolean | Whether to support authentication plugin |
+| needToApplyParameterGroup | Body | Boolean | Need to apply the latest parameter group |
+| needMigration | Body | Boolean | Need to migrate |
+| supportDbVersionUpgrade | Body | Boolean | Whether to support DB version upgrade |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -746,135 +1096,36 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
     "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
+    "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
     "needToApplyParameterGroup": false,
     "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
-
----
-
-### Create DB Instance
-
-```http
-POST /v4.0/db-instances
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | Create DB Instance |
-
-#### Request
-
-| Name                    | Type | Format  | Required | Description                                                                                                           |
-|-------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------|
-| dbInstanceName          | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName | Body | String  | O        | Candidate name to identify DB instances                                                                               |
-| description             | Body | String  | X        | Additional information on DB instances                                                                                |
-| dbFlavorId              | Body | UUID    | O        | Identifier of DB instance specifications                                                                              |
-| dbVersion               | Body | Enum    | O        | DB engine type                                                                                                        |
-| dbPort                  | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                      |
-| dbUserName              | Body | String  | O        | DB user account name                                                                                                  |
-| dbPassword              | Body | String  | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                        |
-| parameterGroupId        | Body | UUID    | O        | Parameter group identifier                                                                                            |
-| dbSecurityGroupIds      | Body | Array   | X        | DB security group identifiers                                                                                         |
-| userGroupIds            | Body | Array   | X        | User group identifiers                                                                                                |
-| useHighAvailability     | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                 |
-| pingInterval            | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType                | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                         |
-| useDefaultNotification  | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                              |
-| useDeletionProtection   | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                              |
-| useSlowQueryAnalysis    | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                 |
-| authenticationPlugin                     | Body | Enum    | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-| network                                  | Body | Object  | O        | Network information objects                                                                                                                                                                                                                                               |
-| network.subnetId                         | Body | UUID    | O        | Subnet identifier                                                                                                                                                                                                                                                         |
-| network.usePublicAccess                  | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                  |
-| network.availabilityZone                 | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                                                                                                                                                             |
-| storage                                  | Body | Object  | O        | Storage information objects                                                                                                                                                                                                                                               |    
-| storage.storageType                      | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                                                                                                                                                                           |
-| storage.storageSize                      | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                             |
-| storage.storageAutoscale                     | Body | Object  | X  | Block Storage Auto Scaling Objects                                         |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | Whether to enable storage auto scaling                                     |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`        |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                           |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-| backup                                   | Body | Object  | O        | Backup information objects                                                                                                                                                                                                                                                |
-| backup.backupPeriod                      | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                |
-| backup.backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
 
 ---
 
@@ -886,1113 +1137,60 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### Required permissions
 
-| Permission Name                               | Description  |
-|-----------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
 
 #### Request
-
-| Name               | Type | Format  | Required | Description                                                                                                       |
-|--------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId       | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| dbInstanceName     | Body | String  | X        | Master name to identify DB instances                                                                              |
-| dbInstanceCandidateName| Body | String  | X        | Candidate name to identify DB instances                                                                               |
-| description        | Body | String  | X        | Additional information on DB instances                                                                            |
-| dbPort             | Body | Number  | X        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Whether to analyze slow queries |
-| dbFlavorId         | Body | UUID    | X        | Identifier of DB instance specifications                                                                          |
-| parameterGroupId   | Body | UUID    | X        | Parameter group identifier                                                                                        |
-| dbSecurityGroupIds | Body | Array   | X        | DB security group identifiers                                                                                     |
-| executeBackup      | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| useOnlineFailover  | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| waitReplicationDelay  | Body | Boolean | X  | Wait for replication lag to clear<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false` |
-| useReadOnly  | Body | Boolean | X  | Switch to read-only mode<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB instance
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | Delete DB instance |
-
-#### Request
-
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| deleteAutoBackup          | Body | Boolean  | X  | Delete automated backups<br/>- Default: `false` |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | Restart DB Instance |
-
-#### Request
-
-| Name              | Type | Format  | Required | Description                                                                                                       |
-|-------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| useOnlineFailover | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| executeBackup     | Body | Boolean | X        | Whether to execute backup at this time<br/>- Default: `false`                                                       |
-| waitReplicationDelay     | Body | Boolean | X  | Wait for replication lag to clear<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false`                                         |
-| useReadOnly     | Body | Boolean | X  | Switch to read-only mode<br/>Available only for DB instances with high availability enabled.<br/>- Default: `false`                                         |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-### Force Restart DB instance
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
-
-| Permission Name                                                 | Description               |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | Force Restart DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### Start DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
-
-| Permission Name                              | Description           |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | Start DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Stop DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
-
-| Permission Name                                         | Description            |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | Stop DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Replicate DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
-
-| Permission Name                                  | Description           |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
-
-#### Request
-
-| Name                                         | Type | Format  | Required | Description                                                                                                                 |
-|----------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O        | DB instance identifier                                                                                                      |
-| dbInstanceName                               | Body | String  | O        | Name to identify DB instances                                                                                               |
-| description                                  | Body | String  | X        | Additional information on DB instances                                                                                      |
-| dbFlavorId                                   | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                          |
-| dbPort                                       | Body | Number  | X        | DB port<br/>- Default: Original DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                  |
-| parameterGroupId                             | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                        |
-| dbSecurityGroupIds                           | Body | Array   | X        | DB security group identifiers<br/>- Default: Original DB instance value                                                     |
-| userGroupIds                                 | Body | Array   | X        | User group identifiers                                                                                                      |
-| useDefaultNotification                       | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                    |
-| useDeletionProtection                        | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                    |
-| useSlowQueryAnalysis                         | Body | Boolean | X        | Whether to analyze Slow query<br/>- Default: `true`                                                                                      |
-| network                                      | Body | Object  | O        | Network information objects                                                                                                 |
-| network.usePublicAccess                      | Body | Boolean | X        | External access is available or not<br/>- Default: Original DB instance value                                               |
-| network.availabilityZone                     | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                               |
-| storage                                      | Body | Object  | X        | Storage information objects                                                                                                 |    
-| storage.storageType                          | Body | Enum    | X        | Block Storage Type<br/>- Default: Original DB instance value<br/>- Example: `General SSD`                                   |
-| storage.storageSize                          | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Original DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`     |
-| storage.storageAutoscale                     | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                          |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                      |
-| storage.storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%)<br/>- Default: Original DB instance value<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Default: Original DB instance value<br/>- Maximum value: `4096`                        |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                  |
-| backup                                       | Body | Object  | X        | Backup information objects                                                                                                  |
-| backup.backupPeriod                          | Body | Number  | X        | Backup retention period<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X        | Query latency (sec)<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `21600`         |
-| backup.backupRetryCount                      | Body | Number  | X        | Number of backup retries<br/>- Default: Original DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `10`       |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                 |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`<br/>- Default: Original DB instance value                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour<br/>- Default: Original DB instance value |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Promote DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | Promote DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Rebuild DB Instance
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | Rebuild DB Instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
----
-
-### View Restoration Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                    | Type | Format   | Description                                                                                                                                                                                                          |
-|-----------------------------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | Oldest restorable time                                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | Most recent restorable time                                                                                                                                                                                          |
-| restorableBackups                       | Body | Array    | List of restorable backups                                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | Backup information objects                                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | Backup identifier                                                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | Backup name                                                                                                                                                                                                          |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | Whether to use table lock                                                                                                                                                                                            |
-| restorableBackups.backup.backupSize     | Body | Number   | Backup size                                                                                                                                                                                                          |
-| restorableBackups.backup.backupType     | Body | Enum     | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual                                                                                                                                     |
-| restorableBackups.backup.backupStatus   | Body | Enum     | Backup Status<br/>- `BACKING_UP`: Backup in progress<br/>- `COMPLETED`: Backup completed<br/>- `DELETING`: Backup being deleted<br/>- `DELETED`: Backup deleted<br/>- `ERROR`: Error occurred |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | Original DB instance identifier                                                                                                                                                                                      |
-| restorableBackups.backup.dbInstanceName | Body | String   | Original DB instance name                                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DB engine type                                                                                                                                                                                                       |
-| restorableBackups.backup.failoverCount  | Body | Number   | Number of failovers                                                                                                                                                                                                  |
-| restorableBackups.backup.binLogFileName | Body | String   | Binary log file name                                                                                                                                                                                                 |
-| restorableBackups.backup.binLogPosition | Body | Number   | Binary log file location                                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | Date and time of backup creation                                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | Date and time of backup renewal                                                                                                                                                                                      |
-| restorableBackups.restorableBinLogs     | Body | Array    | Binary log names that can be restored using the backup                                                                                                                                                               |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### View the last query to be restored
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Required permissions
-
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Common Request
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                                                        |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                                                             |
-| restoreType  | Query | Enum   | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored. |
-
-#### If restoreType is `TIMESTAMP`
-
-| Name        | Type  | Format   | Required | Description                                           |
-|-------------|-------|----------|----------|-------------------------------------------------------|
-| restoreYmdt | Query | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### If restoreType is `BINLOG`
-
-| Name           | Type  | Format | Required | Description                                     |
-|----------------|-------|--------|----------|-------------------------------------------------|
-| backupId       | Query | UUID   | O        | Identifier of the backup to use for restoration |
-| binLogFileName | Query | String | O        | Binary log name to use for restoration          |
-| binLogPosition | Query | Number | O        | Binary log location to use for restoration      |
-
-#### Response
-
-| Name         | Type | Format   | Description                                      |
-|--------------|------|----------|--------------------------------------------------|
-| executedYmdt | Body | DateTime | Query executed date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | Last executed query                              |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### Restoration
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
-
-| Permission Name                                            | Description           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
-
-#### Common Request
-
-| Name                                                | Type | Format  | Required | Description                                                                                                                                                                                                                                                                                   |
-|-----------------------------------------------------|------|---------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                                        |
-| restore                                             | Body | Object  | O        | Restoration information object                                                                                                                                                                                                                                                                |
-| restore.restoreType                                 | Body | Enum    | O        | Restoration type<br/>- `TIMESTAMP`: A point-in-time restoration type using the time within the restorable time<br/>- `BINLOG`: A point-in-time restoration type using a binary log location that can be restored.<br/>- `BACKUP`: Snapshot restoration type using a previously created backup |
-| dbInstanceName                                      | Body | String  | O        | Master name to identify DB instances                                                                                                                                                                                                                                                          |
-| dbInstanceCandidateName                             | Body | String  | O        | Candidate name to identify DB instances<br/>- Required to use high availability                                                                                                                                                                                                                                    |
-| description                                         | Body | String  | X        | Additional information on DB instances                                                                                                                                                                                                                                                        |
-| dbFlavorId                                          | Body | UUID    | X        | Identifier of DB instance specifications                                                                                                                                                                                                                                                      |
-| dbPort                                              | Body | Number  | X        | DB port<br/>- Default: Source DB instance value<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                                                                                                                                                                       |
-| parameterGroupId | Body | UUID    | X        | Parameter group identifier<br/>- Default: Source DB instance value                                                                                                                                                                                                                                        |
-| dbSecurityGroupIds                                  | Body | Array   | X        | DB security group identifiers                                                                                                                                                                                                                                                                 |
-| userGroupIds                                        | Body | Array   | X        | User group identifiers                                                                                                                                                                                                                                                                        |
-| useHighAvailability                                 | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                                                                                                                                                                       |
-| pingType                                            | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                                                                                                                                                  |
-| useDefaultNotification                              | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                                                                                                                                                                    |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                                                                                                                                                                       |
-| useSlowQueryAnalysis                                | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                                                                                                                                                                         |
-| network                                             | Body | Object  | X        | Network information objects                                                                                                                                                                                                                                                                   |
-| network.subnetId                                    | Body | UUID    | X        | Subnet identifier<br/>- Default: Source DB instance value                                                                                                                                                                                                                                                                             |
-| network.usePublicAccess                             | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                                                                                                                                                                    |
-| network.availabilityZone                            | Body | Enum    | X        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: Random selection                                                                                                                                                                                                                 |
-| storage                                             | Body | Object  | X        | Storage information objects                                                                                                                                                                                                                                                                   |
-| storage.storageType                                 | Body | Enum    | X        | Block Storage Type<br/>- Default: Source DB instance value<br/>- Example: `General SSD`                                                                                                                                                                                                                   |
-| storage.storageSize                                 | Body | Number  | X        | Block Storage Size (GB)<br/>- Default: Source DB instance value<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                                                                                                                                                                       |
-| storage.storageAutoscale                            | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                                                                                                                                                                            |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                                                                                                                                                                                    |
-| storage.storageAutoscale.threshold                  | Body | Number  | X        | Auto scale out conditions (%)<br/>- Default: Source DB instance value<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                                                                                                                                 |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Default: Source DB instance value<br/>- Maximum value: `4096`                                                                                                                                                                                                        |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Default: Source DB instance value<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                                                                                                                        |
-| backup                                              | Body | Object  | X        | Backup information objects                                                                                                                                                                                                                                                                    |
-| backup.backupPeriod                                 | Body | Number  | X        | Backup retention period<br/>- Default: Source DB instance value<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                       |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                    |
-| backup.backupRetryCount                             | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                   |
-| backup.backupSchedules                              | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                                                       |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | X        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | X        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour    |
-
-#### Request when restoring a point in time restoration using Timestamp (if restoreType is `TIMESTAMP`)
-
-| Name                | Type | Format   | Required | Description                                                                                                                                                                             |
-|---------------------|------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O        | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD)<br>Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry. |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
-
-| Name                          | Type | Format | Required | Description                                     |
-|-------------------------------|------|--------|----------|-------------------------------------------------|
-| restore.backupId              | Body | UUID   | O        | Identifier of the backup to use for restoration |
-| restore.binLog                | Body | Object | O        | Binary log information object                   |
-| restore.binLog.binLogFileName | Body | String | O        | Binary log name to use for restoration          |
-| restore.binLog.binLogPosition | Body | Number | O        | Binary log location to use for restoration      |
-
-* When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Request when restoring from backup (if restoreType is `BACKUP`)
-
-| Name             | Type | Format | Required                       | Description                                     |
-|------------------|------|--------|--------------------------------|-------------------------------------------------|
-| restore.backupId | Body | UUID   | O (if restoreType is `BACKUP`) | Identifier of the backup to use for restoration |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-### Restore from Object Storage
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
-
-#### Request
-
-| Name                                                | Type | Format  | Required | Description                                                                                                                                    |
-|-----------------------------------------------------|------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O        | Restoration information object                                                                                                                 |
-| restore.tenantId                                    | Body | String  | O        | Tenant ID of object storage where backups are stored                                                                                           |
-| restore.username                                    | Body | String  | O        | NHN Cloud account or IAM member ID                                                                                                             |
-| restore.password                                    | Body | String  | O        | API password for object storage where backups are stored                                                                                       |
-| restore.targetContainer                             | Body | String  | O        | Container for object storage where backups are stored                                                                                          |
-| restore.objectPath                                  | Body | String  | O        | Backup path stored in container                                                                                                                |
-| dbVersion                                           | Body | Enum    | O        | DB engine type                                                                                                                                 |
-| dbInstanceName                                      | Body | String  | O        | Master name to identify DB instances                                                                                  |
-| dbInstanceCandidateName                             | Body | String  | O        | Candidate name to identify DB instances                                                                               |
-| description                                         | Body | String  | X        | Additional information on DB instances                                                                                                         |
-| dbFlavorId                                          | Body | UUID    | O        | Identifier of DB instance specifications                                                                                                       |
-| dbPort                                              | Body | Number  | O        | DB port<br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                                                               |
-| parameterGroupId | Body | UUID    | O        | Parameter group identifier                                                                                                                     |
-| dbSecurityGroupIds                                  | Body | Array   | X        | DB security group identifiers                                                                                                                  |
-| userGroupIds                                        | Body | Array   | X        | User group identifiers                                                                                                                         |
-| useHighAvailability                                 | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                         |
-| pingInterval                                        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType                                            | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                     |
-| useDefaultNotification                              | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                      |
-| useDeletionProtection                               | Body | Boolean | X        | Whether to protect against deletion<br>Default: `false`                                                                                        |
-| useSlowQueryAnalysis                                | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                                             |
-| network                                             | Body | Object  | O        | Network information objects                                                                                                                    |
-| network.subnetId                                    | Body | UUID    | O        | Subnet identifier                                                                                                                              |
-| network.usePublicAccess                             | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                      |
-| network.availabilityZone                            | Body | Enum    | O        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`                                                 |
-| storage                                             | Body | Object  | O        | Storage information objects                                                                                                                    |
-| storage.storageType                                 | Body | Enum    | O        | Block Storage Type<br/>- Example: `General SSD`                                                                               |
-| storage.storageSize                                 | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: `20`<br/>- Maximum value: `2048`                                               |
-| storage.storageAutoscale                            | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                                                   |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                                                  |
-| storage.storageAutoscale.threshold                  | Body | Number  | X        | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                                                    |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                                                                                                              |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                                              |
-| backup                                              | Body | Object  | O        | Backup information objects                                                                                                                     |
-| backup.backupPeriod                                 | Body | Number  | O        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                               |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                              |
-| backup.backupRetryCount                             | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                         |
-| backup.useBackupLock                                | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                                                |
-| backup.backupSchedules                              | Body | Array   | O        | Scheduled auto backup list                                                                                                                                                                                                                                                                                    |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O        | Backup duration<br>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
-
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
-
----
-
-
-### Change DB Instance Deletion Protection Settings
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                         |
-|-----------------------|------|---------|----------|-------------------------------------|
-| dbInstanceId          | URL  | UUID    | O        | DB instance identifier              |
-| useDeletionProtection | Body | Boolean | O        | Whether to protect against deletion |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### High availability status
-
-| Status | Description |
-|----------------------------------|---------------------------------|
-| `CREATED` | High availability has been created |
-| `STABLE` | High availability is operating normally |
-| `PAUSING` | High availability is being paused |
-| `PAUSED` | High availability has been paused |
-| `PAUSED_DUE_TO_TASK` | High availability has been paused due to a task |
-| `DISABLE_MASTER_IN_REPLICATION` | High availability has been disabled due to detection of abnormal master replication |
-| `DISABLE_MHA_PROCESS` | The high availability process has been stopped |
-| `DISABLE_REPLICATION_STOP` | High availability has been disabled due to replication stoppage |
-| `DISABLE_REPLICATION_DELAY` | High availability has been disabled due to replication delay |
-| `MASTER_FAILURE_DETECTION` | A master failure has been detected |
-| `FAILOVER_STARTED` | Failover has started |
-| `FAILOVER_FAILED` | Failover has failed |
-| `FAILOVER_COMPLETED` | Failover has been completed |
-| `DELETED` | High availability has been deleted |
-
----
-
-### View High Availability Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
-
-| Permission | Description |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | View DB instance details |
-
-#### Request
-
-This API does not require a request body.
 
 | Name | Type | Format | Required | Description |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | X | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | Body | String | X | Candidate name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbVersion | Body | Enum | X | DB engine type |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries |
+| useDummy | Body | Boolean | X | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Switch to read-only mode<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### Response
 
 | Name | Type | Format | Description |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | Whether high availability is enabled |
-| haStatus | Body | Enum | High availability status |
-| pingInterval | Body | Number | Ping interval (seconds) |
-| pingType | Body | Enum | Ping type<br/>- `INSERT`<br/>- `SELECT` |
-
-<details><summary>Example</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
-
----
-
-### Modify High Availability
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | Modify high availability |
-
-#### Request
-
-| Name                | Type | Format  | Required | Description                                                                                          |
-|---------------------|------|---------|----------|------------------------------------------------------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O        | DB instance identifier                                                                               |
-| useHighAvailability | Body | Boolean | O        | Whether to use high availability                                                                     |
-| pingInterval        | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| pingType            | Body | Enum    | X        | Ping type when using high availability<br/>- `INSERT`<br/>- `SELECT`                                              |
-| dbInstanceCandidateName        | Body | String  | O  | Name to identify DB instances<br/>- Required for using high availability |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Restart High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | Restart high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Pause High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | Pause high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Recover High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required permissions
-
-| Permission Name                                     | Description           |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | Recover high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Separate High Availability
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required permissions
-
-| Permission Name                                    | Description           |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | Separate high availability |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View Storage Information
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                            | Description           |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                                 | Type | Format  | Description                                                                                                |
-|--------------------------------------|------|---------|------------------------------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | Block Storage Type                                                                                         |
-| storageSize                          | Body | Number  | Block Storage Size (GB)                                                                                    |
-| storageStatus                        | Body | Enum    | Data Storage Current Status<br/>- `DETACHED`: Detached<br/>- `ATTACHED`: Attached<br/>- `DELETED`: Deleted |
-| storageAutoscale                     | Body | Object  | Block Storage Auto Scaling Objects                                                                         |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling                                                                     |
-| storageAutoscale.threshold           | Body | Number  | Auto scale out conditions (%)                                                                              |
-| storageAutoscale.maxStorageSize      | Body | Number  | Auto scaling maximum size (GB)                                                                             |
-| storageAutoscale.cooldownTime        | Body | Number  | Auto scaling cooldown time (minutes)                                                                       |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2004,54 +1202,12 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
-
----
-
-### Modify Storage Information
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
-
-#### Request
-
-| Name                                 | Type | Format  | Required | Description                                                                                                       |
-|--------------------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O        | DB instance identifier                                                                                            |
-| storageSize                          | Body | Number  | O        | Block Storage Size (GB)<br/>- Minimum value: Current value<br/>- Maximum value: `2048`                            |
-| useOnlineFailover                    | Body | Boolean | X        | Whether to restart using failover<br/>Available only for DB instance using high availability<br/>- Default: `false` |
-| storageAutoscale                     | Body | Object  | X        |Block Storage Auto Scaling Objects                                                                                                 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling                                                                                                     |
-| storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95`                                                                       |
-| storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB)<br/>- Maximum value: `4096`                                                                                 |
-| storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440`                                                                 |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
 
 ---
 
@@ -2063,30 +1219,30 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Required permissions
 
-| Permission Name                                        | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Backup Information |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                              | Type | Format  | Description                |
-|-----------------------------------|------|---------|----------------------------|
-| backupPeriod                      | Body | Number  | Backup retention period    |
-| ftwrlWaitTimeout                  | Body | Number  | Query latency (sec)        |
-| backupRetryCount                  | Body | Number  | Number of backup retries   |
-| replicationRegion                 | Body | Enum    | Backup replication region  |
-| useBackupLock                     | Body | Boolean | Whether to use table lock  |
-| backupSchedules                   | Body | Array   | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime  | Body | String  | Backup started time        |
-| backupSchedules.backupWndDuration | Body | Enum    | Backup duration            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Body | Number | Query latency (sec) |
+| backupRetryCount | Body | Number | Number of backup retries |
+| replicationRegion | Body | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Body | Boolean | Whether to use table lock |
+| backupSchedules | Body | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Body | Time | Backup started time |
+| backupSchedules.backupWndDuration | Body | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>Example</summary>
 <p>
@@ -2099,14 +1255,14 @@ This API does not require a request body.
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2114,7 +1270,6 @@ This API does not require a request body.
 
 </p>
 </details>
-
 
 ---
 
@@ -2126,34 +1281,38 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Backup Information |
 
 #### Request
 
-| Name                              | Type | Format  | Required | Description                                                                                                                                                                                                                                                               |
-|-----------------------------------|------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O        | DB instance identifier                                                                                                                                                                                                                                                    |
-| backupPeriod                      | Body | Number  | X        | Backup retention period<br/>- Minimum value: `0`<br/>- Maximum value: `730`                                                                                                                                                                                               |
-| ftwrlWaitTimeout                  | Body | Number  | X        | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X        | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                                                                                                                                                                               |
-| useBackupLock                     | Body | Boolean | X        | Whether to use table lock                                                                                                                                                                                                                                                 |
-| backupSchedules                   | Body | Array   | X        | Scheduled auto backup list                                                                                                                                                                                                                                                |
-| backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
+| useBackupLock | Body | Boolean | X | Whether to use table lock |
+| backupSchedules | Body | Array | X | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
+| backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2164,12 +1323,1378 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### View Binary Log List
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | View binary log list |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| binLogs | Body | Array | BinLog file list |
+| binLogs.binLogFileName | Body | String | BinLog file name |
+| binLogs.binLogFileSize | Body | Number | BinLog file size (Byte) |
+| binLogs.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "binLogs": [
+        {
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 ---
 
+### Delete Binary Log
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | Delete binary log |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| lastBinLogFileName | Body | String | O | Last BinLog file name to delete (delete all files prior to this file) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "lastBinLogFileName": "mysql-bin.000010"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### View Certificate File List
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.List | View certificate file list |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| certificates | Body | Array | Certificate file list |
+| certificates.fileName | Body | String | Certificate file name |
+| certificates.certificateType | Body | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Body | Number | Certificate file size (Byte) |
+| certificates.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "certificates": [
+        {
+            "fileName": "fileName-example",
+            "certificateType": "CA_FILE",
+            "fileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export Certificate File
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.Export | Export certificate file |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| certificateTypes | Body | Array | O | Certificate type list to upload |
+| tenantId | Body | String | O | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM account ID |
+| password | Body | String | O | API password for object storage where certificate file is stored |
+| targetContainer | Body | String | O | Object storage container where certificate file is stored |
+| objectPath | Body | String | O | Path of the certificate file to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "certificateTypes": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Schema
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | List DB schemas |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DB schema list |
+| dbSchemas.dbSchemaId | Body | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | Body | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Body | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Create DB Schema
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | Create DB schema |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbSchemaName | Body | String | O | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB Schema
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | Delete DB schema |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbSchemaId | URL | UUID | O | DB schema identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### List DB Users
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | List DB Users |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB users |
+| dbUsers.dbUserId | Body | UUID | DB user identifier |
+| dbUsers.dbUserName | Body | String | DB user account name |
+| dbUsers.host | Body | String | DB user account host name |
+| dbUsers.authorityType | Body | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | Created date and time |
+| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Body | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Body | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Create DB User
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | Create DB User |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | Body | String | O | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Body | Enum | O | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete DB User
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | Delete DB User |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB User
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | Modify DB User |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbUserId | URL | UUID | O | DB user identifier |
+| dbPassword | Body | String | X | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Body | Enum | X | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Body | Enum | X | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Change DB Instance Deletion Protection Settings
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Change DB Instance Deletion Protection Settings |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Force Restart DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | Force Restart DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+This API does not return a response body.
+
+---
+### View High Availability Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View high availability information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | Whether high availability is enabled<br/>- Default: `false` |
+| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Body | Number | Ping interval (seconds) |
+| pingType | Body | String | Ping type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify High Availability
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | Modify high availability |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| useHighAvailability | Body | Boolean | O | Whether to use high availability |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+
+#### When Using High Availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Pause High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | Pause high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Repair High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | Repair high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | Restart high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Separate High Availability
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | Separate high availability |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### List Log Files
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | List log files |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | Log file list |
+| logFiles.logFileName | Body | String | Log file name |
+| logFiles.logFileType | Body | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | Log file size (Byte) |
+| logFiles.createdYmdt | Body | DateTime | Created date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Export Log File
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | Export log files |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | Log file name list |
+| tenantId | Body | String | O | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password for the object storage where log files are stored |
+| targetContainer | Body | String | O | Object storage container where log files are stored |
+| objectPath | Body | String | O | Path of the log file to be stored in the container |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of the requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Log File Contents
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | View log file contents |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| logFileName | URL | UUID | O | Log file name |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| content | Body | String | Log file contents (maximum 65533 bytes) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+### List DB Instance Maintenances
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | List DB instance maintenances |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### Response
+
+| Name | In | Type | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of maintenances |
+| maintenances | Body | Array | List of maintenances |
+| maintenances.maintenanceId | Body | UUID | Maintenance ID |
+| maintenances.dbInstanceId | Body | UUID | DB instance ID |
+| maintenances.category | Body | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| maintenances.description | Body | String | Maintenance description |
+| maintenances.type | Body | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| maintenances.payload | Body | Object | Payload according to maintenance type |
+| maintenances.required | Body | Boolean | Whether the maintenance is required |
+| maintenances.deadlineYmdt | Body | DateTime | Datetime when the maintenance is forcibly applied |
+| maintenances.status | Body | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
+| maintenances.addedYmdt | Body | DateTime | Datetime when the maintenance was scheduled |
+| maintenances.executionStartedYmdt | Body | DateTime | Maintenance start datetime |
+| maintenances.executionCompletedYmdt | Body | DateTime | Maintenance end datetime |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### Execute DB Instance Maintenance Now
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | Execute DB instance maintenance now |
+
+#### Request
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| configId | Body | String | O | Configuration ID |
+| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | Body | String | X | Maintenance description |
+| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | Body | String | O | Payload according to maintenance type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | In | Type | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Schedule DB Instance Maintenance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | Schedule DB instance maintenance |
+
+#### Request
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| configId | Body | String | O | Configuration ID |
+| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | Body | String | X | Maintenance description |
+| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | Body | String | O | Payload according to maintenance type |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Delete DB Instance Maintenance
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | Delete DB instance maintenance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | In | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| maintenanceId | URL | UUID | O | Maintenance ID |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ### List Network Information
 
 ```http
@@ -2178,31 +2703,31 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Required permissions
 
-| Permission Name                                       | Description            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | List DB Instance Details |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | List Network Information |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                   | Type | Format | Description                                                                                                                                                                                                |
-|------------------------|------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | Availability zone where DB instance will be created                                                                                                                                                        |
-| subnet                 | Body | Object | Subnet object                                                                                                                                                                                              |
-| subnet.subnetId        | Body | UUID   | Subnet identifier                                                                                                                                                                                          |
-| subnet.subnetName      | Body | UUID   | Name to identify subnets                                                                                                                                                                                   |
-| subnet.subnetCidr      | Body | UUID   | CIDR of subnet                                                                                                                                                                                             |
-| endPoints              | Body | Array  | List of access information                                                                                                                                                                                 |
-| endPoints.domain       | Body | String | Domain                                                                                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP address                                                                                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | Access information type<br>-`EXTERNAL`: External access domain<br>-`INTERNAL`: Internal access domain<br>-`PUBLIC`: (Deprecated) External access domain<br>-`PRIVATE`: (Deprecated) Internal access domain |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | Availability zone where DB instance will be created |
+| subnet | Body | Object | Subnet object |
+| subnet.subnetId | Body | UUID | Subnet identifier |
+| subnet.subnetName | Body | String | Name to identify subnets |
+| subnet.subnetCidr | Body | String | CIDR of subnet |
+| endPoints | Body | Array | List of access information |
+| endPoints.domain | Body | String | Domain |
+| endPoints.ipAddress | Body | String | IP address |
+| endPoints.endPointType | Body | String | Access information type |
 
 <details><summary>Example</summary>
 <p>
@@ -2216,15 +2741,15 @@ This API does not require a request body.
     },
     "availabilityZone": "kr-pub-a",
     "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2243,58 +2768,34 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Required permissions
 
-| Permission Name                               | Description           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | Modify DB Instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Network Information |
 
 #### Request
 
-| Name            | Type | Format  | Required | Description                         |
-|-----------------|------|---------|----------|-------------------------------------|
-| dbInstanceId    | URL  | UUID    | O        | DB instance identifier              |
-| usePublicAccess | Body | Boolean | O        | External access is available or not |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| usePublicAccess | Body | Boolean | O | External access is available or not |
 
-#### Response
+<details><summary>Example</summary>
+<p>
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Users
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
+```json
+{
+    "usePublicAccess": false
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                 | Description                  |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | List of users in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
+</p>
+</details>
 
 #### Response
 
-| Name                         | Type | Format   | Description                                                                                                                                                              |
-|------------------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB users                                                                                                                                                                 |
-| dbUsers.dbUserId             | Body | UUID     | DB user identifier                                                                                                                                                       |
-| dbUsers.dbUserName           | Body | String   | DB user account name                                                                                                                                                     |
-| dbUsers.host                 | Body | String   | DB user account host name                                                                                                                                                |
-| dbUsers.authorityType        | Body | Enum     | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| dbUsers.dbUserStatus         | Body | Enum     | DB user current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `UPDATING`: Modifying<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted                     |
-| dbUsers.authenticationPlugin | Body | Enum     | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                       |
-| dbUsers.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2306,15 +2807,365 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbUsers": [
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Promote DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | Promote DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Rebuild DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | Rebuild DB Instance |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### Replicate DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
+| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifier list |
+| userGroupIds | Body | Array | X | User group identifier list |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze Slow query<br/>- Default: `true` |
+| network | Body | Object | O | Network information object |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not |
+| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
+| storage | Body | Object | X | Storage information object |
+| storage.storageType | Body | Enum | X | Data storage type |
+| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | X | Backup information object |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock |
+| backup.backupSchedules | Body | Array | X | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Restart DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | Restart DB Instance |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
+| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Body | Boolean | X | Block write load<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Restoration Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Restoration Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
+| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
+| restorableBackups | Body | Array | List of restorable backups |
+| restorableBackups.backup | Body | Object | Backup information object |
+| restorableBackups.backup.backupId | Body | UUID | Backup identifier |
+| restorableBackups.backup.backupName | Body | String | Backup name |
+| restorableBackups.backup.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.backup.dbInstanceId | Body | UUID | Original DB instance identifier |
+| restorableBackups.backup.dbInstanceName | Body | String | Original DB instance name |
+| restorableBackups.backup.dbVersion | Body | Enum | DB engine type |
+| restorableBackups.backup.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | Backup size |
+| restorableBackups.backup.useBackupLock | Body | Boolean | Whether to use table lock |
+| restorableBackups.backup.failoverCount | Body | Number | Number of failovers |
+| restorableBackups.backup.binLogFileName | Body | String | Binary log file name |
+| restorableBackups.backup.binLogPosition | Body | Object | Binary log file location |
+| restorableBackups.backup.createdYmdt | Body | DateTime | Date and time of backup creation |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | Date and time of backup renewal |
+| restorableBackups.restorableBinLogs | Body | Array | Binary log names that can be restored using the backup |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
         {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
+            "backup": {
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "MYSQL_V8036",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
+            "restorableBinLogs": []
         }
     ]
 }
@@ -2325,153 +3176,32 @@ This API does not require a request body.
 
 ---
 
-### Create DB User
+### View the Last Query to Be Restored
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | Create users in DB instance |
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                              |
-|----------------------|------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                   |
-| dbUserName           | Body | String | O        | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32`                                                                                                |
-| dbPassword           | Body | String | O        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                           |
-| host                 | Body | String | O        | DB user account host name<br/>- Example: `1.1.1.%`                                                                                                                       |
-| authorityType        | Body | Enum   | O        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- Default: `NATIVE`(`ED25519` if not supported)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Modify DB User
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | Modify users in DB instance |
-
-#### Request
-
-| Name                 | Type | Format | Required | Description                                                                                                                                                             |
-|----------------------|------|--------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O        | DB instance identifier                                                                                                                                                  |
-| dbUserId             | URL  | UUID   | O        | DB user identifier                                                                                                                                                      |
-| dbPassword           | Body | String | X        | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256`                                                                                          |
-| authorityType        | Body | Enum   | X        | DB user permission type<br/>- `READ`: Permission to execute SELECT query<br/>- `CRUD`: Permission to execute DML query<br/>- `DDL`: Permission to execute DDL query<br/> |
-| authenticationPlugin | Body | Enum   | X        | Authentication Plugin<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB User
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | Delete users in DB instance |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View the Last Query to Be Restored |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbUserId     | URL  | UUID   | O        | DB user identifier     |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List DB Schema
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | List of schemas in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                                                                                                  |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB schema list                                                                                                               |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB schema identifier                                                                                                         |
-| dbSchemas.dbSchemaName   | Body | String   | DB schema name                                                                                                               |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB schema current status<br/>- `STABLE`: Created<br/>- `CREATING`: Creating<br/>- `DELETING`: Deleting<br/>- `DELETED`: Deleted |
-| dbSchemas.createdYmdt    | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | Query executed date |
+| lastQuery | Body | String | Last executed query |
 
 <details><summary>Example</summary>
 <p>
@@ -2483,163 +3213,165 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+### Restore DB Instance
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
+
+#### Common Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
+| dbPort | Body | Number | X | DB port |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Body | Object | X | Storage information object. If not specified, the storage settings of the source instance are applied. |
+| storage.storageType | Body | Enum | X | Storage type. If not specified, the storage type of the source instance is applied. |
+| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Body | Object | X | Network information object. If not specified, the network settings of the source instance are applied. |
+| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used. |
+| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created. If not specified, randomly selected. |
+| backup | Body | Object | X | Backup information object. If not specified, the backup settings of the source instance are applied. |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Body | Array | X | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| restore | Body | Object | O | Restoration information object |
+| restore.restoreType | Body | Enum | O | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
+| restore.binLog.binLogFileName | Body | String | X | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Body | Object | X | Binary log location to use for restoration |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
+| dbSecurityGroupIds | Body | Array | X | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
+| userGroupIds | Body | Array | X | User group identifier list |
+| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+
+#### When using high availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+#### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry.
+
+#### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+| restore.binLog | Body | Object | X | Binary log information object |
+
+When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
+
+#### Request when restoring from backup (if restoreType is `BACKUP`)
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
         }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### Create DB Schema
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | Create schemas in DB instance |
-
-#### Request
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaName | Body | String | O        | DB schema name         |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### Delete DB Schema
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | Delete schemas in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | URL  | UUID   | O        | DB instance identifier |
-| dbSchemaId   | URL  | UUID   | O        | DB schema identifier   |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### List Log Files
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | List of log files in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                         |
-|--------------|-------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                              |
-| logFileTypes | Query | Array  | X        | Log File type list<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### Response
-
-| Name                 | Type | Format   | Description                                                                                                                                                                                    |
-|----------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | Log File list                                                                                                                                                                                  |
-| logFiles.logFileName | Body | String   | Log File name                                                                                                                                                                                  |
-| logFiles.logFileType | Body | Enum     | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | Log File size(Byte)                                                                                                                                                                            |
-| logFiles.createdYmdt | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                             |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
     },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
         }
-    ]
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
 </p>
 </details>
 
----
-
-### View Log File contents
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### Required permissions
-
-| Permission Name                               | Description                           |
-|-----------------------------------------------|---------------------------------------|
-| RDSforMariaDB:DbInstanceLog.Get | View log file contents in DB instance |
-
-#### Request
-
-This API does not require a request body.
-
-| Name         | Type  | Format | Required | Description                                                                                                                                                                                    |
-|--------------|-------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O        | DB instance identifier                                                                                                                                                                         |
-| logFileName  | URL   | String | O        | Log File name                                                                                                                                                                                  |
-| logFileType  | Query | Enum   | O        | Log File type<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### Response
 
-| Name    | Type | Format | Description                            |
-|---------|------|--------|----------------------------------------|
-| content | Body | String | Log File contents(maximum 65533 Bytes) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2651,7 +3383,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "content": "..."
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2660,84 +3392,31 @@ This API does not require a request body.
 
 ---
 
-### Export Log File
+### Start DB Instance
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+POST /v4.0/db-instances/{dbInstanceId}/start
 ```
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | Export log files in DB instance |
-
-#### Request
-
-| Name            | Type | Format | Required | Description                                              |
-|-----------------|------|--------|----------|----------------------------------------------------------|
-| dbInstanceId    | URL  | UUID   | O        | DB instance identifier                                   |
-| logFileNames    | Body | Array  | O        | Log File name list<br/>- Minimum size: `1`               |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store log file            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                       |
-| password        | Body | String | O        | API password for object storage where log file is stored |
-| targetContainer | Body | String | O        | Object storage container where log file is stored        |
-| objectPath      | Body | String | O        | Log file path to be stored in container                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
-
----
-
-### View BinLog Lists
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
-
-#### Required Permission
-
-| Permission                                               | Description           |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | View BinLog lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | Start DB Instance |
 
 #### Request
 
 This API does not require a request body.
 
-| Name           | Type    | Format      | Required | Description                                                                                   |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID    | O  | DB instance identifier                                                                         |
-| deletable    | Query | Boolean | X  | Show only deletable BinLogs<br/>- `true`: Exclude latest BinLog<br/>- `false`: All<br/>- Default: `false` |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-| Name                     | Type   | Format       | Description                                |
-|------------------------|------|----------|-----------------------------------|
-| binLogs                | Body | Array    | BinLog file list                      |
-| binLogs.binLogFileName | Body | String   | BinLog file name                      |
-| binLogs.binLogFileSize | Body | Number   | BinLog file size (Byte)                |
-| binLogs.createdYmdt    | Body | DateTime | Created at(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2749,13 +3428,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "binLogs": [
-        {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2764,40 +3437,31 @@ This API does not require a request body.
 
 ---
 
-### Delete BinLog
+### Stop DB Instance
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+POST /v4.0/db-instances/{dbInstanceId}/stop
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission                                                | Description        |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | Delete BinLog |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | Stop DB Instance |
 
 #### Request
 
-| Name                 | Type   | Format     | Required | Description                                     |
-|--------------------|------|--------|----|----------------------------------------|
-| dbInstanceId       | URL  | UUID   | O  | DB instance identifier                           |
-| lastBinLogFileName | Body | String | O  | Last BinLog file name to delete (delete all files prior to this file) |
+This API does not require a request body.
 
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "lastBinLogFileName": "mysql-bin.000010"
-}
-```
-
-</p>
-</details>
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2808,6 +3472,67 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Storage Information
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | View Storage Information |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| storageType | Body | String | Data storage type |
+| storageSize | Body | Number | Data storage size (GB) |
+| storageStatus | Body | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+| storageAutoscale | Body | Object | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling |
+| storageAutoscale.threshold | Body | Number | Auto scale out conditions (%) |
+| storageAutoscale.maxStorageSize | Body | Number | Auto scaling maximum size (GB) |
+| storageAutoscale.cooldownTime | Body | Number | Auto scaling cooldown time (minutes) |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
     }
 }
 ```
@@ -2817,35 +3542,55 @@ This API does not return a response body.
 
 ---
 
-### View Certificate File Lists
+### Modify Storage Information
 
 ```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
 
-#### Required Permission
+#### Required permissions
 
-| Permission                                                    | Description           |
-|--------------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceCertificate.List | View certificate file lists |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | Modify Storage Information |
 
-#### Request
+#### Common Request
 
-This API does not require a request body.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB instance identifier |
+| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
+| storageAutoscale | Body | Object | X | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling |
 
-| Name           | Type  | Format   | Required | Description           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB instance identifier |
+#### When using storage auto scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
 
 #### Response
 
-| Name                           | Type   | Format       | Description                                                                           |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
-| certificates                 | Body | Array    | Certificate file list                                                                    |
-| certificates.fileName        | Body | String   | Certificate file name                                                                    |
-| certificates.certificateType | Body | Enum     | Certificate type<br/>- `CA_FILE`: CA certificate<br/>- `CERT_FILE`: certificate<br/>- `KEY_FILE`: Secret key |
-| certificates.fileSize        | Body | Number   | Certificate file size (Byte)                                                              |
-| certificates.createdYmdt     | Body | DateTime | Created at(YYYY-MM-DDThh:mm:ss.SSSTZD)                                            |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
 <details><summary>Example</summary>
 <p>
@@ -2857,14 +3602,7 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "certificates": [
-        {
-            "fileName": "ca.pem",
-            "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2872,57 +3610,6 @@ This API does not require a request body.
 </details>
 
 ---
-
-### Export a Certificate File
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
-#### Required Permission
-
-| Permission                                                      | Description          |
-|----------------------------------------------------------|-------------|
-| RDSforMariaDB:DbInstanceCertificate.Export | Export a certificate file |
-
-#### Request
-
-| Name               | Type   | Format     | Required | Description                                                                           |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
-| dbInstanceId     | URL  | UUID   | O  | DB instance identifier                                                                 |
-| certificateTypes | Body | Array  | O  | Certificate type to upload<br/>- `CA_FILE`: CA certificate<br/>- `CERT_FILE`: Certificate<br/>- `KEY_FILE`: Secret key |
-| tenantId         | Body | String | O  | Tenant ID of object storage to store certificate file                                                |
-| username         | Body | String | O  | NHN Cloud account or IAM account ID                                                    |
-| password         | Body | String | O  | API password for object storage where certificate file is stored                                              |
-| targetContainer  | Body | String | O  | Object storage container where certificate file is stored                                                  |
-| objectPath       | Body | String | O  |
-Certificate file path to be stored in container                                                         |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name    | Type   | Format   | Description          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | Identifier of requested task |
-
----
-
 ## Backups
 
 ### Backup Status
@@ -2935,123 +3622,38 @@ Certificate file path to be stored in container                                 
 | `DELETED`    | Backup is deleted       |
 | `ERROR`      | Error occurred          |
 
-### View Backup Details
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### Required Permission
-
-| Permission                                    | Description       |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | View backup details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name       | Type  | Format   | Required | Description      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | Backup identifier |
-
-#### Response
-
-| Name                      | Type   | Format       | Description              |
-|-------------------------|------|----------|-----------------|
-| backup                  | Body | Object   | Back details        |
-| backup.backupId         | Body | UUID     | Backup identifier         |
-| backup.regionCode       | Body | Enum     | Region code           |
-| backup.backupName       | Body | String   | Name to identify backups |
-| backup.backupStatus     | Body | Enum     | Backup current status       |
-| backup.dbInstanceId     | Body | UUID     | Source DB instance identifier |
-| backup.dbInstanceName   | Body | String   | Source DB instance name  |
-| backup.dbVersion        | Body | Enum     | DB engine version        |
-| backup.backupType       | Body | Enum     | Backup type                             |
-| backup.backupMethodType | Body | Enum     | Backup method                             |
-| backup.backupFileType   | Body | Enum     | Backup file type                          |
-| backup.backupSize       | Body | Number   | Backup size (Byte)                      |
-| backup.isReplicable     | Body | Boolean  | Replicable                          |
-| backup.binLogFileName   | Body | String   | Binary log file name                       |
-| backup.binLogPosition   | Body | Number   | Binary log location                        |
-| backup.createdYmdt      | Body | DateTime | Created at (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt      | Body | DateTime | Updated at (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
 ### Retrieve Backup List
 
 ```http
 GET /v4.0/backups
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Backup.List | Retrieve Backup List |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.List | Retrieve backup list |
 
 #### Request
 
 This API does not require a request body.
 
-| Name         | Type  | Format | Required | Description                                                                          |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1`                                         |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                                                     |
-| backupType   | Query | Enum   | X        | Backup type<br/>- `AUTO`: Automatic<br/>- `MANUAL`:  Manual<br/>- Default value: All |
-| dbInstanceId | Query | UUID   | X        | Original DB instance identifier                                                      |
-| dbVersion    | Query | Enum   | X        | DB engine type                                                                       |
-
 #### Response
 
-| Name                 | Type | Format   | Description                                         |
-|----------------------|------|----------|-----------------------------------------------------|
-| totalCounts          | Body | Number   | Number of all backup lists                          |
-| backups              | Body | Array    | Backup list                                         |
-| backups.backupId     | Body | UUID     | Backup identifier                                   |
-| backups.backupName   | Body | String   | Name to identify backups                            |
-| backups.backupStatus | Body | Enum     | Backup current status                               |
-| backups.dbInstanceId | Body | UUID     | Original DB instance identifier                     |
-| backups.dbVersion    | Body | Enum     | DB engine type                                      |
-| backups.backupType   | Body | Enum     | Backup type                                         |
-| backups.backupSize   | Body | Number   | Backup size (Byte)                                  |
-| createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of backup list entries |
+| backups | Body | Array | Backup list |
+| backups.backupId | Body | UUID | Backup identifier |
+| backups.backupName | Body | String | Name to identify the backup |
+| backups.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | Body | UUID | Source DB instance identifier |
+| backups.dbVersion | Body | Enum | DB engine type |
+| backups.utilVersion | Body | String | Utility version |
+| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | Backup size (Byte) |
+| backups.createdYmdt | Body | DateTime | Created date and time |
+| backups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3066,15 +3668,16 @@ This API does not require a request body.
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3091,91 +3694,184 @@ This API does not require a request body.
 POST /v4.0/backups
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Create | Create backup |
 
-#### Common Request
+#### Request
 
-| Name             | Type | Format | Required | Description                                                                                                             |
-|------------------|------|--------|----------|-------------------------------------------------------------------------------------------------------------------------|
-| backupName       | Body | String | O        | Backup name                                                                                                             |
-| backupMethodType | Body | Enum   | O        | Backup method type<br/>- `FULL`: Full backup<br/>- `INCREMENTAL`: Incremental backup <br/>- `SNAPSHOT`: Snapshot backup |
-
-#### If backupMethodType is `FULL`
-
-| Name         | Type | Format | Required | Description            |
-|--------------|------|--------|----------|------------------------|
-| dbInstanceId | Body | UUID   | O        | DB instance identifier |
-
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| baseBackupId | Body | UUID | X | Source backup identifier |
+| dbInstanceId | Body | UUID | X | DB instance identifier |
+| backupMethodType | Body | Enum | O | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-#### If backupMethodType is `INCREMENTAL`
-
-| Name         | Type | Format | Required | Description                |
-|--------------|------|--------|----------|----------------------------|
-| baseBackupId | Body | UUID   | O        | Baseline backup identifier |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-
-
-#### Snapshot Backup (if backupMethodType is `SNAPSHOT`)
-
-| Name           | Type   | Format   | Required | Description           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB instance identifier |
-
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Delete Backup
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | Delete backup |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### View Backup Details
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### Required Permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | View backup details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| backup | Body | Object | Backup details |
+| backup.backupId | Body | UUID | Backup identifier |
+| backup.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| backup.backupName | Body | String | Name to identify the backup |
+| backup.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backup.dbInstanceId | Body | UUID | Source DB instance identifier |
+| backup.dbInstanceName | Body | String | Source DB instance name |
+| backup.dbVersion | Body | Enum | DB engine version |
+| backup.utilVersion | Body | String | Utility version |
+| backup.backupType | Body | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | Backup size (Byte) |
+| backup.isReplicable | Body | Boolean | Whether replication is possible |
+| backup.binLogFileName | Body | String | Binary log file name |
+| backup.binLogPosition | Body | Object | Binary log location |
+| backup.createdYmdt | Body | DateTime | Created date and time |
+| backup.updatedYmdt | Body | DateTime | Modified date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "MYSQL_V8036",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3185,33 +3881,33 @@ POST /v4.0/backups
 POST /v4.0/backups/{backupId}/export
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Export | Export backup |
 
 #### Request
 
-| Name            | Type | Format | Required | Description                                            |
-|-----------------|------|--------|----------|--------------------------------------------------------|
-| backupId        | URL  | UUID   | O        | Backup identifier                                      |
-| tenantId        | Body | String | O        | Tenant ID of object storage to store backup            |
-| username        | Body | String | O        | NHN Cloud account or IAM member ID                     |
-| password        | Body | String | O        | API password for object storage where backup is stored |
-| targetContainer | Body | String | O        | Object storage container where backup is stored        |
-| objectPath      | Body | String | O        | Backup path to be stored in container                  |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | Body | String | O | NHN Cloud account or IAM member ID |
+| password | Body | String | O | API password of the object storage where the backup will be stored |
+| targetContainer | Body | String | O | Object storage container where the backup will be stored |
+| objectPath | Body | String | O | Path of the backup to be stored in the container |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3220,9 +3916,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3232,72 +3945,97 @@ POST /v4.0/backups/{backupId}/export
 POST /v4.0/backups/{backupId}/restore
 ```
 
-#### Required permissions
+#### Required Permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------|---------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:Backup.Restore | Restore backup |
 
-#### Request
+#### Common Request
 
-| Name                                         | Type | Format  | Required | Description                                                                                                                               |
-|----------------------------------------------|------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O        | Backup identifier                                                                                                                         |
-| dbInstanceName                               | Body | String  | O        | Master name to identify DB instances                                                                                                      |
-| dbInstanceCandidateName                      | Body | String  | X        | Candidate name to identify DB instances                                                                                                   |
-| description                                  | Body | String  | X        | Additional information on DB instances                                                                                                    |
-| dbFlavorId                                   | Body | UUID    | X        | Identifier of DB instance specifications<br/>- Default: Original DB instance value                                                                                                  |
-| dbPort                                       | Body | Integer | X        | DB port <br/> - Default: Source DB instance value     <br/>- Minimum value: `3306`<br/>- Maximum value: `43306`                           |
-| parameterGroupId                             | Body | UUID    | X        | Parameter group identifier<br/>- Default: Original DB instance value                                                                                                                |
-| dbSecurityGroupIds                           | Body | Array   | X        | DB security group identifiers                                                                                                             |
-| userGroupIds                                 | Body | Array   | X        | User group identifiers                                                                                                                    |
-| useHighAvailability                          | Body | Boolean | X        | Whether to use high availability<br/>- Default: `false`                                                                                     |
-| pingInterval                                 | Body | Number  | X        | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600`                     |
-| pingType                                     | Body | Enum    | X        | Ping type when using high availability<br/>- Default: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                               |
-| useDefaultNotification                       | Body | Boolean | X        | Whether to use default notification<br/>- Default: `false`                                                                                  |
-| useDeletionProtection                        | Body | Boolean | X        | Whether to protect against deletion<br/>- Default: `false`                                                                                  | 
-| useSlowQueryAnalysis                         | Body | Boolean | X        | Whether to analyze slow queries<br/>- Default: `true`                                                                                     |
-| network                                      | Body | Object  | X        | Network information objects                                                                                                               |
-| network.subnetId                             | Body | UUID    | X        | Subnet identifier<br/>- Default: Original DB instance value                                                                                                                         |
-| network.usePublicAccess                      | Body | Boolean | X        | External access is available or not<br/>- Default: `false`                                                                                  |
-| network.availabilityZone                     | Body | Enum    | X        | Availability zone where DB instance will be created<br/>- Example: `kr-pub-a`<br/>- Default: Random selection                             |
-| storage                                      | Body | Object  | X        | Storage information objects                                                                                                               |
-| storage.storageType                          | Body | Enum    | X        | Block Storage Type <br/> - Default: Source DB instance value     <br/>- Example: `General SSD`                                            |
-| storage.storageSize                          | Body | Number  | X        | Block Storage Size (GB) <br/> - Default: Source DB instance value     <br/>- Minimum value: `20`<br/>- Maximum value: `2048`              |
-| storage.storageAutoscale                     | Body | Object  | X        | Block Storage Auto Scaling Objects                                                                                                        |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X        | Whether to enable storage auto scaling        <br/> - Default: Source DB instance value                                                   |
-| storage.storageAutoscale.threshold           | Body | Number  | X        | Auto scale out conditions (%) <br/> - Default: Source DB instance value     <br/>- Minimum value: `50`<br/>- Maximum value: `95`          |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X        | Auto scaling maximum size (GB) <br/> - Default: Source DB instance value     <br/>- Maximum value: `4096`                                 |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X        | Auto scaling cooldown time (minutes) <br/> - Default: Source DB instance value     <br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-| backup                                       | Body | Object  | X        | Backup information objects                                                                                                                |
-| backup.backupPeriod                          | Body | Number  | X        | Backup retention period <br/> - Default: Source DB instance value     <br/>- Minimum value: `0`<br/>- Maximum value: `730`                |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X        | Query latency (sec)<br/>- Default: `1800`<br/>- Minimum value: `0`<br/>- Maximum value: `21600`                                                |
-| backup.backupRetryCount                      | Body | Number  | X        | Number of backup retries<br/>- Default: `0`<br/>- Minimum value: `0`<br/>- Maximum value: `10`                                              |
-| backup.useBackupLock                     | Body | Boolean | X        | Whether to use table lock<br/>- Default: `true`                                                                                                                                                                                                                             |
-| backup.backupSchedules                   | Body | Array   | X        | Scheduled auto backup list<br/>- Default: Original DB instance value                                                                                                                                                                                                                                                |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O        | Backup started time<br/>- Example: `00:00:00`                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O        | Backup duration<br/>Auto backup proceeds within duration from backup start time.<br/>- `HALF_AN_HOUR`: 30 minutes<br/>- `ONE_HOUR`: 1 hour<br/>- `ONE_HOUR_AND_HALF`: 1.5 hour<br/>- `TWO_HOURS`: 2 hour<br/>- `TWO_HOURS_AND_HALF`: 2.5 hour<br/>- `THREE_HOURS`: 3 hour |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | Body | UUID | X | DB instance specification identifier. If not specified, the source instance value is used |
+| dbPort | Body | Number | X | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the source instance value is used |
+| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Body | Object | X | Network information object. If not specified, the source instance value is used |
+| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used |
+| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
+| storage | Body | Object | X | Storage information object. If not specified, the source instance value is used |
+| storage.storageType | Body | Enum | X | Storage type. If not specified, the source instance value is used |
+| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object. If not specified, the source instance value is used |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Body | Object | X | Backup information object. If not specified, the source instance backup settings are used |
+| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Body | Number | X | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Body | Boolean | X | Whether to use table lock. If not specified, the source instance value is used |
+| backup.backupSchedules | Body | Array | X | Backup schedule list. If not specified, the source instance value is used |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using High Availability
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
         "storageType": "General SSD",
-        "storageSize": 20
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -3313,50 +4051,38 @@ POST /v4.0/backups/{backupId}/restore
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
----
+<details><summary>Example</summary>
+<p>
 
-### Delete Backup
-
-```http
-DELETE /v4.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | Delete backup |
-
-#### Request
-
-This API does not require a request body.
-
-| Name     | Type | Format | Required | Description       |
-|----------|------|--------|----------|-------------------|
-| backupId | URL  | UUID   | O        | Backup identifier |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+</p>
+</details>
 
 ---
-
 ## DB Security Group
 
 ### DB Security Group Progress
 
-| Status          | Description         |
-|-----------------|---------------------|
-| `NONE`          | No task in progress |
-| `CREATING_RULE` | Creating rules      |
-| `UPDATING_RULE` | Modifying rules     |
-| `DELETING_RULE` | Deleting rules      |
+| Status              | Description             |
+|---------------------|-------------------------|
+| `NONE`              | No task in progress     |
+| `CREATING_RULE`     | Creating rules          |
+| `UPDATING_RULE`     | Modifying rules         |
+| `DELETING_RULE`     | Deleting rules          |
 
 ### List DB Security Groups
 
@@ -3366,29 +4092,26 @@ GET /v4.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------------|----------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.List | List DB security groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|-------|----------|----|-------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1` |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                     |
 #### Response
 
-| Name                                 | Type | Format   | Description                                         |
-|--------------------------------------|------|----------|-----------------------------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB security groups                                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB security group identifier                        |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | Name to identify DB instances                       |
-| dbSecurityGroups.description         | Body | String   | Additional information on DB security group         |
-| dbSecurityGroups.progressStatus      | Body | Enum     | Current status of DB security group                 |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of DB security groups |
+| dbSecurityGroups | Body | Array | DB security groups |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | Name to identify the DB security group |
+| dbSecurityGroups.description | Body | String | Additional information on DB security group |
+| dbSecurityGroups.progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | Created date and time |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3400,102 +4123,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List DB Security Group Details
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | List DB security group details
- |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
-
-#### Response
-
-| Name                | Type | Format   | Description                                                                                                                                              |
-|---------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB security group identifier                                                                                                                             |
-| dbSecurityGroupName | Body | String   | Name to identify DB instances                                                                                                                            |
-| description         | Body | String   | Additional information on DB security group                                                                                                              |
-| progressStatus      | Body | Enum     | Current status of DB security group                                                                                                                      |
-| rules               | Body | Array    | DB security group rules                                                                                                                                  |
-| rules.ruleId        | Body | UUID     | DB security group rule identifier                                                                                                                        |
-| rules.description   | Body | String   | Additional information on DB security group rule                                                                                                         |
-| rules.direction     | Body | Enum     | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                |
-| rules.etherType     | Body | Enum     | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                         |
-| rules.port          | Body | Object   | Port object                                                                                                                                              |
-| rules.port.portType | Body | Enum     | Port type<br/>- `DB_PORT`: Sets to DB instance port value.<br/>- `PORT`: Sets to specified port value.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number   | Minimum port range                                                                                                                                       |
-| rules.port.maxPort  | Body | Number   | Maximum port range                                                                                                                                       |
-| rules.cidr          | Body | String   | Remote source for traffic to allow                                                                                                                       |
-| rules.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| rules.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-| createdYmdt         | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                       |
-| updatedYmdt         | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                      |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
 }
 ```
 
@@ -3512,46 +4150,44 @@ POST /v4.0/db-security-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Create | Create DB security group |
 
 #### Request
 
-| Name                | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|---------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O        | Name to identify DB instances                                                                                                                                                                                                    |
-| description         | Body | String | X        | Additional information on DB security group                                                                                                                                                                                      |
-| rules               | Body | Array  | O        | DB security group rules                                                                                                                                                                                                          |
-| rules.description   | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| rules.etherType     | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| rules.cidr          | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-| rules.port          | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| rules.port.portType | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to the specified port value. `minPort` and `maxPort` must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| rules.port.minPort  | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| rules.port.maxPort  | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+| rules | Body | Array | O | DB security group rules |
+| rules.direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Body | Object | O | Port object |
+| rules.port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | Additional information on DB security group rule |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
@@ -3562,48 +4198,9 @@ POST /v4.0/db-security-groups
 
 #### Response
 
-| Name              | Type | Format | Description                  |
-|-------------------|------|--------|------------------------------|
-| dbSecurityGroupId | Body | UUID   | DB security group identifier |
-
----
-
-### Modify DB Security Group
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | Modify DB security group |
-
-#### Request
-
-| Name                | Type | Format | Required | Description                                 |
-|---------------------|------|--------|----------|---------------------------------------------|
-| dbSecurityGroupId   | URL  | UUID   | O        | DB security group identifier                |
-| dbSecurityGroupName | Body | String | X        | Name to identify DB instances               |
-| description         | Body | String | X        | Additional information on DB security group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DB security group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -3614,13 +4211,13 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
 
 ---
 
@@ -3632,21 +4229,66 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Delete | Delete DB security group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name              | Type | Format | Required | Description                  |
-|-------------------|------|--------|----------|------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List DB Security Group Details
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | List DB security group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DB security group identifier |
+| dbSecurityGroupName | Body | String | Name to identify the DB security group |
+| description | Body | String | Additional information on DB security group |
+| progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| rules | Body | Array | DB security group rules |
+| rules.ruleId | Body | UUID | DB security group rule identifier |
+| rules.description | Body | String | Additional information on DB security group rule |
+| rules.direction | Body | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Body | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Body | Object | Port object |
+| rules.port.portType | Body | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Body | Number | Minimum port range |
+| rules.port.maxPort | Body | Number | Maximum port range |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | Created date and time |
+| rules.updatedYmdt | Body | DateTime | Modified date and time |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3657,7 +4299,114 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify DB Security Group
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | Modify DB security group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Delete DB Security Group Rule
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | Delete DB security group rule |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -3674,26 +4423,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Required permissions
 
-| Permission Name                                        | Description           |
-|--------------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Create | Create DB security group rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to specified port value. The `minPort` and `maxPort` values must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Body | Object | O | Port object |
+| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 <details><summary>Example</summary>
 <p>
@@ -3703,11 +4449,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3716,9 +4463,26 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3730,27 +4494,24 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Required permissions
 
-| Permission Name                                        | Description           |
-|--------------------------------------------------------|------------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Modify | Modify DB security group rule |
 
 #### Request
 
-| Name              | Type | Format | Required | Description                                                                                                                                                                                                                      |
-|-------------------|------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O        | DB security group identifier                                                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O        | DB security group rule identifier                                                                                                                                                                                                |
-| description       | Body | String | X        | Additional information on DB security group rule                                                                                                                                                                                 |
-| direction         | Body | Enum   | O        | Communication direction<br/>- `INGRESS`: Inbound<br/>- `EGRESS`: Outbound                                                                                                                                                        |
-| etherType         | Body | Enum   | O        | Ether type<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                                                                 |
-| port              | Body | Object | O        | Port object                                                                                                                                                                                                                      |
-| port.portType     | Body | Enum   | O        | Port type<br/>- `DB_PORT`: Sets to DB instance port value. Values for `minPort` and `maxPort` are not required.<br/>- `PORT`: Sets to specified port value. The `minPort` and `maxPort` values must be the same.<br/>- `PORT_RANGE`: Sets to specified port range. |
-| port.minPort      | Body | Number | X        | Minimum port range<br/>- Minimum value: 1                                                                                                                                                                                        |
-| port.maxPort      | Body | Number | X        | Maximum port range<br/>- Maximum value: 65535                                                                                                                                                                                    |
-| cidr              | Body | String | O        | Remote source for traffic to allow<br/>- Example: `1.1.1.1/32`                                                                                                                                                                   |
-
-> [Caution]
-> DB port cannot be set to transmit direction.
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Body | Object | O | Port object |
+| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 <details><summary>Example</summary>
 <p>
@@ -3760,9 +4521,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "DB_PORT"
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3771,42 +4535,29 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Response
 
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | Identifier of requested task |
 
----
+<details><summary>Example</summary>
+<p>
 
-### Delete DB Security Group Rule
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | Delete DB security group rule |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format | Required | Description                        |
-|-------------------|-------|--------|----------|------------------------------------|
-| dbSecurityGroupId | URL   | UUID   | O        | DB security group identifier       |
-| ruleIds           | Query | Array  | O        | DB security group rule identifiers |
-
-#### Response
-
-| Name  | Type | Format | Description                  |
-|-------|------|--------|------------------------------|
-| jobId | Body | UUID   | Identifier of requested task |
+</p>
+</details>
 
 ---
-
-## Parameter group
+## Parameter Groups
 
 ### List Parameter Groups
 
@@ -3816,30 +4567,28 @@ GET /v4.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-------------------------------------------------|---------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.List | List parameter groups |
 
 #### Request
 
 This API does not require a request body.
 
-| Name      | Type  | Format | Required | Description    |
-|-----------|-------|--------|----------|----------------|
-| dbVersion | Query | Enum   | X        | DB engine type |
-
 #### Response
 
-| Name                                 | Type | Format   | Description                                                                                 |
-|--------------------------------------|------|----------|---------------------------------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | Parameter groups                                                                            |
-| parameterGroups.parameterGroupId     | Body | UUID     | Parameter group identifier                                                                  |
-| parameterGroups.parameterGroupName   | Body | String   | Name to identify parameter groups                                                           |
-| parameterGroups.description          | Body | String   | Additional information on parameter group                                                   |
-| parameterGroups.dbVersion            | Body | Enum     | DB engine type                                                                              |
-| parameterGroups.parameterGroupStatus | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply |
-| parameterGroups.createdYmdt          | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                          |
-| parameterGroups.updatedYmdt          | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of parameter groups |
+| parameterGroups | Body | Array | Parameter groups |
+| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
+| parameterGroups.description | Body | String | Additional information on parameter group |
+| parameterGroups.dbVersion | Body | Enum | DB engine type |
+| parameterGroups.parameterGroupType | Body | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
+| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -3851,15 +4600,17 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3867,88 +4618,6 @@ This API does not require a request body.
 
 </p>
 </details>
-
-
----
-
-### List Parameter Group Details
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                | Description           |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | List parameter group details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-| Name                          | Type | Format   | Description                                                                                                                                           |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | Parameter group identifier                                                                                                                            |
-| parameterGroupName            | Body | String   | Name to identify parameter groups                                                                                                                     |
-| description                   | Body | String   | Additional information on parameter group                                                                                                             |
-| dbVersion                     | Body | Enum     | DB engine type                                                                                                                                        |
-| parameterGroupStatus          | Body | Enum     | Parameter group current status<br/>- `STABLE`: Applied<br/>- `NEED_TO_APPLY`: Need to apply                                                           |
-| parameters                    | Body | Array    | Parameter list                                                                                                                                        |
-| parameters.parameterId        | Body | UUID     | Parameter identifier                                                                                                                                  |
-| parameters.parameterFileGroup | Body | Enum     | Parameter file group type<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                                                          |
-| parameters.parameterName      | Body | String   | Parameter name                                                                                                                                        |
-| parameters.fileParameterName  | Body | String   | Parameter file name                                                                                                                                   |
-| parameters.value              | Body | String   | Current value                                                                                                                                         |
-| parameters.defaultValue       | Body | String   | Default value                                                                                                                                         |
-| parameters.allowedValue       | Body | String   | Permitted values                                                                                                                                      |
-| parameters.updateType         | Body | Enum     | Modify type<br/>- `VARIABLE`: Modifiable any time<br/>- `CONSTANT`: Not modifiable<br/>- `INIT_VARIABLE`: Only modifiable when DB instance is created |
-| parameters.applyType          | Body | Enum     | Apply type<br/>- `SESSION`: Apply session<br/>- `FILE`: Apply setting file (restart required)<br/>- `BOTH`: All (restart required)                    |
-| createdYmdt                   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| updatedYmdt                   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                   |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
 
 ---
 
@@ -3960,25 +4629,26 @@ POST /v4.0/parameter-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Create | Create parameter group |
 
 #### Request
 
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-| dbVersion          | Body | Enum   | O        | DB engine type                            |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | Body | Enum | O | DB engine type |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -3987,88 +4657,9 @@ POST /v4.0/parameter-groups
 
 #### Response
 
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Copy Parameter Group
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | Copy parameter group |
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | O        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name             | Type | Format | Description                |
-|------------------|------|--------|----------------------------|
-| parameterGroupId | Body | UUID   | Parameter group identifier |
-
----
-
-### Modify Parameter Group
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
-
-#### Request
-
-| Name               | Type | Format | Required | Description                               |
-|--------------------|------|--------|----------|-------------------------------------------|
-| parameterGroupId   | URL  | UUID   | O        | Parameter group identifier                |
-| parameterGroupName | Body | String | X        | Name to identify parameter groups         |
-| description        | Body | String | X        | Additional information on parameter group |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4079,107 +4670,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify Parameter
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
-
-#### Request
-
-| Name                           | Type | Format | Required | Description                |
-|--------------------------------|------|--------|----------|----------------------------|
-| parameterGroupId               | URL  | UUID   | O        | Parameter group identifier |
-| modifiedParameters             | Body | Array  | O        | Parameters to change       |
-| modifiedParameters.parameterId | Body | UUID   | O        | Parameter identifier       |
-| modifiedParameters.value       | Body | String | O        | Parameter value to change  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### Reset Parameter Group
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | Reset parameter group |
-
-#### Request
-
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4196,21 +4688,65 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|---------------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Delete | Delete parameter group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name             | Type | Format | Required | Description                |
-|------------------|------|--------|----------|----------------------------|
-| parameterGroupId | URL  | UUID   | O        | Parameter group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List Parameter Group Details
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | List parameter group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+| parameterGroupName | Body | String | Name to identify parameter groups |
+| description | Body | String | Additional information on parameter group |
+| dbVersion | Body | Enum | DB engine type |
+| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Body | Array | Parameter list |
+| parameters.parameterId | Body | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Body | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | Parameter name |
+| parameters.fileParameterName | Body | String | Parameter file name |
+| parameters.value | Body | String | Current value |
+| parameters.defaultValue | Body | String | Default value |
+| parameters.allowedValue | Body | String | Permitted values |
+| parameters.updateType | Body | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4221,7 +4757,27 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4230,6 +4786,172 @@ This API does not return a response body.
 
 ---
 
+### Modify Parameter Group
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Copy Parameter Group
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | Copy parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | Parameter group identifier |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### Modify Parameter
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | Modify parameter group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | Parameters to change |
+| modifiedParameters.parameterId | Body | UUID | O | Parameter identifier |
+| modifiedParameters.value | Body | String | O | Parameter value to change |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+### Reset Parameter Group
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | Reset parameter group |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## User Group
 
 ### List User Groups
@@ -4240,8 +4962,8 @@ GET /v4.0/user-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|--------------------------------------------|--------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.List | List user groups |
 
 #### Request
@@ -4250,13 +4972,14 @@ This API does not require a request body.
 
 #### Response
 
-| Name                     | Type | Format   | Description                                         |
-|--------------------------|------|----------|-----------------------------------------------------|
-| userGroups               | Body | Array    | User Groups                                         |
-| userGroups.userGroupId   | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName | Body | String   | Name to identify user groups                        |
-| userGroups.createdYmdt   | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| userGroups.updatedYmdt   | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of user groups |
+| userGroups | Body | Array | User group list |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| userGroups.createdYmdt | Body | DateTime | Created date and time |
+| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4268,74 +4991,15 @@ This API does not require a request body.
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### List User Group Details
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | List user group details |
-
-#### Request
-
-This API does not require a request body.
-
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
-
-#### Response
-
-| Name              | Type | Format   | Description                                                                                                                                            |
-|-------------------|------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | User group identifier                                                                                                                                  |
-| userGroupName     | Body | String   | Name to identify user groups                                                                                                                           |
-| userGroupTypeCode | Body | Enum     | User group type    <br /> `ENTIRE`: User group including all project members <br /> `INDIVIDUAL_MEMBER`: User group including specific project members |
-| members           | Body | Array    | Project member list                                                                                                                                    |
-| members.memberId  | Body | UUID     | Project member identifier                                                                                                                              |
-| createdYmdt       | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt       | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4352,34 +5016,26 @@ POST /v4.0/user-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Create | Create user group |
 
 #### Request
 
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupName | Body | String  | O        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | O        | Project member identifiers <br /> Ignored when `selectAll` is true          |
-| selectAll     | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | O | List of project member identifiers |
+| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4388,52 +5044,9 @@ POST /v4.0/user-groups
 
 #### Response
 
-| Name        | Type | Format | Description           |
-|-------------|------|--------|-----------------------|
-| userGroupId | Body | UUID   | User group identifier |
-
----
-
-### Modify User Group
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | Modify user group|
-
-#### Request
-
-| Name          | Type | Format  | Required | Description                                                                 |
-|---------------|------|---------|----------|-----------------------------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O        | User group identifier                                                       |
-| userGroupName | Body | String  | X        | Name to identify user groups                                                |
-| memberIds     | Body | Array   | X        | Project member identifiers                                                  |
-| selectAll     | Body | Boolean | X        | All project members or not <br /> If true, the group is set for all members |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4444,7 +5057,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4461,19 +5075,55 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Delete | Delete user group |
 
 #### Request
 
-| Name        | Type | Format | Required | Description           |
-|-------------|------|--------|----------|-----------------------|
-| userGroupId | URL  | UUID   | O        | User group identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### List User Group Details
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | List user group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | User group identifier |
+| userGroupName | Body | String | Name to identify user groups |
+| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | Project member list |
+| members.memberId | Body | UUID | Project member identifier |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4484,7 +5134,17 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4493,6 +5153,46 @@ This API does not return a response body.
 
 ---
 
+### Modify User Group
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | Modify user group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | Name to identify user groups |
+| memberIds | Body | Array | X | List of project member identifiers |
+| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## Notification Group
 
 ### List Notification Groups
@@ -4503,8 +5203,8 @@ GET /v4.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------------------|-------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.List | List notification groups |
 
 #### Request
@@ -4513,16 +5213,16 @@ This API does not require a request body.
 
 #### Response
 
-| Name                                     | Type | Format   | Description                                         |
-|------------------------------------------|------|----------|-----------------------------------------------------|
-| notificationGroups                       | Body | Array    | Notification Groups                                 |
-| notificationGroups.notificationGroupId   | Body | UUID     | Notification group identifier                       |
-| notificationGroups.notificationGroupName | Body | String   | Name to identify notification groups                |
-| notificationGroups.notifyEmail           | Body | Boolean  | Whether to be notified by email                     |
-| notificationGroups.notifySms             | Body | Boolean  | Whether to be notified by SMS                       |
-| notificationGroups.isEnabled             | Body | Boolean  | Indicates whether the flavor is enabled             |
-| notificationGroups.createdYmdt           | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| notificationGroups.updatedYmdt           | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | Notification group list |
+| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Body | Boolean | Whether enabled |
+| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
+| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4536,90 +5236,15 @@ This API does not require a request body.
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### View Notification Group Details
-
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | List notification groups |
-
-#### Request
-
-This API does not require a request body.
-
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
-
-#### Response
-
-| Name                       | Type | Format   | Description                                         |
-|----------------------------|------|----------|-----------------------------------------------------|
-| notificationGroupId        | Body | UUID     | Notification group identifier                       |
-| notificationGroupName      | Body | String   | Name to identify notification groups                |
-| notifyEmail                | Body | Boolean  | Whether to be notified by email                     |
-| notifySms                  | Body | Boolean  | Whether to be notified by SMS                       |
-| isEnabled                  | Body | Boolean  | Indicates whether the flavor is enabled             |
-| dbInstances                | Body | Array    | DB Instances to monitor                             |
-| dbInstances.dbInstanceId   | Body | UUID     | DB instance identifier                              |
-| dbInstances.dbInstanceName | Body | String   | Name to identify DB instances                       |
-| userGroups                 | Body | Array    | User Groups                                         |
-| userGroups.userGroupId     | Body | UUID     | User group identifier                               |
-| userGroups.userGroupName   | Body | String   | Name to identify user groups                        |
-| createdYmdt                | Body | DateTime | Created date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)  |
-| updatedYmdt                | Body | DateTime | Modified date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
 }
 ```
 
@@ -4636,83 +5261,32 @@ POST /v4.0/notification-groups
 
 #### Required permissions
 
-| Permission Name                                      | Description           |
-|------------------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Create | Create notification group |
 
 #### Request
 
-| Name                  | Type | Format  | Required | Description                                                 |
-|-----------------------|------|---------|----------|-------------------------------------------------------------|
-| notificationGroupName | Body | String  | O        | Name to identify notification groups                        |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email<br/>- Default: `true`         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS<br/>- Default: `true`           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled<br/>- Default: `true` |
-| dbInstanceIds         | Body | Array   | O        | DB instance identifiers to monitor                          |
-| userGroupIds          | Body | Array   | O        | User group identifiers                                      |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Body | Array | O | List of DB instance identifiers to monitor |
+| userGroupIds | Body | Array | O | List of user group identifiers |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-| Name                | Type | Format | Description                   |
-|---------------------|------|--------|-------------------------------|
-| notificationGroupId | Body | UUID   | Notification group identifier |
-
----
-
-### Modify Notification Group
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | Modify notification group |
-
-#### Request
-
-| Name                  | Type | Format  | Required | Description                             |
-|-----------------------|------|---------|----------|-----------------------------------------|
-| notificationGroupId   | URL  | UUID    | O        | Notification group identifier           |
-| notificationGroupName | Body | String  | X        | Name to identify notification groups    |
-| notifyEmail           | Body | Boolean | X        | Whether to be notified by email         |
-| notifySms             | Body | Boolean | X        | Whether to be notified by SMS           |
-| isEnabled             | Body | Boolean | X        | Indicates whether the flavor is enabled |
-| dbInstanceIds         | Body | Array   | X        | DB instance identifiers to monitor      |
-| userGroupIds          | Body | Array   | X        | User group identifiers                  |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
+    "notificationGroupName": "notificationGroupName",
     "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
@@ -4721,7 +5295,9 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### Response
 
-This API does not return a response body.
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -4732,7 +5308,8 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4749,21 +5326,61 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### Required permissions
 
-| Permission Name                                      | Description           |
-|------------------------------------------------------|------------|
+| Permission Name | Description |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Delete | Delete notification group |
 
 #### Request
 
 This API does not require a request body.
 
-| Name                | Type | Format | Required | Description                   |
-|---------------------|------|--------|----------|-------------------------------|
-| notificationGroupId | URL  | UUID   | O        | Notification group identifier |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### View Notification Group Details
+
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | View notification group details |
+
+#### Request
+
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | Notification group identifier |
+| notificationGroupName | Body | String | Name to identify notification groups |
+| notifyEmail | Body | Boolean | Whether to be notified by email |
+| notifySms | Body | Boolean | Whether to be notified by SMS |
+| isEnabled | Body | Boolean | Whether enabled |
+| dbInstances | Body | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
+| userGroups | Body | Array | User group list |
+| userGroups.userGroupId | Body | UUID | User group identifier |
+| userGroups.userGroupName | Body | String | Name to identify user groups |
+| createdYmdt | Body | DateTime | Created date and time |
+| updatedYmdt | Body | DateTime | Modified date and time |
 
 <details><summary>Example</summary>
 <p>
@@ -4774,7 +5391,26 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4783,7 +5419,75 @@ This API does not return a response body.
 
 ---
 
+### Modify Notification Group
+
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | Modify notification group |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | Name to identify notification groups |
+| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Body | Array | X | List of DB instance identifiers to monitor |
+| userGroupIds | Body | Array | X | List of user group identifiers |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
 ## Monitoring
+
+### View Stats
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Metric.List | View stats |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+This API does not return a response body.
+
+---
 
 ### List Metric List
 
@@ -4793,9 +5497,9 @@ GET /v4.0/metrics
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | List metric information |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Metric.List | List metric list |
 
 #### Request
 
@@ -4803,11 +5507,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                | Type | Format | Description          |
-|---------------------|------|--------|----------------------|
-| metrics             | Body | Array  | Metric List          |
-| metrics.measureName | Body | Enum   | Metric type to query |
-| metrics.unit        | Body | String | Measure unit         |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric list |
+| metrics.measureName | Body | String | Metric type to query |
+| metrics.unit | Body | String | Measure unit |
 
 <details><summary>Example</summary>
 <p>
@@ -4821,74 +5525,8 @@ This API does not require a request body.
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### View stats
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | List metric information |
-
-#### Request
-
-| Name         | Type  | Format   | Required | Description                                      |
-|--------------|-------|----------|----------|--------------------------------------------------|
-| dbInstanceId | Query | UUID     | O        | DB instance identifier                           |
-| measureNames | Query | Array    | O        | Metric list to query<br/>- Minimum length: `1`   |
-| from         | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)   |
-| interval     | Query | Number   | X        | View interval                                    |
-
-#### Response
-
-| Name                              | Type | Format    | Description                 |
-|-----------------------------------|------|-----------|-----------------------------|
-| metricStatistics                  | Body | Array     | Statistics information list |
-| metricStatistics.measureName      | Body | Enum      | Measure type                |
-| metricStatistics.unit             | Body | String    | Measure unit                |
-| metricStatistics.values           | Body | Array     | Measure values              |
-| metricStatistics.values.timestamp | Body | Timestamp | Measure time                |
-| metricStatistics.values.value     | Body | Object    | Measure value               |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
@@ -4905,102 +5543,14 @@ GET /v4.0/metric-statistics
 
 Events can be categorized into categories, which are shown below.
 
-| Event category | Description |
-|----------------|-------------|
-| ALL            | All         |
-| BACKUP         | Backups     |
-| DB_INSTANCE    | DB Instance |
-| JOB            | Jobs        |
-| TENANT         | Tenant      |
-| MONITORING     | Monitoring  |
-
-### List Events
-
-```http
-GET /v4.0/events
-```
-
-#### Required permissions
-
-| Permission Name                                           | Description           |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | List Events |
-
-#### Request
-
-This API does not require a request body.
-
-| Name              | Type  | Format   | Required | Description                                                                                                                                                         |
-|-------------------|-------|----------|----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1`                                                                                                         |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20                                                                                                                             |
-| from              | Query | Datetime | O        | Start date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                    |
-| to                | Query | Datetime | O        | End date and time (YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                      |
-| eventCategoryType | Query | Enum     | O        | Event category types to query<br/>- `ALL`: All<br/>- `INSTANCE`: DB instance<br/>- `BACKUP`: Backup<br/>- `DB_SECURITY_GROUP`: DB security group<br/>- `TENANT`: Tenant |
-| sourceId          | Query | String   | X        | Event target resource identifier                                                                                                                                    |
-| keyword           | Query | String   | X        | String keyword in event message                                                                                                                                     |
-| ascendingOrder    | Query | Enum     | X        | Event message sorting order<br/>- `ASC`: Ascending order<br/>- `DESC`: Descending order<br/>- Default: `DESC`                                                       |
-
-#### Response
-
-| Name                     | Type | Format   | Description                                               |
-|--------------------------|------|----------|-----------------------------------------------------------|
-| totalCounts              | Body | Number   | Total number of events                                    |
-| events                   | Body | Array    | Events                                                    |
-| events.eventCategoryType | Body | Enum     | Event category type                                       |
-| events.eventCode         | Body | Enum     | Occurred event type                                       |
-| events.sourceId          | Body | String   | Event source identifier                                   |
-| events.sourceName        | Body | String   | Name to identify event sources                            |
-| events.messages          | Body | Array    | Event messages                                            |
-| events.messages.langCode | Body | String   | Language code                                             |
-| events.messages.message  | Body | String   | Event Message                                             |
-| events.eventYmdt         | Body | DateTime | Event occurred date and time (YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+| Event category    | Description      |
+|-------------|---------|
+| ALL         | All      |
+| BACKUP      | Backup      |
+| DB_INSTANCE | DB instance |
+| JOB         | Job      |
+| TENANT      | Tenant     |
+| MONITORING  | Monitoring    |
 
 ### List Subscribable Event Codes
 
@@ -5010,9 +5560,9 @@ GET /v4.0/event-codes
 
 #### Required permissions
 
-| Permission Name                                           | Description           |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | List Events |
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Event.List | List subscribable event codes |
 
 #### Request
 
@@ -5020,11 +5570,11 @@ This API does not require a request body.
 
 #### Response
 
-| Name                         | Type | Format | Description         |
-|------------------------------|------|--------|---------------------|
-| eventCodes                   | Body | Array  | Event Codes         |
-| eventCodes.eventCode         | Body | Enum   | Event Code          |
-| eventCodes.eventCategoryType | Body | Enum   | Event category type |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | Event code list |
+| eventCodes.eventCode | Body | Enum | Event code |
+| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>Example</summary>
 <p>
@@ -5038,8 +5588,73 @@ This API does not require a request body.
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### List Events
+
+```http
+GET /v4.0/events
+```
+
+#### Required permissions
+
+| Permission Name | Description |
+|-----|-----|
+| RDSforMariaDB:Event.List | List events |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of events |
+| events | Body | Array | Event list |
+| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | Occurred event type |
+| events.sourceId | Body | UUID | Event source identifier |
+| events.sourceName | Body | String | Name to identify event sources |
+| events.messages | Body | Array | Event messages |
+| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | Event message |
+| events.eventYmdt | Body | DateTime | Event occurred date and time |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5059,28 +5674,22 @@ GET /v4.0/event-subscriptions
 
 #### Required Permission
 
-| Permission                                                    | Description            |
-|---------------------------------------------------------|---------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.List | List event subscriptions |
 
 #### Request
 
-| Name                | Type    | Format       | Required | Description                                       |
-|-------------------|-------|----------|----|------------------------------------------|
-| page              | Query | Number   | X  | Page to retrieve<br/>- Default: 1 <br/>- Minimum value: `1` |
-| size              | Query | Number   | X  | Page size to retrieve<br/>- Default: 20             |
-| eventSubscriptionId    | Query | UUID   | X  | Event subscription identifier                              |
-| eventSubscriptionName  | Query | String | X  | Name to identify event subscription                      |
-| userGroupId            | Query | UUID   | X  | User group identifier                              |
+This API does not require a request body.
 
 #### Response
 
-| Name                                            | Type   | Format       | Description                       |
-|-----------------------------------------------|------|----------|--------------------------|
-| totalCounts                                   | Body | Number   | Total number of event subscriptions           |
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | Total number of event subscriptions |
 | eventSubscriptions | Body | Array | List of event subscriptions |
 | eventSubscriptions.eventSubscriptionId | Body | UUID | Event subscription identifier |
-| eventSubscriptions.eventCategoryType | Body | Enum | Event category type |
+| eventSubscriptions.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | A name that identifies the event subscription |
 | eventSubscriptions.enabled | Body | Boolean | Whether to activate |
 | eventSubscriptions.notifyEmail | Body | Boolean | Whether to send emails |
@@ -5088,9 +5697,9 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.eventCodes | Body | Array | List of event codes to subscribe to |
 | eventSubscriptions.sources | Body | Array | List of event sources to subscribe to |
 | eventSubscriptions.sources.sourceId | Body | UUID | Identifier of the event source |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | List of identifiers of user groups subscribing to the event |
-| eventSubscriptions.createdYmdt                | Body | DateTime | Created at                    |
+| eventSubscriptions.createdYmdt | Body | DateTime | Created at |
 
 <details><summary>Example</summary>
 <p>
@@ -5105,25 +5714,23 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
             "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
+            "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
                 }
             ],
             "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
+                "550e8400-e29b-41d4-a716-446655440000"
             ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5142,47 +5749,43 @@ POST /v4.0/event-subscriptions
 
 #### Required Permission
 
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Create | Create an event subscription |
 
 #### Request
 
-| Name                      | Type | Format  | Required | Description                                                           |
-|---------------------------|------|---------|----------|-----------------------------------------------------------------------|
-| eventCategoryType         | Body | Enum    | O        | Event category type                                                   |
-| eventSubscriptionName     | Body | String  | O        | A name that identifies the event subscription - maximum length: `100` |
-| enabled                   | Body | Boolean | O        | Whether to enable                                                     |
-| notifyEmail               | Body | Boolean | O        | Whether to send emails                                                |
-| notifySms                 | Body | Boolean | O        | Whether to send SMS messages                                          |
-| eventCodes                | Body | Array   | O        | List of event codes to subscribe to                                   |
-| sources                   | Body | Array   | O        | List of event sources to subscribe to                                 |
-| sources.sourceId          | Body | UUID    | O        | Identifier of the event source                                        |
-| sources.eventCategoryType | Body | Enum    | O        | Event category type                                                   |
-| userGroupIds              | Body | Array   | O        | List of identifiers of user groups to subscribe to                    |
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | A name that identifies the event subscription |
+| enabled | Body | Boolean | O | Whether to activate |
+| notifyEmail | Body | Boolean | O | Whether to send emails |
+| notifySms | Body | Boolean | O | Whether to send SMS messages |
+| eventCodes | Body | Array | O | List of event codes to subscribe to |
+| sources | Body | Array | O | List of event sources to subscribe to |
+| sources.sourceId | Body | UUID | O | Identifier of the event source |
+| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | O | List of identifiers of user groups to subscribe to |
 
 <details><summary>Example</summary>
 <p>
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5191,9 +5794,9 @@ POST /v4.0/event-subscriptions
 
 #### Response
 
-| Name                    | Type   | Format   | Description          |
-|-----------------------|------|------|-------------|
-| eventSubscriptionId   | Body | UUID | Event subscription identifier | 
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| eventSubscriptionId | Body | UUID | Event subscription identifier |
 
 <details><summary>Example</summary>
 <p>
@@ -5205,86 +5808,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### Modify an Event Subscription
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### Required Permission
-
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
-
-#### Request
-
-| Name                      | Type | Format  | Required | Description                                           |
-|---------------------------|------|---------|----------|-------------------------------------------------------|
-| eventSubscriptionId       | URL  | UUID    | O        | Event subscription identifier                         |
-| eventCategoryType         | Body | Enum    | X        | Event category type                                   |
-| eventSubscriptionName     | Body | String  | X        | A name that identifies the event subscription         |
-| enabled                   | Body | Boolean | X        | Whether to enable                                     |
-| notifyEmail               | Body | Boolean | X        | Whether to send an email                              |
-| notifySms                 | Body | Boolean | X        | Whether to send an SMS                                |
-| eventCodes                | Body | Array   | X        | A list of event codes to subscribe to                 |
-| sources                   | Body | Array   | X        | A list of event sources to subscribe to               |
-| sources.sourceId          | Body | UUID    | X        | Event source identifier                               |
-| sources.eventCategoryType | Body | Enum    | X        | Event category type                                   |
-| userGroupIds              | Body | Array   | X        | A list of identifiers for user groups to subscribe to |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### Response
-
-This API does not return a response body.
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5301,19 +5825,108 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### Required Permission
 
-| Permission                                                      | Description           |
-|----------------------------------------------------------|--------------|
+| Permission | Description |
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | Delete an event subscription |
 
 #### Request
 
-| Name                    | Type  | Format   | Required | Description          |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId   | URL | UUID | O  | Event subscription identifier |
+This API does not require a request body.
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### Response
 
 This API does not return a response body.
+
+---
+
+### Modify an Event Subscription
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
+
+#### Request
+
+| Name | Type | Format | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | A name that identifies the event subscription |
+| enabled | Body | Boolean | X | Whether to activate |
+| notifyEmail | Body | Boolean | X | Whether to send emails |
+| notifySms | Body | Boolean | X | Whether to send SMS messages |
+| eventCodes | Body | Array | X | List of event codes to subscribe to |
+| sources | Body | Array | X | List of event sources to subscribe to |
+| sources.sourceId | Body | UUID | O | Identifier of the event source |
+| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | List of identifiers of user groups to subscribe to |
+
+<details><summary>Example</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### Response
+
+This API does not return a response body.
+
+---
+
+## Availability Zone
+
+### List Availability Zones
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### Required Permission
+
+| Permission | Description |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | List availability zones |
+
+#### Request
+
+This API does not require a request body.
+
+#### Response
+
+| Name | Type | Format | Description |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | List of availability zones |
+| availabilityZones.availabilityZoneName | Body | String | Availability zone name |
+| availabilityZones.zoneState | Body | Object | Availability zone status |
+| availabilityZones.zoneState.available | Body | Boolean | Whether the availability zone is available |
 
 <details><summary>Example</summary>
 <p>
@@ -5324,7 +5937,15 @@ This API does not return a response body.
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "availabilityZones": [
+        {
+            "availabilityZoneName": "availabilityZoneName-example",
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
 }
 ```
 

--- a/en/api-guide-v4.0.md
+++ b/en/api-guide-v4.0.md
@@ -1,91 +1,108 @@
-## Database > RDS for MariaDB > API Guide
+## RDS for MariaDB API Guide
+
+**Database > RDS for MariaDB > API v4.0 Guide**
 
 ## RDS for MariaDB API Common Information
 
 ### API Endpoint
 
 | Region | Endpoint |
-|--------|----------|
+|------|----------|
 | Korea (Pangyo) region | https://kr1-rds-mariadb.api.nhncloudservice.com |
+
 
 ### Authentication and Authorization
 
 RDS for MariaDB uses User Access Key tokens for authentication and authorization when making API calls. The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key. For more information on issuing and using User Access Key tokens, please refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 The issued token must be included in the request header along with the Appkey.
 
-| Name                | Type   | Format | Required | Description                                           |
-|---------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | Appkey of RDS for MariaDB or integrated Appkey for project |
-| X-NHN-AUTHORIZATION | Header | String | O  | Bearer type token issued with the Public API                           |
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | Appkey of RDS for MariaDB or integrated Appkey for project |
+| X-NHN-AUTHORIZATION | Header | String | Y | Bearer type token issued with the Public API |
 
 In addition, the APIs you can call are limited based on the project member role. You can grant permissions separately for `RDS for MariaDB ADMIN` and `RDS for MariaDB VIEWER`.
 
 * `RDS for MariaDB ADMIN permission holders` can use all available features as before.
 * `RDS for MariaDB VIEWER permission holders` can use read-only feature.
-    * Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
-    * But, notification group and user group-related features are available.
+* Cannot use any features aimed at DB instances or create, modify, or delete any DB instance.
+* But, notification group and user group-related features are available.
 
 If an API request fails to authenticate or is not authorized, the following error occurs.
 
-| resultCode | resultMessage | Description            |
-|------------|---------------|------------------------|
-| 80401      | Unauthorized  | Failed to authenticate |
-| 80403      | Forbidden     | Unauthorized.          |
+| resultCode | resultMessage | Description |
+|------------|---------------|-----|
+| 80401 | Unauthorized | Failed to authenticate |
+| 80403 | Forbidden | Unauthorized. |
 
 ### Common Response Information
 
 The API responds with "200 OK" to all API requests. For more information on the response results, see Response Body Header.
 
-#### Response Body
+<details>
+  <summary><strong>Successful Response</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### Field
-| Name          | Format  | Description                                              |
-|---------------|---------|----------------------------------------------------------|
-| resultCode    | Number  | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
-| resultMessage | String  | Result message                                           |
-| isSuccessful  | Boolean | Successful or not                                        |
+</details>
 
+<details>
+  <summary><strong>Failure Response</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| resultCode | Number | Result code<br/>- Success: `0`<br/>- Failure: `Non-zero` |
+| resultMessage | String | Result message |
+| isSuccessful | Boolean | Successful or not |
 ### DB engine type
 
 | DB engine type | Available for creation | Available for restoration from OBS | Authentication Plugin Support |
-|--------------|----------|-----------------|--------|
-| MARIADB\_V10330  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10611  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10612  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10616  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10622  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V10625  | X        | X               | NATIVE, ED25519 |
-| MARIADB\_V101107 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101108 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101113 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V101116 | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11407  | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11410  | O        | O               | NATIVE, ED25519 |
-| MARIADB\_V11806  | O        | O               | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * You can use the value for the dbVersion field of ENUM type.
 * Depending on the version, creation or restoration may not be possible.
-
 
 ## Project Information
 
 ### List Project Members
 
-```http
-GET /v4.0/project/members
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -93,51 +110,52 @@ GET /v4.0/project/members
 
 #### Request
 
+```http
+GET /v4.0/project/members
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| members | Body | Array | Project member list |
-| members.memberId | Body | UUID | Project member identifier |
-| members.memberName | Body | String | Project member name |
-| members.emailAddress | Body | String | Project member email address |
-| members.phoneNumber | Body | String | Project member phone number |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| members.memberName | String | Project member name |
+| members.emailAddress | String | Project member email address |
+| members.phoneNumber | String | Project member phone number |
 
 ---
 
 ### List Regions
 
-```http
-GET /v4.0/project/regions
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -145,48 +163,50 @@ GET /v4.0/project/regions
 
 #### Request
 
+```http
+GET /v4.0/project/regions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| regions | Body | Array | Region list |
-| regions.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
-| regions.isEnabled | Body | Boolean | Whether the region is enabled |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| regions | Array | Region list |
+| regions.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| regions.isEnabled | Boolean | Whether the region is enabled |
+
 ---
+
 ## Specifications of DB Instance
 
 ### List DB Instance Specifications
 
-```http
-GET /v4.0/db-flavors
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -194,41 +214,46 @@ GET /v4.0/db-flavors
 
 #### Request
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | List of DB instance specifications |
-| dbFlavors.dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| dbFlavors.dbFlavorName | Body | String | Name of DB instance specifications |
-| dbFlavors.ram | Body | Number | Memory size (MB) |
-| dbFlavors.vcpus | Body | Number | CPU cores |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbFlavorName": "dbFlavorName-example",
-            "ram": 1,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbFlavors | Array | List of DB instance specifications |
+| dbFlavors.dbFlavorId | UUID | Identifier of DB instance specifications |
+| dbFlavors.dbFlavorName | String | Name of DB instance specifications |
+| dbFlavors.ram | Number | Memory size (MB) |
+| dbFlavors.vcpus | Number | CPU cores |
 
 ---
 
@@ -236,11 +261,7 @@ This API does not require a request body.
 
 ### List Subnets
 
-```http
-GET /v4.0/network/subnets
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -248,43 +269,48 @@ GET /v4.0/network/subnets
 
 #### Request
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| subnets | Body | Array | Subnet list |
-| subnets.subnetId | Body | UUID | Subnet identifier |
-| subnets.subnetName | Body | String | Name to identify subnets |
-| subnets.subnetCidr | Body | String | CIDR of subnet |
-| subnets.usingGateway | Body | Boolean | Whether to use gateway |
-| subnets.availableIpCount | Body | Number | Number of available IPs |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| subnets | Array | Subnet list |
+| subnets.subnetId | UUID | Subnet identifier |
+| subnets.subnetName | String | Name to identify subnets |
+| subnets.subnetCidr | String | CIDR of subnet |
+| subnets.usingGateway | Boolean | Whether to use gateway |
+| subnets.availableIpCount | Number | Number of available IPs |
 
 ---
 
@@ -292,11 +318,7 @@ This API does not require a request body.
 
 ### List DB Engines
 
-```http
-GET /v4.0/db-versions
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -304,39 +326,44 @@ GET /v4.0/db-versions
 
 #### Request
 
+```http
+GET /v4.0/db-versions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB engine list |
-| dbVersions.dbVersion | Body | String | DB engine type |
-| dbVersions.dbVersionName | Body | String | DB engine name |
-| dbVersions.restorableFromObs | Body | Boolean | Restoring backup from object storage available or not |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MYSQL_V8036",
-            "dbVersionName": "dbVersionName-example",
-            "restorableFromObs": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbVersions | Array | DB engine list |
+| dbVersions.dbVersion | String | DB engine type |
+| dbVersions.dbVersionName | String | DB engine name |
+| dbVersions.restorableFromObs | Boolean | Restoring backup from object storage available or not |
 
 ---
 
@@ -344,11 +371,7 @@ This API does not require a request body.
 
 ### List Storage Types
 
-```http
-GET /v4.0/storage-types
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -356,33 +379,38 @@ GET /v4.0/storage-types
 
 #### Request
 
+```http
+GET /v4.0/storage-types
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | Storage type list |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageTypes | Array | Storage type list |
 
 ---
 
@@ -390,28 +418,24 @@ This API does not require a request body.
 
 ### Task Status
 
-| Status Name        | Description                           |
-|--------------------|---------------------------------------|
-| `PREPARING`        | Task in preparation                   |
-| `READY`            | Task in ready                         |
-| `RUNNING`          | Task in progress                      |
-| `COMPLETED`        | Task completed                        |
-| `REGISTERED`       | Task registered                       |
-| `WAIT_TO_REGISTER` | Task waiting to register              |
-| `INTERRUPTED`      | Task being interrupted                |
-| `CANCELED`         | Task canceled                         |
-| `FAILED`           | Task failed                           |
-| `ERROR`            | Error occurred while task in progress |
-| `DELETED`          | Task deleted                          |
-| `FAIL_TO_READY`    | Failed to get ready for task          |
+| Status | Description |
+|--------------------|----------------------|
+| `PREPARING` | Task in preparation |
+| `READY` | Task in ready |
+| `RUNNING` | Task in progress |
+| `COMPLETED` | Task completed |
+| `REGISTERED` | Task registered |
+| `WAIT_TO_REGISTER` | Task waiting to register |
+| `INTERRUPTED` | Task being interrupted |
+| `CANCELED` | Task canceled |
+| `FAILED` | Task failed |
+| `ERROR` | Error occurred while task in progress |
+| `DELETED` | Task deleted |
+| `FAIL_TO_READY` | Failed to get ready for task |
 
 ### List Task Details
 
-```http
-GET /v4.0/jobs/{jobId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -419,60 +443,64 @@ GET /v4.0/jobs/{jobId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Task identifier |
-| jobStatus | Body | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | Relevant resource list |
-| resourceRelations.resourceType | Body | String | Relevant resource type |
-| resourceRelations.resourceId | Body | String | Relevant resource identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+| jobStatus | Enum | Current task status<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | Relevant resource list |
+| resourceRelations.resourceType | String | Relevant resource type |
+| resourceRelations.resourceId | String | Relevant resource identifier |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
+
 ---
+
 ## DB Instance Group
 
 ### List DB Instance Groups
 
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -480,51 +508,52 @@ GET /v4.0/db-instance-groups
 
 #### Request
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB instance group list |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceGroups.replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | Created date and time |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB instance group list |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceGroups.replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstanceGroups.createdYmdt | DateTime | Created at |
+| dbInstanceGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### List DB Instance Group Details
 
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -532,51 +561,58 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| replicationType | Body | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
-| dbInstances | Body | Array | List of DB instances belonging to the DB instance group |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| replicationType | Enum | DB instance group replication type<br/>- STANDALONE: `Without high availability`<br/>- HIGH_AVAILABILITY: `With high availability` |
+| dbInstances | Array | List of DB instances belonging to the DB instance group |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
@@ -586,54 +622,50 @@ This API does not require a request body.
 
 | Status | Description |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DB instance is available |
-| `BEFORE_CREATE`     | Before DB instance is created |
-| `STORAGE_FULL`      | Insufficient DB instance storage |
-| `FAIL_TO_CREATE`    | Failed to create DB instance |
-| `FAIL_TO_CONNECT`   | Failed to connect DB instance |
-| `REPLICATION_STOP`  | Replication of DB instance is stopped |
-| `FAILOVER`          | High availability DB instance failed over |
-| `SHUTDOWN`          | DB instance is stopped |
-| `DELETED`           | DB instance is deleted |
+| `AVAILABLE` | DB instance is available |
+| `BEFORE_CREATE` | Before DB instance is created |
+| `STORAGE_FULL` | Insufficient DB instance storage |
+| `FAIL_TO_CREATE` | Failed to create DB instance |
+| `FAIL_TO_CONNECT` | Failed to connect DB instance |
+| `REPLICATION_STOP` | Replication of DB instance is stopped |
+| `FAILOVER` | High availability DB instance failed over |
+| `SHUTDOWN` | DB instance is stopped |
+| `DELETED` | DB instance is deleted |
 
 ### DB Instance Progress Status
 
 | Status | Description |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | Parameter group is being applied |
-| `BACKING_UP`               | Backing up |
-| `CANCELING`                | Canceling |
-| `CREATING`                 | Creating |
-| `CREATING_SCHEMA`          | Creating DB schema |
-| `CREATING_USER`            | Creating user |
-| `DELETING`                 | Deleting |
-| `DELETING_SCHEMA`          | Deleting DB schema |
-| `DELETING_USER`            | Deleting user |
-| `EXPORTING_BACKUP`         | Exporting backup |
-| `FAILING_OVER`             | Under failover |
-| `MIGRATING`                | Under migration |
-| `MODIFYING`                | Under modification |
-| `PREPARING`                | In preparation |
-| `PROMOTING`                | Promoting |
-| `REBUILDING`               | Rebuilding |
-| `REPAIRING`                | Recovering |
-| `REPLICATING`              | Replicating |
-| `RESTARTING`               | Restarting |
-| `RESTARTING_FORCIBLY`      | Force restarting |
-| `RESTORING`                | Restoring |
-| `STARTING`                 | Starting |
-| `STOPPING`                 | Stopping |
-| `SYNCING_SCHEMA`           | Synchronizing DB schema |
-| `SYNCING_USER`             | Synchronizing user |
-| `UPDATING_USER`            | Modifying user |
+| `BACKING_UP` | Backing up |
+| `CANCELING` | Canceling |
+| `CREATING` | Creating |
+| `CREATING_SCHEMA` | Creating DB schema |
+| `CREATING_USER` | Creating user |
+| `DELETING` | Deleting |
+| `DELETING_SCHEMA` | Deleting DB schema |
+| `DELETING_USER` | Deleting user |
+| `EXPORTING_BACKUP` | Exporting backup |
+| `FAILING_OVER` | Under failover |
+| `MIGRATING` | Under migration |
+| `MODIFYING` | Under modification |
+| `PREPARING` | In preparation |
+| `PROMOTING` | Promoting |
+| `REBUILDING` | Rebuilding |
+| `REPAIRING` | Recovering |
+| `REPLICATING` | Replicating |
+| `RESTARTING` | Restarting |
+| `RESTARTING_FORCIBLY` | Force restarting |
+| `RESTORING` | Restoring |
+| `STARTING` | Starting |
+| `STOPPING` | Stopping |
+| `SYNCING_SCHEMA` | Synchronizing DB schema |
+| `SYNCING_USER` | Synchronizing user |
+| `UPDATING_USER` | Modifying user |
 
 ### List DB Instances
 
-```http
-GET /v4.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -641,356 +673,359 @@ GET /v4.0/db-instances
 
 #### Request
 
+```http
+GET /v4.0/db-instances
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB instance list |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| dbInstances.description | Body | String | Additional information on DB instances |
-| dbInstances.dbVersion | Body | Enum | DB engine type |
-| dbInstances.dbPort | Body | Number | DB port |
-| dbInstances.dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before creation (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Insufficient storage (red)`<br/>- FAIL_TO_CREATE: `Creation failed (red)`<br/>- FAIL_TO_CONNECT: `Connection failed (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| dbInstances.progressStatus | Body | Enum | DB instance current progress status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | Created date and time |
-| dbInstances.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstances | Array | DB instance list |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| dbInstances.description | String | Additional information on DB instances |
+| dbInstances.dbVersion | String | DB engine type |
+| dbInstances.dbPort | Number | DB port |
+| dbInstances.dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstances.dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| dbInstances.progressStatus | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | Created at |
+| dbInstances.updatedYmdt | DateTime | Modified date and time |
+
 ---
+
 ### Create DB Instance
 
-```http
-POST /v4.0/db-instances
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | Create DB Instance |
 
-#### Common request
+#### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbVersion | Body | Enum | O | DB engine type |
-| dbPort | Body | Number | O | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
-| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| userGroupIds | Body | Array | X | User group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| authenticationPlugin | Body | Enum | X | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Data storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+POST /v4.0/db-instances
+```
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-#### When using storage auto scaling
-
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE",
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 1800,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbVersion | String | Y | DB engine type |
+| dbPort | Number | Y | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| authenticationPlugin | Enum | N | Authentication Plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS Option<br/>- Default: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+| network | Object | Y | Network information object |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | Y | Storage information object |
+| storage.storageType | Enum | Y | Data storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | Y | Backup information object |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restore DB Instance from Object Storage
 
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | Restore a DB instance from object storage |
 
-#### Common request
+#### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | O | Identifier of DB instance specifications |
-| dbPort | Body | Number | O | DB port |
-| dbVersion | Body | Enum | O | DB engine type |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| storage | Body | Object | O | Storage information objects |
-| storage.storageType | Body | Enum | O | Storage type |
-| storage.storageSize | Body | Number | O | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling objects |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| network | Body | Object | O | Network information objects |
-| network.subnetId | Body | UUID | O | Subnet identifier |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| backup | Body | Object | O | Backup information objects |
-| backup.backupPeriod | Body | Number | O | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | O | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.tenantId | Body | String | O | Tenant ID of object storage where backups are stored |
-| restore.username | Body | String | O | NHN Cloud account or IAM member ID |
-| restore.password | Body | String | O | API password for object storage where backups are stored |
-| restore.targetContainer | Body | String | O | Container for object storage where backups are stored |
-| restore.objectPath | Body | String | O | Backup path stored in container |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| parameterGroupId | Body | UUID | O | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| userGroupIds | Body | Array | X | User group identifiers |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-#### When using storage auto scaling
-
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "MYSQL_V8036",
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | Y | Identifier of DB instance specifications |
+| dbPort | Number | Y | DB port |
+| dbVersion | String | Y | DB engine type |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | Y | Storage information object |
+| storage.storageType | Enum | Y | Storage type |
+| storage.storageSize | Number | Y | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Object | Y | Network information object |
+| network.subnetId | UUID | Y | Subnet identifier |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| backup | Object | Y | Backup information object |
+| backup.backupPeriod | Number | Y | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | Y | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.tenantId | String | Y | Tenant ID of object storage where backups are stored |
+| restore.username | String | Y | NHN Cloud account or IAM member ID |
+| restore.password | String | Y | API password for object storage where backups are stored |
+| restore.targetContainer | String | Y | Container for object storage where backups are stored |
+| restore.objectPath | String | Y | Backup path stored in container |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | UUID | Y | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Delete DB Instance
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -998,55 +1033,60 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| deleteAutoBackup | Body | Boolean | X | Whether to delete automated backups<br/>- Default: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "deleteAutoBackup": false
+"deleteAutoBackup": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | Whether to delete automated backups<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Instance Details
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1054,88 +1094,91 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstanceGroupId | Body | UUID | DB instance group identifier |
-| dbInstanceName | Body | String | Name to identify DB instances |
-| description | Body | String | Additional information on DB instances |
-| dbVersion | Body | Enum | DB engine type |
-| dbPort | Body | Number | DB port |
-| dbInstanceType | Body | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
-| dbInstanceStatus | Body | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
-| progressStatus | Body | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | Parameter group identifier applied to DB instance |
-| dbSecurityGroupIds | Body | Array | DB security group identifiers applied to DB instance |
-| notificationGroupIds | Body | Array | Notification group identifiers applied to DB instance |
-| useDeletionProtection | Body | Boolean | Whether to protect DB instance against deletion |
-| useSlowQueryAnalysis | Body | Boolean | Whether to analyze slow queries |
-| supportAuthenticationPlugin | Body | Boolean | Whether to support authentication plugin |
-| needToApplyParameterGroup | Body | Boolean | Need to apply the latest parameter group |
-| needMigration | Body | Boolean | Need to migrate |
-| supportDbVersionUpgrade | Body | Boolean | Whether to support DB version upgrade |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": false,
-    "supportAuthenticationPlugin": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": false,
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB instance identifier |
+| dbInstanceGroupId | UUID | DB instance group identifier |
+| dbInstanceName | String | Name to identify DB instances |
+| description | String | Additional information on DB instances |
+| dbVersion | String | DB engine type |
+| dbPort | Number | DB port |
+| dbInstanceType | Enum | DB instance role type<br/>- MASTER: `Master`<br/>- FAILED_MASTER: `Failed master`<br/>- CANDIDATE_MASTER: `Candidate master`<br/>- READ_ONLY_SLAVE: `Read replica` |
+| dbInstanceStatus | Enum | DB instance current status<br/>- BEFORE_CREATE: `Before create (gray)`<br/>- AVAILABLE: `Available (green)`<br/>- STORAGE_FULL: `Storage full (red)`<br/>- FAIL_TO_CREATE: `Failed to create (red)`<br/>- FAIL_TO_CONNECT: `Failed to connect (red)`<br/>- REPLICATION_STOP: `Replication stopped (red)`<br/>- REPLICATION_DELAY: `Replication delayed (yellow)`<br/>- FAILOVER: `Failover completed (red)`<br/>- SHUTDOWN: `Stopped (gray)`<br/>- DELETED: `Deleted (gray)` |
+| progressStatus | Enum | DB instance current task status<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | Identifier of DB instance specifications |
+| parameterGroupId | UUID | Parameter group identifier applied to DB instance |
+| dbSecurityGroupIds | Array | DB security group identifiers applied to DB instance |
+| notificationGroupIds | Array | Notification group identifiers applied to DB instance |
+| useDeletionProtection | Boolean | Whether to protect DB instance against deletion |
+| useSlowQueryAnalysis | Boolean | Whether to analyze slow queries |
+| supportAuthenticationPlugin | Boolean | Whether to support authentication plugin |
+| needToApplyParameterGroup | Boolean | Need to apply the latest parameter group |
+| needMigration | Boolean | Need to migrate |
+| supportDbVersionUpgrade | Boolean | Whether to support DB version upgrade |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Instance
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1143,81 +1186,86 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | X | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| dbInstanceCandidateName | Body | String | X | Candidate name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbVersion | Body | Enum | X | DB engine type |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries |
-| useDummy | Body | Boolean | X | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifiers |
-| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
-| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
-| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
-| useReadOnly | Body | Boolean | X | Switch to read-only mode<br/>- Default: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "useSlowQueryAnalysis": false,
-    "useDummy": false,
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useSlowQueryAnalysis": false,
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| dbInstanceCandidateName | String | N | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbVersion | String | N | DB engine type |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries |
+| useDummy | Boolean | N | Whether to use dummies when upgrading the DB version of a single DB instance<br/>- Default: `false` |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| executeBackup | Boolean | N | Whether to execute backup at this time<br/>- Default: `false` |
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Block write load<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Backup Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1225,61 +1273,64 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | Backup retention period (days) |
-| ftwrlWaitTimeout | Body | Number | Query latency (sec) |
-| backupRetryCount | Body | Number | Number of backup retries |
-| replicationRegion | Body | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
-| useBackupLock | Body | Boolean | Whether to use table lock |
-| backupSchedules | Body | Array | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime | Body | Time | Backup started time |
-| backupSchedules.backupWndDuration | Body | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1,
-    "backupRetryCount": 1,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| backupPeriod | Number | Backup retention period (days) |
+| ftwrlWaitTimeout | Number | Query latency (sec) |
+| backupRetryCount | Number | Number of backup retries |
+| replicationRegion | Enum | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| useBackupLock | Boolean | Whether to use table lock |
+| backupSchedules | Array | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Backup duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### Modify Backup Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1287,148 +1338,167 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo) Region` |
-| useBackupLock | Body | Boolean | X | Whether to use table lock |
-| backupSchedules | Body | Array | X | Scheduled auto backup list |
-| backupSchedules.backupWndBgnTime | Body | Time | O | Backup started time |
-| backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupPeriod": 0,
-    "ftwrlWaitTimeout": 0,
-    "backupRetryCount": 0,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| useBackupLock | Boolean | N | Whether to use table lock |
+| backupSchedules | Array | N | Scheduled auto backup list |
+| backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### View Binary Log List
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
+---
+
+### View Binary Log List
 
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceBinLog.List | View binary log list |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLog file list |
-| binLogs.binLogFileName | Body | String | BinLog file name |
-| binLogs.binLogFileSize | Body | Number | BinLog file size (Byte) |
-| binLogs.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "binLogs": [
-        {
-            "binLogFileName": "binLogFileName-example",
-            "binLogFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"binLogs": [
+{
+"binLogFileName": "binLogFileName-example",
+"binLogFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| binLogs | Array | BinLog file list |
+| binLogs.binLogFileName | String | BinLog file name |
+| binLogs.binLogFileSize | Number | BinLog file size (Byte) |
+| binLogs.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Delete Binary Log
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceBinLog.Purge | Delete binary log |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | Last BinLog file name to delete (delete all files prior to this file) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "lastBinLogFileName": "mysql-bin.000010"
+"lastBinLogFileName": "mysql-bin.000010"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | Last BinLog file name to delete (delete all files prior to this file) |
 
 #### Response
 
@@ -1438,291 +1508,306 @@ This API does not return a response body.
 
 ### View Certificate File List
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.List | View certificate file list |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| certificates | Body | Array | Certificate file list |
-| certificates.fileName | Body | String | Certificate file name |
-| certificates.certificateType | Body | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | Certificate file size (Byte) |
-| certificates.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "certificates": [
-        {
-            "fileName": "fileName-example",
-            "certificateType": "CA_FILE",
-            "fileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"certificates": [
+{
+"fileName": "fileName-example",
+"certificateType": "CA_FILE",
+"fileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| certificates | Array | Certificate file list |
+| certificates.fileName | String | Certificate file name |
+| certificates.certificateType | Enum | Certificate type<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | Certificate file size (Byte) |
+| certificates.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Export Certificate File
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.Export | Export certificate file |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| certificateTypes | Body | Array | O | Certificate type list to upload |
-| tenantId | Body | String | O | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM account ID |
-| password | Body | String | O | API password for object storage where certificate file is stored |
-| targetContainer | Body | String | O | Object storage container where certificate file is stored |
-| objectPath | Body | String | O | Path of the certificate file to be stored in the container |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "certificateTypes": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"certificateTypes": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | Certificate type list to upload |
+| tenantId | String | Y | Tenant ID of object storage where certificate file is stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for object storage where certificate file is stored |
+| targetContainer | String | Y | Object storage container where certificate file is stored |
+| objectPath | String | Y | Path of the certificate file to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Schema
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.List | List DB schemas |
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DB schema list |
-| dbSchemas.dbSchemaId | Body | UUID | DB schema identifier |
-| dbSchemas.dbSchemaName | Body | String | DB schema name |
-| dbSchemas.dbSchemaStatus | Body | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSchemaName": "dbSchemaName-example",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSchemas | Array | DB schema list |
+| dbSchemas.dbSchemaId | UUID | DB schema identifier |
+| dbSchemas.dbSchemaName | String | DB schema name |
+| dbSchemas.dbSchemaStatus | Enum | DB schema current status<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Create DB Schema
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.Create | Create DB schema |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbSchemaName | Body | String | O | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSchemaName": "dbSchemaName-example"
+"dbSchemaName": "dbSchemaName-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB schema name<br/>- Maximum length: `64`<br/>- Must start with a letter; letters, digits, and _ allowed; 1–64 characters; MySQL reserved words not allowed |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete DB Schema
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstanceSchema.Delete | Delete DB schema |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbSchemaId | URL | UUID | O | DB schema identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbSchemaId | URL | UUID | Y | DB schema identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### List DB Users
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1730,65 +1815,68 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB users |
-| dbUsers.dbUserId | Body | UUID | DB user identifier |
-| dbUsers.dbUserName | Body | String | DB user account name |
-| dbUsers.host | Body | String | DB user account host name |
-| dbUsers.authorityType | Body | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| dbUsers.dbUserStatus | Body | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | Created date and time |
-| dbUsers.updatedYmdt | Body | DateTime | Modified date and time |
-| dbUsers.authenticationPlugin | Body | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| dbUsers.tlsOption | Body | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "host": "192.168.0.1",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "authenticationPlugin": "NATIVE",
-            "tlsOption": "NONE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbUsers | Array | DB users |
+| dbUsers.dbUserId | UUID | DB user identifier |
+| dbUsers.dbUserName | String | DB user account name |
+| dbUsers.host | String | DB user account host name |
+| dbUsers.authorityType | Enum | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| dbUsers.dbUserStatus | Enum | DB user current status<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | Created at |
+| dbUsers.updatedYmdt | DateTime | Modified date and time |
+| dbUsers.authenticationPlugin | Enum | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| dbUsers.tlsOption | Enum | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 ---
 
 ### Create DB User
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1796,65 +1884,70 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserName | Body | String | O | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
-| dbPassword | Body | String | O | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| host | Body | String | O | DB user account host name<br/>- Maximum length: `45` |
-| authorityType | Body | Enum | O | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "host": "192.168.0.1",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB user account name<br/>- Minimum length: `1`<br/>- Maximum length: `32` |
+| dbPassword | String | Y | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| host | String | Y | DB user account host name<br/>- Maximum length: `45` |
+| authorityType | Enum | Y | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- Default value: `NONE`<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete DB User
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1862,45 +1955,48 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify DB User
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1908,62 +2004,67 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbUserId | URL | UUID | O | DB user identifier |
-| dbPassword | Body | String | X | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
-| authorityType | Body | Enum | X | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
-| authenticationPlugin | Body | Enum | X | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
-| tlsOption | Body | Enum | X | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| dbUserId | URL | UUID | Y | DB user identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbPassword": "dbPassword",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB user account password<br/>- Minimum length: `4`<br/>- Maximum length: `256` |
+| authorityType | Enum | N | DB user permission type<br/>- CUSTOM: `Custom permission`<br/>- READ: `Read permission`<br/>- CRUD: `CRUD permission`<br/>- DDL: `DDL permission`<br/>- ALL: `Full permission` |
+| authenticationPlugin | Enum | N | Authentication plugin<br/>- NATIVE: `mysql_native_password authentication`<br/>- ED25519: `ed25519 authentication (MariaDB only)` |
+| tlsOption | Enum | N | TLS option<br/>- NONE: `TLS not used`<br/>- SSL: `SSL authentication`<br/>- X509: `X509 certificate authentication` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Change DB Instance Deletion Protection Settings
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -1971,22 +2072,32 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useDeletionProtection | Body | Boolean | O | Whether to enable deletion protection |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | Whether to enable deletion protection |
 
 #### Response
 
@@ -1996,11 +2107,7 @@ This API does not return a response body.
 
 ### Force Restart DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2008,24 +2115,29 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### View High Availability Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2033,114 +2145,122 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | Whether high availability is enabled<br/>- Default: `false` |
-| haStatus | Body | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
-| pingInterval | Body | Number | Ping interval (seconds) |
-| pingType | Body | String | Ping type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": false,
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "pingType": "pingType-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"useHighAvailability": false,
+"haStatus": "CREATED",
+"pingInterval": 1,
+"pingType": "pingType-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| useHighAvailability | Boolean | Whether to use high availability<br/>- Default: `false` |
+| haStatus | Enum | High availability status<br/>- CREATED: `Created`<br/>- STABLE: `Stable`<br/>- PAUSING: `Pausing`<br/>- DISABLE: `Disabled`<br/>- DISABLE_MASTER_IN_REPLICATION: `High availability stopped due to abnormal master replication detected`<br/>- DISABLE_MHA_PROCESS: `High availability process stopped`<br/>- DISABLE_REPLICATION_STOP: `High availability stopped due to replication stop`<br/>- DISABLE_REPLICATION_DELAY: `High availability stopped due to replication delay`<br/>- FAILOVER_STARTED: `Failover started`<br/>- FAILOVER_FAILED: `Failover failed`<br/>- FAILOVER_COMPLETED: `Failover completed`<br/>- DELETED: `Deleted`<br/>- PAUSED: `Paused`<br/>- PAUSED_DUE_TO_TASK: `Paused due to task`<br/>- MASTER_FAILURE_DETECTION: `Master failure detected` |
+| pingInterval | Number | Ping interval (seconds) |
+| pingType | String | Ping type |
 
 ---
 
 ### Modify High Availability
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | Modify high availability |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| useHighAvailability | Body | Boolean | O | Whether to use high availability |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"pingInterval": 1
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | Whether to use high availability |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
 
 #### When Using High Availability
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "useHighAvailability": false,
-    "pingInterval": 1
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Pause High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2148,44 +2268,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Repair High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2193,44 +2316,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2238,44 +2364,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Separate High Availability
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2283,43 +2412,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### List Log Files
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2327,55 +2460,58 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | Log file list |
-| logFiles.logFileName | Body | String | Log file name |
-| logFiles.logFileType | Body | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | Log file size (Byte) |
-| logFiles.createdYmdt | Body | DateTime | Created date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "logFileName-example",
-            "logFileType": "ERROR",
-            "logFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"logFiles": [
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"logFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| logFiles | Array | Log file list |
+| logFiles.logFileName | String | Log file name |
+| logFiles.logFileType | Enum | Log file type<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | Log file size (Byte) |
+| logFiles.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Export Log File
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2383,65 +2519,70 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | Log file name list |
-| tenantId | Body | String | O | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM member ID |
-| password | Body | String | O | API password for the object storage where log files are stored |
-| targetContainer | Body | String | O | Object storage container where log files are stored |
-| objectPath | Body | String | O | Path of the log file to be stored in the container |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "logFileNames": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"logFileNames": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | Log file name list |
+| tenantId | String | Y | Tenant ID of the object storage where log files are stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password for the object storage where log files are stored |
+| targetContainer | String | Y | Object storage container where log files are stored |
+| objectPath | String | Y | Path of the log file to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of the requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Log File Contents
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2449,44 +2590,48 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| logFileName | URL | UUID | O | Log file name |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| logFileName | URL | UUID | Y | Log file name |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| content | Body | String | Log file contents (maximum 65533 bytes) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "content-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"content": "content-example"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| content | String | Log file contents (maximum 65533 bytes) |
+
 ---
+
 ### List DB Instance Maintenances
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2494,79 +2639,82 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| Name | In | Type | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | In | Type | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of maintenances |
-| maintenances | Body | Array | List of maintenances |
-| maintenances.maintenanceId | Body | UUID | Maintenance ID |
-| maintenances.dbInstanceId | Body | UUID | DB instance ID |
-| maintenances.category | Body | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| maintenances.description | Body | String | Maintenance description |
-| maintenances.type | Body | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| maintenances.payload | Body | Object | Payload according to maintenance type |
-| maintenances.required | Body | Boolean | Whether the maintenance is required |
-| maintenances.deadlineYmdt | Body | DateTime | Datetime when the maintenance is forcibly applied |
-| maintenances.status | Body | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
-| maintenances.addedYmdt | Body | DateTime | Datetime when the maintenance was scheduled |
-| maintenances.executionStartedYmdt | Body | DateTime | Maintenance start datetime |
-| maintenances.executionCompletedYmdt | Body | DateTime | Maintenance end datetime |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "maintenances": [
-        {
-            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "category": "USER",
-            "description": "description-example",
-            "type": "UPDATE_DB_INSTANCE",
-            "payload": {
-            },
-            "required": false,
-            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
-            "status": "PENDING",
-            "executionType": "SCHEDULED",
-            "addedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"maintenances": [
+{
+"maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": {
+},
+"required": false,
+"deadlineYmdt": "2023-12-31T15:00:00+09:00",
+"status": "PENDING",
+"executionType": "SCHEDULED",
+"addedYmdt": "2023-12-31T15:00:00+09:00",
+"executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+"executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of maintenances |
+| maintenances | Array | List of maintenances |
+| maintenances.maintenanceId | UUID | Maintenance ID |
+| maintenances.dbInstanceId | UUID | DB instance ID |
+| maintenances.category | Enum | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| maintenances.description | String | Maintenance description |
+| maintenances.type | Enum | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| maintenances.payload | Object | Payload according to maintenance type |
+| maintenances.required | Boolean | Whether the maintenance is required |
+| maintenances.deadlineYmdt | DateTime | Datetime when the maintenance is forcibly applied |
+| maintenances.status | Enum | Maintenance status<br/>- PENDING: `Pending`<br/>- READY: `Ready`<br/>- RUNNING: `Running`<br/>- COMPLETED: `Completed`<br/>- FAILED: `Failed`<br/>- EXCLUDED: `Excluded`<br/>- DELETED: `Deleted`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | Maintenance execution type<br/>- SCHEDULED: `Scheduled execution (automatic execution during maintenance window)`<br/>- MANUAL: `Manual execution (immediate execution)`<br/>- FORCED: `Forced execution (automatic execution after deadline exceeded)` |
+| maintenances.addedYmdt | DateTime | Datetime when the maintenance was scheduled |
+| maintenances.executionStartedYmdt | DateTime | Maintenance start datetime |
+| maintenances.executionCompletedYmdt | DateTime | Maintenance end datetime |
 
 ---
 
 ### Execute DB Instance Maintenance Now
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2574,63 +2722,68 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### Request
 
-| Name | In | Type | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| configId | Body | String | O | Configuration ID |
-| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| description | Body | String | X | Maintenance description |
-| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| payload | Body | String | O | Payload according to maintenance type |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| configId | String | Y | Configuration ID |
+| category | Enum | Y | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | String | N | Maintenance description |
+| type | Enum | Y | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | String | Y | Payload according to maintenance type |
 
 #### Response
 
-| Name | In | Type | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Schedule DB Instance Maintenance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2638,30 +2791,40 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### Request
 
-| Name | In | Type | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| configId | Body | String | O | Configuration ID |
-| category | Body | Enum | O | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
-| description | Body | String | X | Maintenance description |
-| type | Body | Enum | O | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
-| payload | Body | String | O | Payload according to maintenance type |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| configId | String | Y | Configuration ID |
+| category | Enum | Y | Maintenance category<br/>- USER: `User maintenance category`<br/>- PROVIDER: `Provider maintenance category`<br/>- AUTO: `Auto maintenance category` |
+| description | String | N | Maintenance description |
+| type | Enum | Y | Maintenance type<br/>- UPDATE_DB_INSTANCE: `Modify DB instance (flavor change, port change, parameter group change)`<br/>- UPGRADE_ENGINE_VERSION: `Engine version upgrade`<br/>- APPLY_CHANGE_PARAMETER: `Apply parameter changes in parameter group`<br/>- UPGRADE_OS: `OS version upgrade`<br/>- PATCH_SECURITY: `Security patch`<br/>- MIGRATION: `Migration for hypervisor maintenance`<br/>- CLEANUP_STORAGE: `Storage cleanup` |
+| payload | String | Y | Payload according to maintenance type |
 
 #### Response
 
@@ -2671,11 +2834,7 @@ This API does not return a response body.
 
 ### Delete DB Instance Maintenance
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2683,25 +2842,30 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| Name | In | Type | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | Identifier of the DB instance |
-| maintenanceId | URL | UUID | O | Maintenance ID |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+| maintenanceId | URL | UUID | Y | Maintenance ID |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ### List Network Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2709,64 +2873,67 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | Availability zone where DB instance will be created |
-| subnet | Body | Object | Subnet object |
-| subnet.subnetId | Body | UUID | Subnet identifier |
-| subnet.subnetName | Body | String | Name to identify subnets |
-| subnet.subnetCidr | Body | String | CIDR of subnet |
-| endPoints | Body | Array | List of access information |
-| endPoints.domain | Body | String | Domain |
-| endPoints.ipAddress | Body | String | IP address |
-| endPoints.endPointType | Body | String | Access information type |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24"
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24"
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZone | String | Availability zone where DB instance will be created |
+| subnet | Object | Subnet object |
+| subnet.subnetId | UUID | Subnet identifier |
+| subnet.subnetName | String | Name to identify subnets |
+| subnet.subnetCidr | String | CIDR of subnet |
+| endPoints | Array | List of access information |
+| endPoints.domain | String | Domain |
+| endPoints.ipAddress | String | IP address |
+| endPoints.endPointType | String | Access information type |
 
 ---
 
 ### Modify Network Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2774,55 +2941,60 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| usePublicAccess | Body | Boolean | O | External access is available or not |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | External access is available or not |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Promote DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2830,44 +3002,47 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Rebuild DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -2875,166 +3050,175 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ### Replicate DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | Replicate DB Instance |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | O | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications |
-| dbPort | Body | Number | X | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
-| parameterGroupId | Body | UUID | X | Parameter group identifier |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifier list |
-| userGroupIds | Body | Array | X | User group identifier list |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether deletion protection is enabled<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze Slow query<br/>- Default: `true` |
-| network | Body | Object | O | Network information object |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not |
-| network.availabilityZone | Body | Enum | O | Availability zone where DB instance will be created |
-| storage | Body | Object | X | Storage information object |
-| storage.storageType | Body | Enum | X | Data storage type |
-| storage.storageSize | Body | Number | X | Data storage size (GB)<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | X | Backup information object |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock |
-| backup.backupSchedules | Body | Array | X | Scheduled auto backup list |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using storage auto scaling
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling condition (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications |
+| dbPort | Number | N | DB port<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Object | Y | Network information object |
+| network.usePublicAccess | Boolean | N | External access is available or not |
+| network.availabilityZone | Enum | Y | Availability zone where DB instance will be created |
+| storage | Object | N | Storage information object |
+| storage.storageType | Enum | N | Data storage type |
+| storage.storageSize | Number | N | Data storage size (GB)<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | N | Backup information object |
+| backup.backupPeriod | Number | N | Backup retention period (days)<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock |
+| backup.backupSchedules | Array | N | Scheduled auto backup list |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restart DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3042,61 +3226,66 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| useOnlineFailover | Body | Boolean | X | Whether to restart using failover<br/>- Default: `false` |
-| executeBackup | Body | Boolean | X | Whether to execute backup at this time<br/>- Default: `false` |
-| waitReplicationDelay | Body | Boolean | X | Wait for replication lag to clear<br/>- Default: `false` |
-| useReadOnly | Body | Boolean | X | Block write load<br/>- Default: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "useOnlineFailover": false,
-    "executeBackup": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | Whether to restart using failover<br/>- Default: `false` |
+| executeBackup | Boolean | N | Whether to execute backup at this time<br/>- Default: `false` |
+| waitReplicationDelay | Boolean | N | Wait for replication lag to clear<br/>- Default: `false` |
+| useReadOnly | Boolean | N | Block write load<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Restoration Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3104,85 +3293,88 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | Oldest restorable time |
-| latestRestorableYmdt | Body | DateTime | Most recent restorable time |
-| restorableBackups | Body | Array | List of restorable backups |
-| restorableBackups.backup | Body | Object | Backup information object |
-| restorableBackups.backup.backupId | Body | UUID | Backup identifier |
-| restorableBackups.backup.backupName | Body | String | Backup name |
-| restorableBackups.backup.backupStatus | Body | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | Original DB instance identifier |
-| restorableBackups.backup.dbInstanceName | Body | String | Original DB instance name |
-| restorableBackups.backup.dbVersion | Body | Enum | DB engine type |
-| restorableBackups.backup.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | Backup size |
-| restorableBackups.backup.useBackupLock | Body | Boolean | Whether to use table lock |
-| restorableBackups.backup.failoverCount | Body | Number | Number of failovers |
-| restorableBackups.backup.binLogFileName | Body | String | Binary log file name |
-| restorableBackups.backup.binLogPosition | Body | Object | Binary log file location |
-| restorableBackups.backup.createdYmdt | Body | DateTime | Date and time of backup creation |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | Date and time of backup renewal |
-| restorableBackups.restorableBinLogs | Body | Array | Binary log names that can be restored using the backup |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "550e8400-e29b-41d4-a716-446655440000",
-                "backupName": "backupName-example",
-                "backupStatus": "BACKING_UP",
-                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-                "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "MYSQL_V8036",
-                "backupType": "AUTO",
-                "backupSize": 1,
-                "useBackupLock": false,
-                "failoverCount": 1,
-                "binLogFileName": "binLogFileName-example",
-                "binLogPosition": {
-                },
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            },
-            "restorableBinLogs": []
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"backupType": "AUTO",
+"backupSize": 1,
+"useBackupLock": false,
+"failoverCount": 1,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+},
+"restorableBinLogs": []
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | Oldest restorable time |
+| latestRestorableYmdt | DateTime | Most recent restorable time |
+| restorableBackups | Array | List of restorable backups |
+| restorableBackups.backup | Object | Backup information object |
+| restorableBackups.backup.backupId | UUID | Backup identifier |
+| restorableBackups.backup.backupName | String | Backup name |
+| restorableBackups.backup.backupStatus | Enum | Backup status<br/>- BACKING_UP: `Backing up (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| restorableBackups.backup.dbInstanceId | UUID | Source DB instance identifier |
+| restorableBackups.backup.dbInstanceName | String | Source DB instance name |
+| restorableBackups.backup.dbVersion | String | DB engine type |
+| restorableBackups.backup.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | Backup size |
+| restorableBackups.backup.useBackupLock | Boolean | Whether to use table lock |
+| restorableBackups.backup.failoverCount | Number | Number of failovers |
+| restorableBackups.backup.binLogFileName | String | Binary log file name |
+| restorableBackups.backup.binLogPosition | Object | Binary log file location |
+| restorableBackups.backup.createdYmdt | DateTime | Date and time of backup creation |
+| restorableBackups.backup.updatedYmdt | DateTime | Date and time of backup renewal |
+| restorableBackups.restorableBinLogs | Array | Binary log names that can be restored using the backup |
 
 ---
 
 ### View the Last Query to Be Restored
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3190,215 +3382,224 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | Query executed date |
-| lastQuery | Body | String | Last executed query |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-12-31T15:00:00+09:00",
-    "lastQuery": "lastQuery-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+"lastQuery": "lastQuery-example"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| executedYmdt | DateTime | Query executed date |
+| lastQuery | String | Last executed query |
+
 ---
+
 ### Restore DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | Restore DB Instance |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| dbInstanceName | Body | String | O | Master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB instances<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
-| dbPort | Body | Number | X | DB port |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| storage | Body | Object | X | Storage information object. If not specified, the storage settings of the source instance are applied. |
-| storage.storageType | Body | Enum | X | Storage type. If not specified, the storage type of the source instance is applied. |
-| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| network | Body | Object | X | Network information object. If not specified, the network settings of the source instance are applied. |
-| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used. |
-| network.usePublicAccess | Body | Boolean | X | External access is available or not<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where DB instance will be created. If not specified, randomly selected. |
-| backup | Body | Object | X | Backup information object. If not specified, the backup settings of the source instance are applied. |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock<br/>- Default: `true` |
-| backup.backupSchedules | Body | Array | X | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | Backup started time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1.5 hours`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2.5 hours`<br/>- THREE_HOURS: `3 hours` |
-| restore | Body | Object | O | Restoration information object |
-| restore.restoreType | Body | Enum | O | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
-| restore.binLog.binLogFileName | Body | String | X | Binary log name to use for restoration |
-| restore.binLog.binLogPosition | Body | Object | X | Binary log location to use for restoration |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
-| dbSecurityGroupIds | Body | Array | X | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
-| userGroupIds | Body | Array | X | User group identifier list |
-| useDeletionProtection | Body | Boolean | X | Whether to protect against deletion<br/>- Default: `false` |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using high availability
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify DB instances<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+<details>
+  <summary><strong>Example Code</strong></summary>
 
-#### When using storage auto scaling
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+}
+}
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | Identifier of DB instance specifications. If not specified, the specifications of the source instance are applied. |
+| dbPort | Number | N | DB port |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| storage | Object | N | Storage information object. If not specified, the storage settings of the source instance are applied. |
+| storage.storageType | Enum | N | Storage type. If not specified, the storage type of the source instance is applied. |
+| storage.storageSize | Number | N | Data storage size (GB). If not specified, the storage size of the source instance is applied.<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| network | Object | N | Network information object. If not specified, the network settings of the source instance are applied. |
+| network.subnetId | UUID | N | Subnet identifier. If not specified, the source instance value is used. |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where DB instance will be created. If not specified, randomly selected. |
+| backup | Object | N | Backup information object. If not specified, the backup settings of the source instance are applied. |
+| backup.backupPeriod | Number | N | Backup retention period (days). If not specified, the backup retention period of the source instance is applied.<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency (sec)<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.backupRetryCount | Number | N | Number of backup retries<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock<br/>- Default: `true` |
+| backup.backupSchedules | Array | N | Scheduled auto backup list. If not specified, the backup schedule of the source instance is applied. |
+| backup.backupSchedules.backupWndBgnTime | Time | N | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | N | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| restore | Object | Y | Restoration information object |
+| restore.restoreType | Enum | Y | Restoration type<br/>- TIMESTAMP: `A point-in-time restoration type using the time within the restorable time`<br/>- BINLOG: `A point-in-time restoration type using a binary log location that can be restored`<br/>- BACKUP: `Snapshot restoration type using a previously created backup` |
+| restore.binLog.binLogFileName | String | N | Binary log name to use for restoration |
+| restore.binLog.binLogPosition | Object | N | Binary log location to use for restoration |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| parameterGroupId | UUID | N | Parameter group identifier. If not specified, the parameter group of the source instance is applied. |
+| dbSecurityGroupIds | Array | N | DB security group identifier list. If not specified, the security groups of the source instance are applied. |
+| userGroupIds | Array | N | List of user group identifiers |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+
+#### When Using High Availability
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Request when restoring a point in time using Timestamp (if restoreType is `TIMESTAMP`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB instance restore date (YYYY-MM-DDThh:mm:ss.SSSTZD) |
 
 Restoration is possible only before the most recent restorable time, which is queried through restoration information inquiry.
 
 #### Request for point-in-time restoration using binary logs (if restoreType is `BINLOG`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
-| restore.binLog | Body | Object | X | Binary log information object |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
+| restore.binLog | Object | N | Binary log information object |
 
 When restoring a point in time using the binary log, it is possible to restore the log recorded after that based on the binary log file and location of the base backup.
 
 #### Request when restoring from backup (if restoreType is `BACKUP`)
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | Identifier of the backup to use for restoration |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "TIMESTAMP",
-        "binLog": {
-            "binLogFileName": "binLogFileName-example",
-            "binLogPosition": {
-            }
-        }
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | Identifier of the backup to use for restoration |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Start DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3406,44 +3607,47 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Stop DB Instance
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3451,44 +3655,47 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### Request
 
-This API does not require a request body.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Storage Information
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3496,139 +3703,148 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| storageType | Body | String | Data storage type |
-| storageSize | Body | Number | Data storage size (GB) |
-| storageStatus | Body | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
-| storageAutoscale | Body | Object | Data storage auto scaling object |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | Whether to enable storage auto scaling |
-| storageAutoscale.threshold | Body | Number | Auto scale out conditions (%) |
-| storageAutoscale.maxStorageSize | Body | Number | Auto scaling maximum size (GB) |
-| storageAutoscale.cooldownTime | Body | Number | Auto scaling cooldown time (minutes) |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED",
-    "storageAutoscale": {
-        "useStorageAutoscale": false,
-        "threshold": 1,
-        "maxStorageSize": 1,
-        "cooldownTime": 1
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED",
+"storageAutoscale": {
+"useStorageAutoscale": false,
+"threshold": 1,
+"maxStorageSize": 1,
+"cooldownTime": 1
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| storageType | String | Data storage type |
+| storageSize | Number | Data storage size (GB) |
+| storageStatus | Enum | Current status of data storage<br/>- DELETED: `Deleted`<br/>- PENDING_DELETION: `Pending deletion`<br/>- DELETION_RESERVED: `Deletion reserved (awaiting snapshot cleanup)`<br/>- DETACHED: `Detached`<br/>- ATTACHED: `Attached` |
+| storageAutoscale | Object | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Boolean | Whether to enable storage auto scaling |
+| storageAutoscale.threshold | Number | Auto scale out conditions (%) |
+| storageAutoscale.maxStorageSize | Number | Auto scaling maximum size (GB) |
+| storageAutoscale.cooldownTime | Number | Auto scaling cooldown time (minutes) |
 
 ---
 
 ### Modify Storage Information
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | Modify Storage Information |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB instance identifier |
-| storageSize | Body | Number | O | Data storage size (GB)<br/>- Maximum value: `2048` |
-| storageAutoscale | Body | Object | X | Data storage auto scaling object |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling |
+| dbInstanceId | URL | UUID | Y | DB instance identifier |
 
-#### When using storage auto scaling
+#### Request Body
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | Auto scale out conditions (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "storageSize": 1,
-    "storageAutoscale": {
-        "useStorageAutoscale": false
-    }
+"storageSize": 1,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | Data storage size (GB)<br/>- Maximum value: `2048` |
+| storageAutoscale | Object | N | Data storage auto scaling object |
+| storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling |
+
+#### When Using Storage Auto Scaling
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Backups
 
 ### Backup Status
 
-| Status       | Description             |
-|--------------|-------------------------|
-| `BACKING_UP` | Backup in progress      |
-| `COMPLETED`  | Backup is completed     |
-| `DELETING`   | Backup is being deleted |
-| `DELETED`    | Backup is deleted       |
-| `ERROR`      | Error occurred          |
+| Status | Description |
+|--------------|--------------|
+| `BACKING_UP` | Backup in progress |
+| `COMPLETED` | Backup is completed |
+| `DELETING` | Backup is being deleted |
+| `DELETED` | Backup is deleted |
+| `ERROR` | Error occurred |
 
 ### Retrieve Backup List
 
-```http
-GET /v4.0/backups
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3636,65 +3852,66 @@ GET /v4.0/backups
 
 #### Request
 
+```http
+GET /v4.0/backups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of backup list entries |
-| backups | Body | Array | Backup list |
-| backups.backupId | Body | UUID | Backup identifier |
-| backups.backupName | Body | String | Name to identify the backup |
-| backups.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| backups.dbInstanceId | Body | UUID | Source DB instance identifier |
-| backups.dbVersion | Body | Enum | DB engine type |
-| backups.utilVersion | Body | String | Utility version |
-| backups.backupType | Body | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | Backup size (Byte) |
-| backups.createdYmdt | Body | DateTime | Created date and time |
-| backups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "MYSQL_V8036",
-            "utilVersion": "utilVersion-example",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of backup list entries |
+| backups | Array | Backup list |
+| backups.backupId | UUID | Backup identifier |
+| backups.backupName | String | Name to identify the backup |
+| backups.backupStatus | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backups.dbInstanceId | UUID | Source DB instance identifier |
+| backups.dbVersion | String | DB engine type |
+| backups.utilVersion | String | Utility version |
+| backups.backupType | Enum | Backup type<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | Backup size (Byte) |
+| backups.createdYmdt | DateTime | Created at |
+| backups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Backup
 
-```http
-POST /v4.0/backups
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3702,60 +3919,60 @@ POST /v4.0/backups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| baseBackupId | Body | UUID | X | Source backup identifier |
-| dbInstanceId | Body | UUID | X | DB instance identifier |
-| backupMethodType | Body | Enum | O | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "backupName": "backupName",
-    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "backupMethodType": "FULL"
+"backupName": "backupName",
+"baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"backupMethodType": "FULL"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| backupName | String | Y | Name to identify the backup<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| baseBackupId | UUID | N | Source backup identifier |
+| dbInstanceId | UUID | N | DB instance identifier |
+| backupMethodType | Enum | Y | Backup method type<br/>- FULL: `Full backup`<br/>- INCREMENTAL: `Incremental backup`<br/>- SNAPSHOT: `Snapshot backup` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Delete Backup
 
-```http
-DELETE /v4.0/backups/{backupId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3763,44 +3980,47 @@ DELETE /v4.0/backups/{backupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### View Backup Details
 
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3808,80 +4028,83 @@ GET /v4.0/backups/{backupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| backup | Body | Object | Backup details |
-| backup.backupId | Body | UUID | Backup identifier |
-| backup.regionCode | Body | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
-| backup.backupName | Body | String | Name to identify the backup |
-| backup.backupStatus | Body | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
-| backup.dbInstanceId | Body | UUID | Source DB instance identifier |
-| backup.dbInstanceName | Body | String | Source DB instance name |
-| backup.dbVersion | Body | Enum | DB engine version |
-| backup.utilVersion | Body | String | Utility version |
-| backup.backupType | Body | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | Backup size (Byte) |
-| backup.isReplicable | Body | Boolean | Whether replication is possible |
-| backup.binLogFileName | Body | String | Binary log file name |
-| backup.binLogPosition | Body | Object | Binary log location |
-| backup.createdYmdt | Body | DateTime | Created date and time |
-| backup.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "550e8400-e29b-41d4-a716-446655440000",
-        "regionCode": "KR1",
-        "backupName": "backupName-example",
-        "backupStatus": "BACKING_UP",
-        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "MYSQL_V8036",
-        "utilVersion": "utilVersion-example",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XBSTREAM",
-        "backupSize": 1,
-        "isReplicable": false,
-        "binLogFileName": "binLogFileName-example",
-        "binLogPosition": {
-        },
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"regionCode": "KR1",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupMethodType": "FULL",
+"backupFileType": "XBSTREAM",
+"backupSize": 1,
+"isReplicable": false,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| backup | Object | Backup details |
+| backup.backupId | UUID | Backup identifier |
+| backup.regionCode | Enum | Region code<br/>- KR1: `Korea (Pangyo)` |
+| backup.backupName | String | Name to identify the backup |
+| backup.backupStatus | Enum | Current backup status<br/>- BACKING_UP: `Backup in progress (spinner)`<br/>- VERIFYING: `Verifying (spinner)`<br/>- COMPLETED: `Available (green icon)`<br/>- DELETING: `Deleting (spinner)`<br/>- DELETED: `Deleted (gray icon)`<br/>- ERROR: `Error (red icon)` |
+| backup.dbInstanceId | UUID | Source DB instance identifier |
+| backup.dbInstanceName | String | Source DB instance name |
+| backup.dbVersion | String | DB engine version |
+| backup.utilVersion | String | Utility version |
+| backup.backupType | Enum | Backup type (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | Backup method (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | Backup file type<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | Backup size (Byte) |
+| backup.isReplicable | Boolean | Whether replication is possible |
+| backup.binLogFileName | String | Binary log file name |
+| backup.binLogPosition | Object | Binary log location |
+| backup.createdYmdt | DateTime | Created at |
+| backup.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Export Backup
 
-```http
-POST /v4.0/backups/{backupId}/export
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -3889,208 +4112,219 @@ POST /v4.0/backups/{backupId}/export
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
-| username | Body | String | O | NHN Cloud account or IAM member ID |
-| password | Body | String | O | API password of the object storage where the backup will be stored |
-| targetContainer | Body | String | O | Object storage container where the backup will be stored |
-| objectPath | Body | String | O | Path of the backup to be stored in the container |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| tenantId | String | Y | Tenant ID of the object storage where the backup will be stored<br/>- Minimum length: `32`<br/>- Maximum length: `32` |
+| username | String | Y | NHN Cloud account or IAM member ID |
+| password | String | Y | API password of the object storage where the backup will be stored |
+| targetContainer | String | Y | Object storage container where the backup will be stored |
+| objectPath | String | Y | Path of the backup to be stored in the container |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Restore Backup
 
-```http
-POST /v4.0/backups/{backupId}/restore
-```
-
-#### Required Permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | Restore backup |
 
-#### Common Request
+#### Request
 
-| Name | Type | Format | Required | Description |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on the DB instance<br/>- Maximum length: `100` |
-| dbFlavorId | Body | UUID | X | DB instance specification identifier. If not specified, the source instance value is used |
-| dbPort | Body | Number | X | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
-| parameterGroupId | Body | UUID | X | Parameter group identifier. If not specified, the source instance value is used |
-| dbSecurityGroupIds | Body | Array | X | List of DB security group identifiers |
-| userGroupIds | Body | Array | X | List of user group identifiers |
-| useHighAvailability | Body | Boolean | X | Whether to use high availability<br/>- Default: `false` |
-| pingInterval | Body | Number | X | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
-| useDefaultNotification | Body | Boolean | X | Whether to use default notification<br/>- Default: `false` |
-| useDeletionProtection | Body | Boolean | X | Whether to enable deletion protection<br/>- Default: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Whether to analyze slow queries<br/>- Default: `true` |
-| network | Body | Object | X | Network information object. If not specified, the source instance value is used |
-| network.subnetId | Body | UUID | X | Subnet identifier. If not specified, the source instance value is used |
-| network.usePublicAccess | Body | Boolean | X | Whether external access is available<br/>- Default: `false` |
-| network.availabilityZone | Body | Enum | X | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
-| storage | Body | Object | X | Storage information object. If not specified, the source instance value is used |
-| storage.storageType | Body | Enum | X | Storage type. If not specified, the source instance value is used |
-| storage.storageSize | Body | Number | X | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
-| storage.storageAutoscale | Body | Object | X | Data storage auto scaling object. If not specified, the source instance value is used |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | Whether to enable storage auto scaling<br/>- Default: `false` |
-| backup | Body | Object | X | Backup information object. If not specified, the source instance backup settings are used |
-| backup.backupPeriod | Body | Number | X | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
-| backup.backupRetryCount | Body | Number | X | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
-| backup.replicationRegion | Body | Enum | X | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
-| backup.useBackupLock | Body | Boolean | X | Whether to use table lock. If not specified, the source instance value is used |
-| backup.backupSchedules | Body | Array | X | Backup schedule list. If not specified, the source instance value is used |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | Backup start time |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
+| backupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | Master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on the DB instance<br/>- Maximum length: `100` |
+| dbFlavorId | UUID | N | DB instance specification identifier. If not specified, the source instance value is used |
+| dbPort | Number | N | DB port. If not specified, the source instance value is used<br/>- Minimum value: 3306, Maximum value: 43306 |
+| parameterGroupId | UUID | N | Parameter group identifier. If not specified, the source instance value is used |
+| dbSecurityGroupIds | Array | N | List of DB security group identifiers |
+| userGroupIds | Array | N | List of user group identifiers |
+| useHighAvailability | Boolean | N | Whether to use high availability<br/>- Default: `false` |
+| pingInterval | Number | N | Ping interval (sec) when using high availability<br/>- Default: `3`<br/>- Minimum value: `1`<br/>- Maximum value: `600` |
+| useDefaultNotification | Boolean | N | Whether to use default notification<br/>- Default: `false` |
+| useDeletionProtection | Boolean | N | Whether to enable deletion protection<br/>- Default: `false` |
+| useSlowQueryAnalysis | Boolean | N | Whether to analyze slow queries<br/>- Default: `true` |
+| network | Object | N | Network information object. If not specified, the source instance value is used |
+| network.subnetId | UUID | N | Subnet identifier. If not specified, the source instance value is used |
+| network.usePublicAccess | Boolean | N | Whether external access is available<br/>- Default: `false` |
+| network.availabilityZone | Enum | N | Availability zone where the DB instance will be created. If not specified, a random zone is selected |
+| storage | Object | N | Storage information object. If not specified, the source instance value is used |
+| storage.storageType | Enum | N | Storage type. If not specified, the source instance value is used |
+| storage.storageSize | Number | N | Data storage size (GB). If not specified, the source instance value is used<br/>- Minimum value: `20` |
+| storage.storageAutoscale | Object | N | Data storage auto scaling object. If not specified, the source instance value is used |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | Whether to enable storage auto scaling<br/>- Default: `false` |
+| backup | Object | N | Backup information object. If not specified, the source instance backup settings are used |
+| backup.backupPeriod | Number | N | Backup retention period (days). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `730` |
+| backup.backupRetryCount | Number | N | Number of backup retries. If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `10` |
+| backup.ftwrlWaitTimeout | Number | N | Query latency wait time (sec). If not specified, the source instance value is used<br/>- Minimum value: `0`<br/>- Maximum value: `21600` |
+| backup.replicationRegion | Enum | N | Backup replication region<br/>- KR1: `Korea (Pangyo)` |
+| backup.useBackupLock | Boolean | N | Whether to use table lock. If not specified, the source instance value is used |
+| backup.backupSchedules | Array | N | Backup schedule list. If not specified, the source instance value is used |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | Backup start time |
+| backup.backupSchedules.backupWndDuration | Enum | Y | Backup duration<br/>- HALF_AN_HOUR: `30 minutes`<br/>- ONE_HOUR: `1 hour`<br/>- ONE_HOUR_AND_HALF: `1 hour 30 minutes`<br/>- TWO_HOURS: `2 hours`<br/>- TWO_HOURS_AND_HALF: `2 hours 30 minutes`<br/>- THREE_HOURS: `3 hours` |
 
 #### When Using High Availability
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | Candidate master name to identify the DB instance<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
 
 #### When Using Storage Auto Scaling
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
-
-<details><summary>Example</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | Auto scaling threshold (%)<br/>- Minimum value: `50`<br/>- Maximum value: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | Auto scaling maximum size (GB)<br/>- Maximum value: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | Auto scaling cooldown time (minutes)<br/>- Minimum value: `10`<br/>- Maximum value: `1440` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## DB Security Group
 
 ### DB Security Group Progress
 
-| Status              | Description             |
-|---------------------|-------------------------|
-| `NONE`              | No task in progress     |
-| `CREATING_RULE`     | Creating rules          |
-| `UPDATING_RULE`     | Modifying rules         |
-| `DELETING_RULE`     | Deleting rules          |
+| Status | Description |
+|-----------------|--------------|
+| `NONE` | No task in progress |
+| `CREATING_RULE` | Creating rules |
+| `UPDATING_RULE` | Modifying rules |
+| `DELETING_RULE` | Deleting rules |
 
 ### List DB Security Groups
 
-```http
-GET /v4.0/db-security-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4098,57 +4332,58 @@ GET /v4.0/db-security-groups
 
 #### Request
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of DB security groups |
-| dbSecurityGroups | Body | Array | DB security groups |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB security group identifier |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | Name to identify the DB security group |
-| dbSecurityGroups.description | Body | String | Additional information on DB security group |
-| dbSecurityGroups.progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | Created date and time |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of DB security groups |
+| dbSecurityGroups | Array | DB security groups |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroups.dbSecurityGroupName | String | Name to identify the DB security group |
+| dbSecurityGroups.description | String | Additional information on DB security group |
+| dbSecurityGroups.progressStatus | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| dbSecurityGroups.createdYmdt | DateTime | Created at |
+| dbSecurityGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create DB Security Group
 
-```http
-POST /v4.0/db-security-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4156,78 +4391,78 @@ POST /v4.0/db-security-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
-| rules | Body | Array | O | DB security group rules |
-| rules.direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| rules.etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| rules.port | Body | Object | O | Port object |
-| rules.port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| rules.port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| rules.port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | Additional information on DB security group rule |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 3306,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB security group<br/>- Maximum length: `100` |
+| rules | Array | Y | DB security group rules |
+| rules.direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Object | Y | Port object |
+| rules.port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| rules.port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | Additional information on DB security group rule |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
 
 ---
 
 ### Delete DB Security Group
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4235,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4249,11 +4492,7 @@ This API does not return a response body.
 
 ### List DB Security Group Details
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4261,82 +4500,85 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB security group identifier |
-| dbSecurityGroupName | Body | String | Name to identify the DB security group |
-| description | Body | String | Additional information on DB security group |
-| progressStatus | Body | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
-| rules | Body | Array | DB security group rules |
-| rules.ruleId | Body | UUID | DB security group rule identifier |
-| rules.description | Body | String | Additional information on DB security group rule |
-| rules.direction | Body | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| rules.etherType | Body | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| rules.port | Body | Object | Port object |
-| rules.port.portType | Body | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| rules.port.minPort | Body | Number | Minimum port range |
-| rules.port.maxPort | Body | Number | Maximum port range |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | Created date and time |
-| rules.updatedYmdt | Body | DateTime | Modified date and time |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
-        {
-            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description-example",
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB security group identifier |
+| dbSecurityGroupName | String | Name to identify the DB security group |
+| description | String | Additional information on DB security group |
+| progressStatus | Enum | Current status of DB security group<br/>- NONE: `None`<br/>- CREATING_RULE: `Creating rules`<br/>- UPDATING_RULE: `Modifying rules`<br/>- DELETING_RULE: `Deleting rules`<br/>- APPLYING_DEFAULT_RULE: `Applying default rules` |
+| rules | Array | DB security group rules |
+| rules.ruleId | UUID | DB security group rule identifier |
+| rules.description | String | Additional information on DB security group rule |
+| rules.direction | Enum | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| rules.etherType | Enum | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| rules.port | Object | Port object |
+| rules.port.portType | Enum | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| rules.port.minPort | Number | Minimum port range |
+| rules.port.maxPort | Number | Maximum port range |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | Created at |
+| rules.updatedYmdt | DateTime | Modified date and time |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify DB Security Group
 
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4344,24 +4586,34 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on DB security group<br/>- Maximum length: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | Name to identify the DB security group<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on DB security group<br/>- Maximum length: `100` |
 
 #### Response
 
@@ -4371,11 +4623,7 @@ This API does not return a response body.
 
 ### Delete DB Security Group Rule
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4383,45 +4631,48 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Create DB Security Group Rule
 
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4429,70 +4680,75 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| port | Body | Object | O | Port object |
-| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
 
 ---
 
 ### Modify DB Security Group Rule
 
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4500,72 +4756,78 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
-| etherType | Body | Enum | O | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
-| port | Body | Object | O | Port object |
-| port.portType | Body | Enum | O | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
-| port.minPort | Body | Number | X | Minimum port range<br/>- Minimum value: `3306` |
-| port.maxPort | Body | Number | X | Maximum port range<br/>- Maximum value: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | Additional information on DB security group rule<br/>- Maximum length: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| direction | Enum | Y | Communication direction<br/>- INGRESS: `Inbound`<br/>- EGRESS: `Outbound` |
+| etherType | Enum | Y | Ether type<br/>- IPV4: `IPv4`<br/>- IPV6: `IPv6` |
+| port | Object | Y | Port object |
+| port.portType | Enum | Y | Port type<br/>- ALL: `All port range (not used in the user console)`<br/>- PORT: `Specific port`<br/>- DB_PORT: `DB receiving port`<br/>- PORT_RANGE: `Port range` |
+| port.minPort | Number | N | Minimum port range<br/>- Minimum value: `3306` |
+| port.maxPort | Number | N | Maximum port range<br/>- Maximum value: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | Additional information on DB security group rule<br/>- Maximum length: `200` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | Identifier of requested task |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| jobId | UUID | Identifier of requested task |
+
 ---
+
 ## Parameter Groups
 
 ### List Parameter Groups
 
-```http
-GET /v4.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4573,61 +4835,62 @@ GET /v4.0/parameter-groups
 
 #### Request
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of parameter groups |
-| parameterGroups | Body | Array | Parameter groups |
-| parameterGroups.parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroups.parameterGroupName | Body | String | Name to identify parameter groups |
-| parameterGroups.description | Body | String | Additional information on parameter group |
-| parameterGroups.dbVersion | Body | Enum | DB engine type |
-| parameterGroups.parameterGroupType | Body | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameterGroups.createdYmdt | Body | DateTime | Created date and time |
-| parameterGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "parameterGroupType": "USER",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupType": "USER",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of parameter groups |
+| parameterGroups | Array | Parameter groups |
+| parameterGroups.parameterGroupId | UUID | Parameter group identifier |
+| parameterGroups.parameterGroupName | String | Name to identify parameter groups |
+| parameterGroups.description | String | Additional information on parameter group |
+| parameterGroups.dbVersion | String | DB engine type |
+| parameterGroups.parameterGroupType | Enum | Parameter group type<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameterGroups.createdYmdt | DateTime | Created at |
+| parameterGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Parameter Group
 
-```http
-POST /v4.0/parameter-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4635,58 +4898,58 @@ POST /v4.0/parameter-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
-| dbVersion | Body | Enum | O | DB engine type |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
+| dbVersion | String | Y | DB engine type |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Delete Parameter Group
 
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4694,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -4708,11 +4979,7 @@ This API does not return a response body.
 
 ### List Parameter Group Details
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4720,79 +4987,82 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-| parameterGroupName | Body | String | Name to identify parameter groups |
-| description | Body | String | Additional information on parameter group |
-| dbVersion | Body | Enum | DB engine type |
-| parameterGroupStatus | Body | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
-| parameters | Body | Array | Parameter list |
-| parameters.parameterId | Body | UUID | Parameter identifier |
-| parameters.parameterFileGroup | Body | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | Parameter name |
-| parameters.fileParameterName | Body | String | Parameter file name |
-| parameters.value | Body | String | Current value |
-| parameters.defaultValue | Body | String | Default value |
-| parameters.allowedValue | Body | String | Permitted values |
-| parameters.updateType | Body | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterFileGroup": "CLIENT",
-            "parameterName": "parameterName-example",
-            "fileParameterName": "fileParameterName-example",
-            "value": "value-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+"parameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+"applyType": "BOTH"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
+| parameterGroupName | String | Name to identify parameter groups |
+| description | String | Additional information on parameter group |
+| dbVersion | String | DB engine type |
+| parameterGroupStatus | Enum | Parameter group current status<br/>- STABLE: `Applied`<br/>- NEED_TO_APPLY: `Need to apply`<br/>- DELETED: `Deleted` |
+| parameters | Array | Parameter list |
+| parameters.parameterId | UUID | Parameter identifier |
+| parameters.parameterFileGroup | Enum | Parameter file group type<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | Parameter name |
+| parameters.fileParameterName | String | Parameter file name |
+| parameters.value | String | Current value |
+| parameters.defaultValue | String | Default value |
+| parameters.allowedValue | String | Permitted values |
+| parameters.updateType | Enum | Modify type<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | Apply type<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Parameter Group
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4800,24 +5070,34 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
 
 #### Response
 
@@ -4827,11 +5107,7 @@ This API does not return a response body.
 
 ### Copy Parameter Group
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4839,57 +5115,62 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| description | Body | String | X | Additional information on parameter group<br/>- Maximum length: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | Name to identify parameter groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| description | String | N | Additional information on parameter group<br/>- Maximum length: `100` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | Parameter group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| parameterGroupId | UUID | Parameter group identifier |
 
 ---
 
 ### Modify Parameter
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4897,29 +5178,39 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | Parameters to change |
-| modifiedParameters.parameterId | Body | UUID | O | Parameter identifier |
-| modifiedParameters.value | Body | String | O | Parameter value to change |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "value": "value-example"
-        }
-    ]
+"modifiedParameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"value": "value-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | Parameters to change |
+| modifiedParameters.parameterId | UUID | Y | Parameter identifier |
+| modifiedParameters.value | String | Y | Parameter value to change |
 
 #### Response
 
@@ -4929,11 +5220,7 @@ This API does not return a response body.
 
 ### Reset Parameter Group
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4941,26 +5228,31 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### Request
 
-This API does not require a request body.
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## User Group
 
 ### List User Groups
 
-```http
-GET /v4.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -4968,53 +5260,54 @@ GET /v4.0/user-groups
 
 #### Request
 
+```http
+GET /v4.0/user-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of user groups |
-| userGroups | Body | Array | User group list |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| userGroups.createdYmdt | Body | DateTime | Created date and time |
-| userGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of user groups |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| userGroups.createdYmdt | DateTime | Created at |
+| userGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create User Group
 
-```http
-POST /v4.0/user-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5022,58 +5315,58 @@ POST /v4.0/user-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | Name to identify user groups |
-| memberIds | Body | Array | O | List of project member identifiers |
-| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | Y | List of project member identifiers |
+| selectAll | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
 
 ---
 
 ### Delete User Group
 
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5081,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5095,11 +5396,7 @@ This API does not return a response body.
 
 ### List User Group Details
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5107,59 +5404,62 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | User group identifier |
-| userGroupName | Body | String | Name to identify user groups |
-| userGroupTypeCode | Body | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | Project member list |
-| members.memberId | Body | UUID | Project member identifier |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"userGroupTypeCode": "ENTIRE",
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| userGroupId | UUID | User group identifier |
+| userGroupName | String | Name to identify user groups |
+| userGroupTypeCode | Enum | User group type<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | Project member list |
+| members.memberId | UUID | Project member identifier |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify User Group
 
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5167,41 +5467,48 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | Name to identify user groups |
-| memberIds | Body | Array | X | List of project member identifiers |
-| selectAll | Body | Boolean | X | Whether to include all project members<br/>- Default: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | Name to identify user groups |
+| memberIds | Array | N | List of project member identifiers |
+| selectAll | Boolean | N | Whether to include all project members<br/>- Default: `false` |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Notification Group
 
 ### List Notification Groups
 
-```http
-GET /v4.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5209,57 +5516,58 @@ GET /v4.0/notification-groups
 
 #### Request
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | Notification group list |
-| notificationGroups.notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroups.notificationGroupName | Body | String | Name to identify notification groups |
-| notificationGroups.notifyEmail | Body | Boolean | Whether to be notified by email |
-| notificationGroups.notifySms | Body | Boolean | Whether to be notified by SMS |
-| notificationGroups.isEnabled | Body | Boolean | Whether enabled |
-| notificationGroups.createdYmdt | Body | DateTime | Created date and time |
-| notificationGroups.updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroups": [
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroups | Array | Notification group list |
+| notificationGroups.notificationGroupId | UUID | Notification group identifier |
+| notificationGroups.notificationGroupName | String | Name to identify notification groups |
+| notificationGroups.notifyEmail | Boolean | Whether to be notified by email |
+| notificationGroups.notifySms | Boolean | Whether to be notified by SMS |
+| notificationGroups.isEnabled | Boolean | Whether to activate |
+| notificationGroups.createdYmdt | DateTime | Created at |
+| notificationGroups.updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Create Notification Group
 
-```http
-POST /v4.0/notification-groups
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5267,64 +5575,64 @@ POST /v4.0/notification-groups
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `true` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `true` |
-| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `true` |
-| dbInstanceIds | Body | Array | O | List of DB instance identifiers to monitor |
-| userGroupIds | Body | Array | O | List of user group identifiers |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | Name to identify notification groups<br/>- Minimum length: `1`<br/>- Maximum length: `100` |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `true` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `true` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `true` |
+| dbInstanceIds | Array | Y | List of DB instance identifiers to monitor |
+| userGroupIds | Array | Y | List of user group identifiers |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
 
 ---
 
 ### Delete Notification Group
 
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5332,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5346,11 +5662,7 @@ This API does not return a response body.
 
 ### View Notification Group Details
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5358,74 +5670,77 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-This API does not require a request body.
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | Notification group identifier |
-| notificationGroupName | Body | String | Name to identify notification groups |
-| notifyEmail | Body | Boolean | Whether to be notified by email |
-| notifySms | Body | Boolean | Whether to be notified by SMS |
-| isEnabled | Body | Boolean | Whether enabled |
-| dbInstances | Body | Array | List of DB instances to monitor |
-| dbInstances.dbInstanceId | Body | UUID | DB instance identifier |
-| dbInstances.dbInstanceName | Body | String | Name to identify DB instances |
-| userGroups | Body | Array | User group list |
-| userGroups.userGroupId | Body | UUID | User group identifier |
-| userGroups.userGroupName | Body | String | Name to identify user groups |
-| createdYmdt | Body | DateTime | Created date and time |
-| updatedYmdt | Body | DateTime | Modified date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example"
+}
+],
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| notificationGroupId | UUID | Notification group identifier |
+| notificationGroupName | String | Name to identify notification groups |
+| notifyEmail | Boolean | Whether to be notified by email |
+| notifySms | Boolean | Whether to be notified by SMS |
+| isEnabled | Boolean | Whether to activate |
+| dbInstances | Array | List of DB instances to monitor |
+| dbInstances.dbInstanceId | UUID | DB instance identifier |
+| dbInstances.dbInstanceName | String | Name to identify DB instances |
+| userGroups | Array | User group list |
+| userGroups.userGroupId | UUID | User group identifier |
+| userGroups.userGroupName | String | Name to identify user groups |
+| createdYmdt | DateTime | Created at |
+| updatedYmdt | DateTime | Modified date and time |
 
 ---
 
 ### Modify Notification Group
 
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5433,53 +5748,66 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | Name to identify notification groups |
-| notifyEmail | Body | Boolean | X | Whether to be notified by email<br/>- Default: `false` |
-| notifySms | Body | Boolean | X | Whether to be notified by SMS<br/>- Default: `false` |
-| isEnabled | Body | Boolean | X | Whether enabled<br/>- Default: `false` |
-| dbInstanceIds | Body | Array | X | List of DB instance identifiers to monitor |
-| userGroupIds | Body | Array | X | List of user group identifiers |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | Name to identify notification groups |
+| notifyEmail | Boolean | N | Whether to be notified by email<br/>- Default: `false` |
+| notifySms | Boolean | N | Whether to be notified by SMS<br/>- Default: `false` |
+| isEnabled | Boolean | N | Whether enabled<br/>- Default: `false` |
+| dbInstanceIds | Array | N | List of DB instance identifiers to monitor |
+| userGroupIds | Array | N | List of user group identifiers |
 
 #### Response
 
 This API does not return a response body.
 
 ---
+
 ## Monitoring
 
 ### View Stats
 
-```http
-GET /v4.0/metric-statistics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:Metric.List | View stats |
 
 #### Request
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### Request Body
 
 This API does not require a request body.
 
@@ -5491,11 +5819,7 @@ This API does not return a response body.
 
 ### List Metric List
 
-```http
-GET /v4.0/metrics
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5503,37 +5827,42 @@ GET /v4.0/metrics
 
 #### Request
 
+```http
+GET /v4.0/metrics
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric list |
-| metrics.measureName | Body | String | Metric type to query |
-| metrics.unit | Body | String | Measure unit |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "measureName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"metrics": [
+{
+"measureName": "measureName-example",
+"unit": "unit-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| metrics | Array | Metric list |
+| metrics.measureName | String | Metric type to query |
+| metrics.unit | String | Measure unit |
 
 ---
 
@@ -5543,22 +5872,18 @@ This API does not require a request body.
 
 Events can be categorized into categories, which are shown below.
 
-| Event category    | Description      |
+| Event category | Description |
 |-------------|---------|
-| ALL         | All      |
-| BACKUP      | Backup      |
+| ALL | All |
+| BACKUP | Backup |
 | DB_INSTANCE | DB instance |
-| JOB         | Job      |
-| TENANT      | Tenant     |
-| MONITORING  | Monitoring    |
+| JOB | Job |
+| TENANT | Tenant |
+| MONITORING | Monitoring |
 
 ### List Subscribable Event Codes
 
-```http
-GET /v4.0/event-codes
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5566,47 +5891,48 @@ GET /v4.0/event-codes
 
 #### Request
 
+```http
+GET /v4.0/event-codes
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | Event code list |
-| eventCodes.eventCode | Body | Enum | Event code |
-| eventCodes.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventCodes": [
+{
+"eventCode": "ENUM_VALUE",
+"eventCategoryType": "ALL"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventCodes | Array | Event code list |
+| eventCodes.eventCode | Enum | Event code |
+| eventCodes.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### List Events
 
-```http
-GET /v4.0/events
-```
-
-#### Required permissions
+#### Required Permission
 
 | Permission Name | Description |
 |-----|-----|
@@ -5614,228 +5940,239 @@ GET /v4.0/events
 
 #### Request
 
+```http
+GET /v4.0/events
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of events |
-| events | Body | Array | Event list |
-| events.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | Occurred event type |
-| events.sourceId | Body | UUID | Event source identifier |
-| events.sourceName | Body | String | Name to identify event sources |
-| events.messages | Body | Array | Event messages |
-| events.messages.langCode | Body | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | Event message |
-| events.eventYmdt | Body | DateTime | Event occurred date and time |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"events": [
+{
+"eventCategoryType": "ALL",
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+"messages": [
+{
+"langCode": "KO",
+"message": "message-example"
+}
+],
+"eventYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of events |
+| events | Array | Event list |
+| events.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | Occurred event type |
+| events.sourceId | UUID | Identifier of the event source |
+| events.sourceName | String | Name to identify event sources |
+| events.messages | Array | Event messages |
+| events.messages.langCode | Enum | Language code<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | Event message |
+| events.eventYmdt | DateTime | Event occurred date and time |
+
 ---
+
 ## Event Subscription
 
 ### List Event Subscriptions
 
-```http
-GET /v4.0/event-subscriptions
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.List | List event subscriptions |
 
 #### Request
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | Total number of event subscriptions |
-| eventSubscriptions | Body | Array | List of event subscriptions |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | Event subscription identifier |
-| eventSubscriptions.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | A name that identifies the event subscription |
-| eventSubscriptions.enabled | Body | Boolean | Whether to activate |
-| eventSubscriptions.notifyEmail | Body | Boolean | Whether to send emails |
-| eventSubscriptions.notifySms | Body | Boolean | Whether to send SMS messages |
-| eventSubscriptions.eventCodes | Body | Array | List of event codes to subscribe to |
-| eventSubscriptions.sources | Body | Array | List of event sources to subscribe to |
-| eventSubscriptions.sources.sourceId | Body | UUID | Identifier of the event source |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | List of identifiers of user groups subscribing to the event |
-| eventSubscriptions.createdYmdt | Body | DateTime | Created at |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "eventSubscriptions": [
-        {
-            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL",
-            "eventSubscriptionName": "eventSubscriptionName-example",
-            "enabled": false,
-            "notifyEmail": false,
-            "notifySms": false,
-            "eventCodes": [],
-            "sources": [
-                {
-                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-                    "eventCategoryType": "ALL"
-                }
-            ],
-            "userGroupIds": [
-                "550e8400-e29b-41d4-a716-446655440000"
-            ],
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"eventSubscriptions": [
+{
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| totalCounts | Number | Total number of event subscriptions |
+| eventSubscriptions | Array | List of event subscriptions |
+| eventSubscriptions.eventSubscriptionId | UUID | Event subscription identifier |
+| eventSubscriptions.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | A name that identifies the event subscription |
+| eventSubscriptions.enabled | Boolean | Whether to activate |
+| eventSubscriptions.notifyEmail | Boolean | Whether to send emails |
+| eventSubscriptions.notifySms | Boolean | Whether to send SMS messages |
+| eventSubscriptions.eventCodes | Array | List of event codes to subscribe to |
+| eventSubscriptions.sources | Array | List of event sources to subscribe to |
+| eventSubscriptions.sources.sourceId | UUID | Identifier of the event source |
+| eventSubscriptions.sources.eventCategoryType | Enum | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | List of identifiers of user groups subscribing to the event |
+| eventSubscriptions.createdYmdt | DateTime | Created at |
 
 ---
 
 ### Create an Event Subscription
 
-```http
-POST /v4.0/event-subscriptions
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Create | Create an event subscription |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | A name that identifies the event subscription |
-| enabled | Body | Boolean | O | Whether to activate |
-| notifyEmail | Body | Boolean | O | Whether to send emails |
-| notifySms | Body | Boolean | O | Whether to send SMS messages |
-| eventCodes | Body | Array | O | List of event codes to subscribe to |
-| sources | Body | Array | O | List of event sources to subscribe to |
-| sources.sourceId | Body | UUID | O | Identifier of the event source |
-| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | List of identifiers of user groups to subscribe to |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | A name that identifies the event subscription |
+| enabled | Boolean | Y | Whether to activate |
+| notifyEmail | Boolean | Y | Whether to send emails |
+| notifySms | Boolean | Y | Whether to send SMS messages |
+| eventCodes | Array | Y | List of event codes to subscribe to |
+| sources | Array | Y | List of event sources to subscribe to |
+| sources.sourceId | UUID | Y | Identifier of the event source |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | List of identifiers of user groups to subscribe to |
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | Event subscription identifier |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | Event subscription identifier |
 
 ---
 
 ### Delete an Event Subscription
 
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | Delete an event subscription |
 
 #### Request
 
-This API does not require a request body.
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| Name | Type | Format | Required | Description |
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+This API does not require a request body.
 
 #### Response
 
@@ -5845,55 +6182,61 @@ This API does not return a response body.
 
 ### Modify an Event Subscription
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:EventSubscription.Modify | Modify an event subscription |
 
 #### Request
 
-| Name | Type | Format | Required | Description |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | A name that identifies the event subscription |
-| enabled | Body | Boolean | X | Whether to activate |
-| notifyEmail | Body | Boolean | X | Whether to send emails |
-| notifySms | Body | Boolean | X | Whether to send SMS messages |
-| eventCodes | Body | Array | X | List of event codes to subscribe to |
-| sources | Body | Array | X | List of event sources to subscribe to |
-| sources.sourceId | Body | UUID | O | Identifier of the event source |
-| sources.eventCategoryType | Body | Enum | O | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | List of identifiers of user groups to subscribe to |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>Example</summary>
-<p>
+#### Request Parameters
+
+| Name | Category | Type | Required | Description |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### Request Body
+
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Required | Description |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | A name that identifies the event subscription |
+| enabled | Boolean | N | Whether to activate |
+| notifyEmail | Boolean | N | Whether to send emails |
+| notifySms | Boolean | N | Whether to send SMS messages |
+| eventCodes | Array | N | List of event codes to subscribe to |
+| sources | Array | N | List of event sources to subscribe to |
+| sources.sourceId | UUID | Y | Identifier of the event source |
+| sources.eventCategoryType | Enum | Y | Event category type<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | List of identifiers of user groups to subscribe to |
 
 #### Response
 
@@ -5905,51 +6248,52 @@ This API does not return a response body.
 
 ### List Availability Zones
 
-```http
-GET /v4.0/availability-zones
-```
-
 #### Required Permission
 
-| Permission | Description |
+| Permission Name | Description |
 |-----|-----|
 | RDSforMariaDB:AvailabilityZone.List | List availability zones |
 
 #### Request
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### Request Body
+
 This API does not require a request body.
 
 #### Response
 
-| Name | Type | Format | Description |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | List of availability zones |
-| availabilityZones.availabilityZoneName | Body | String | Availability zone name |
-| availabilityZones.zoneState | Body | Object | Availability zone status |
-| availabilityZones.zoneState.available | Body | Boolean | Whether the availability zone is available |
-
-<details><summary>Example</summary>
-<p>
+<details>
+  <summary><strong>Example Code</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "availabilityZoneName": "availabilityZoneName-example",
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZones": [
+{
+"availabilityZoneName": "availabilityZoneName-example",
+"zoneState": {
+"available": false
+}
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| Name | Type | Description |
+|-----|-----|-----|
+| availabilityZones | Array | List of availability zones |
+| availabilityZones.availabilityZoneName | String | Availability zone name |
+| availabilityZones.zoneState | Object | Availability zone status |
+| availabilityZones.zoneState.available | Boolean | Whether the availability zone is available |
 
 ---

--- a/ja/api-guide-v3.0-gov.md
+++ b/ja/api-guide-v3.0-gov.md
@@ -1,12 +1,15 @@
-## Database > RDS for MariaDB > APIガイド
+## RDS for MariaDB API ガイド
+
+**Database > RDS for MariaDB > API v3.0 ガイド**
 
 ## RDS for MariaDB API共通情報
 
 ### APIエンドポイント
 
-| リージョン           | エンドポイント                                       |
-|-----------------|-----------------------------------------------|
+| リージョン | エンドポイント |
+|------|----------|
 | 韓国(パンギョ)リージョン | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
+
 
 ### 認証および権限
 
@@ -15,153 +18,178 @@ RDS for MariaDB APIを使用するには、User Access Keyが必要です。User
 User Access KeyとSecret Access Keyは、コンソールのAPIセキュリティ設定で発行できます。User Access Keyの発行及び使用に関する詳細は、[User Access Key](/nhncloud/ja/public-api/user-access-key)を参照してください。
 作成されたKeyはAppkeyと一緒にリクエストHeaderに含める必要があります。
 
-| 名前                         | 種類     | 形式     | 必須 | 説明                                                        |
-|----------------------------|--------|--------|----|-----------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O  | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
-| X-TC-AUTHENTICATION-ID     | Header | String | O  | APIセキュリティ設定メニューのUser Access Key ID                        |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O  | APIセキュリティ設定メニューのSecret Access Key                         |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | APIセキュリティ設定メニューのUser Access Key ID |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | APIセキュリティ設定メニューのSecret Access Key |
 
 またプロジェクトメンバーのロールによって呼び出すことができるAPIが制限されます。 `RDS for MariaDB ADMIN`、`RDS for MariaDB VIEWER`に区分して権限を付与できます。
 
 * `RDS for MariaDB ADMIN`権限はすべての機能を使用可能です。
 * `RDS for MariaDB VIEWER`権限は情報を照会する機能のみ使用可能です。
-    * DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
-    * ただし、通知グループとユーザーグループに関連する機能は使用可能です。
+* DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
+* ただし、通知グループとユーザーグループに関連する機能は使用可能です。
 
 APIリクエスト時、認証に失敗したり権限がない場合、次のようなエラーが発生します。
 
-| resultCode | resultMessage | 説明         |
-|------------|---------------|------------|
-| 80401      | Unauthorized  | 認証に失敗しました。 |
-| 80403      | Forbidden     | 権限がありません。  |
+| resultCode | resultMessage | 説明 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 認証に失敗しました。 |
+| 80403 | Forbidden | 権限がありません。 |
 
 ### レスポンス共通情報
 
 すべてのAPIリクエストに「200 OK」でレスポンスします。詳細なレスポンス結果はレスポンス本文のヘッダを参照します。
 
-#### レスポンス本文
+<details>
+  <summary><strong>成功レスポンス</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### フィールド
+</details>
 
-| 名前            | 形式      | 説明                                     |
-|---------------|---------|----------------------------------------|
-| resultCode    | Number  | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
-| resultMessage | String  | 結果メッセージ                                |
-| isSuccessful  | Boolean | 成否                                     |
+<details>
+  <summary><strong>失敗レスポンス</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| resultCode | Number | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
+| resultMessage | String | 結果メッセージ |
+| isSuccessful | Boolean | 成否 |
 ### DBエンジンタイプ
 
 | DBエンジンタイプ | 作成可否 | OBSからの復元可否 | 認証プラグインサポート情報 |
-|-----------------|----------|------------------|-----------------|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
 ## プロジェクト情報
 
-### リージョンリストを表示
-
-```http
-GET /v3.0/project/regions
-```
+### プロジェクトメンバーリストを表示
 
 #### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                 | 種類   | 形式      | 説明                                                                                     |
-|--------------------|------|---------|----------------------------------------------------------------------------------------|
-| regions            | Body | Array   | リージョンリスト                                                                               |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                                                                           |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### プロジェクトメンバーリストを表示
 
 ```http
 GET /v3.0/project/members
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                   | 種類   | 形式     | 説明                 |
-|----------------------|------|--------|--------------------|
-| members              | Body | Array  | プロジェクトメンバーリスト      |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子     |
-| members.memberName   | Body | String | プロジェクトメンバーの名前      |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号    |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | String | プロジェクトメンバーの名前 |
+| members.emailAddress | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | String | プロジェクトメンバーの電話番号 |
+
+---
+
+### リージョンリストを表示
+
+#### リクエスト
+
+```http
+GET /v3.0/project/regions
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| regions | Array | リージョンリスト |
+| regions.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Boolean | リージョンが有効かどうか |
 
 ---
 
@@ -169,47 +197,48 @@ GET /v3.0/project/members
 
 ### DBインスタンス仕様リストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                     | 種類   | 形式     | 説明             |
-|------------------------|------|--------|----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト  |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名    |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数         |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbFlavors | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Number | CPUコア数 |
 
 ---
 
@@ -217,49 +246,50 @@ GET /v3.0/db-flavors
 
 ### サブネットリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                       | 種類   | 形式      | 説明              |
-|--------------------------|------|---------|-----------------|
-| subnets                  | Body | Array   | サブネットリスト        |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子       |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前   |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR      |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| subnets | Array | サブネットリスト |
+| subnets.subnetId | UUID | サブネットの識別子 |
+| subnets.subnetName | String | サブネットの識別できる名前 |
+| subnets.subnetCidr | String | サブネットのCIDR |
+| subnets.usingGateway | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Number | 使用可能なIP数 |
 
 ---
 
@@ -267,45 +297,46 @@ GET /v3.0/network/subnets
 
 ### DBエンジンリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                           | 種類   | 形式      | 説明                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBエンジンリスト             |
-| dbVersions.dbVersion         | Body | String  | DBエンジンタイプ             |
-| dbVersions.dbVersionName     | Body | String  | DBエンジン名前              |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbVersions | Array | DBエンジンリスト |
+| dbVersions.dbVersion | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | String | DBエンジン名前 |
+| dbVersions.restorableFromObs | Boolean | オブジェクトストレージから復元可能かどうか |
 
 ---
 
@@ -313,78 +344,79 @@ GET /v3.0/db-versions
 
 ### ストレージタイプリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/storage-types
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前           | 種類   | 形式    | 説明          |
-|--------------|------|-------|-------------|
-| storageTypes | Body | Array | ストレージタイプリスト |
-
-<details><summary>例</summary>
-
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageTypes | Array | ストレージタイプリスト |
 
 ---
 
 ### ストレージリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/storages
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前       | 種類   | 形式    | 説明       |
-|----------|------|-------|----------|
-| storages | Body | Array | ストレージリスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storages": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storages": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storages | Array | ストレージリスト |
 
 ---
 
@@ -392,72 +424,75 @@ GET /v3.0/storages
 
 ### 作業状態
 
-| 状態名                | 説明                |
-|--------------------|-------------------|
-| `PREPARING`        | 作業が準備中の場合         |
-| `READY`            | 作業が準備完了している場合     |
-| `RUNNING`          | 作業が進行中の場合         |
-| `COMPLETED`        | 作業が完了している場合       |
-| `REGISTERED`       | 作業が登録されている場合      |
-| `WAIT_TO_REGISTER` | 作業登録待機中の場合        |
-| `INTERRUPTED`      | 作業進行中に割り込みが発生した場合 |
-| `CANCELED`         | 作業がキャンセルされた場合     |
-| `FAILED`           | 作業が失敗した場合         |
-| `ERROR`            | 作業進行中にエラーが発生した場合  |
-| `DELETED`          | 作業が削除された場合        |
-| `FAIL_TO_READY`    | 作業の準備に失敗した場合      |
+| 状態名 | 説明 |
+|--------------------|----------------------|
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了している場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了している場合 |
+| `REGISTERED` | 作業が登録されている場合 |
+| `WAIT_TO_REGISTER` | 作業登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業の準備に失敗した場合 |
 
 ### 作業情報の詳細表示
+
+#### リクエスト
 
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前    | 種類  | 形式   | 必須 | 説明     |
-|-------|-----|------|----|--------|
-| jobId | URL | UUID | O  | 作業の識別子 |
-
 #### レスポンス
 
-| 名前                             | 種類   | 形式       | 説明                               |
-|--------------------------------|------|----------|----------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                           |
-| jobStatus                      | Body | Enum     | 作業の現在状態                          |
-| resourceRelations              | Body | Array    | 関連リソースリスト                        |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ                        |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                       |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+| jobStatus | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 関連リソースリスト |
+| resourceRelations.resourceType | String | 関連リソースタイプ |
+| resourceRelations.resourceId | String | 関連リソースの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -465,103 +500,107 @@ GET /v3.0/jobs/{jobId}
 
 ### DBインスタンスグループリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                 | 種類   | 形式       | 説明                                                                     |
-|------------------------------------|------|----------|------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DBインスタンスグループリスト                                                        |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                       |
-| dbInstanceGroups.replicationType   | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                       |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                       |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `単一`<br/>- HIGH_AVAILABILITY: `高可用性(HA)` |
+| dbInstanceGroups.createdYmdt | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスグループの詳細を表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
-
 #### レスポンス
 
-| 名前                           | 種類   | 形式       | 説明                                                                                                                                      |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| replicationType              | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                                  |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `単一`<br/>- HIGH_AVAILABILITY: `高可用性(HA)` |
+| dbInstances | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -569,1762 +608,2332 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                  | 説明                             |
-|---------------------|--------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合               |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合                |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合           |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合              |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合              |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合             |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合      |
-| `SHUTDOWN`          | DBインスタンスが停止した場合                |
-| `DELETED`           | DBインスタンスが削除された場合               |
+| 状態 | 説明 |
+|---------------------|------------------------------|
+| `AVAILABLE` | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE` | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL` | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE` | DBインスタンスの作成に失敗した場合 |
+| `FAIL_TO_CONNECT` | DBインスタンスの接続に失敗した場合 |
+| `REPLICATION_STOP` | DBインスタンスの複製が中断した場合 |
+| `FAILOVER` | DBインスタンスが高可用性(HA)フェイルオーバーした場合 |
+| `SHUTDOWN` | DBインスタンスが停止した場合 |
+| `DELETED` | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                         | 説明             |
-|----------------------------|----------------|
-| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中   |
-| `BACKING_UP`               | バックアップ中        |
-| `CANCELING`                | キャンセル中         |
-| `CREATING`                 | 作成中            |
-| `CREATING_SCHEMA`          | DBスキーマ作成中	     |
-| `CREATING_USER`            | ユーザー作成中	       |
-| `DELETING`                 | 削除中            |
-| `DELETING_SCHEMA`          | DBスキーマ削除中      |
-| `DELETING_USER`            | ユーザー削除中        |
-| `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中      |
-| `MIGRATING`                | マイグレーション中      |
-| `MODIFYING`                | 修正中            |
-| `PREPARING`                | 準備中            |
-| `PROMOTING`                | 昇格中            |
-| `REBUILDING`               | 再構築中           |
-| `REPAIRING`                | 復旧中            |
-| `REPLICATING`              | 複製中            |
-| `RESTARTING`               | 再起動中           |
-| `RESTARTING_FORCIBLY`      | 強制再起動中         |
-| `RESTORING`                | 復元中            |
-| `STARTING`                 | 起動中            |
-| `STOPPING`                 | 停止中            |
-| `SYNCING_SCHEMA`           | DBスキーマ同期中      |
-| `SYNCING_USER`             | ユーザー同期中	       |
-| `UPDATING_USER`            | ユーザー修正中	       |
+| 状態 | 説明 |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
+| `BACKING_UP` | バックアップ中 |
+| `CANCELING` | キャンセル中 |
+| `CREATING` | 作成中 |
+| `CREATING_SCHEMA` | DBスキーマ作成中 |
+| `CREATING_USER` | ユーザー作成中 |
+| `DELETING` | 削除中 |
+| `DELETING_SCHEMA` | DBスキーマ削除中 |
+| `DELETING_USER` | ユーザー削除中 |
+| `EXPORTING_BACKUP` | バックアップをエクスポート中 |
+| `FAILING_OVER` | フェイルオーバー中 |
+| `MIGRATING` | マイグレーション中 |
+| `MODIFYING` | 修正中 |
+| `PREPARING` | 準備中 |
+| `PROMOTING` | 昇格中 |
+| `REBUILDING` | 再構築中 |
+| `REPAIRING` | 復旧中 |
+| `REPLICATING` | 複製中 |
+| `RESTARTING` | 再起動中 |
+| `RESTARTING_FORCIBLY` | 強制再起動中 |
+| `RESTORING` | 復元中 |
+| `STARTING` | 起動中 |
+| `STOPPING` | 停止中 |
+| `SYNCING_SCHEMA` | DBスキーマ同期中 |
+| `SYNCING_USER` | ユーザー同期中 |
+| `UPDATING_USER` | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
+
+#### リクエスト
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                            | 種類   | 形式       | 説明                                                                                                                                      |
-|-------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                             |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                        |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                           |
-| dbInstances.dbVersion         | Body | Enum     | DBエンジンタイプ                                                                                                                               |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                                   |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                         |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBインスタンスの詳細を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類   | 形式       | 説明                                                                                                                                      |
-|-----------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstanceGroupId           | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| dbInstanceName              | Body | String   | DBインスタンスを識別できる名前                                                                                                                        |
-| description                 | Body | String   | DBインスタンスの追加情報                                                                                                                           |
-| dbVersion                   | Body | Enum     | DBエンジンタイプ                                                                                                                               |
-| dbPort                      | Body | Number   | DBポート                                                                                                                                   |
-| dbInstanceType              | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus            | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| progressStatus              | Body | Enum     | DBインスタンスの現在作業進行状態                                                                                                                       |
-| dbFlavorId                  | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                          |
-| parameterGroupId            | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                       |
-| notificationGroupIds        | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                             |
-| useDeletionProtection       | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | 認証プラグインサポートの有無                                                                                                                          |
-| needToApplyParameterGroup   | Body | Boolean  | 最新パラメータグループの適用が必要かどうか                                                                                                                   |
-| needMigration               | Body | Boolean  | マイグレーションが必要かどうか                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | DBのバージョンアップグレードをサポートするかどうか                                                                                                              |
-| createdYmdt                 | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| updatedYmdt                 | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstances | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | String | DBエンジンタイプ |
+| dbInstances.dbPort | Number | DBポート |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを作成する
 
+#### リクエスト
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                                       | 種類   | 形式      | 必須 | 説明                                                                  |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName                  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                                |
-| description                              | Body | String  | X  | DBインスタンスに関する追加情報                                                    |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbVersion                                | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| dbUserName                               | Body | String  | O  | DBユーザーアカウント名                                                        |
-| dbPassword                               | Body | String  | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                 |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                     |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                       |
-| authenticationPlugin                     | Body | Enum    | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                   |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                 | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                  |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                   | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-| 名前                     | 種類  | 形式     | 必須 | 説明                                        |
-|-------------------------|------|---------|----|--------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                              |
-| dbInstanceName          | Body | String  | X  | DBインスタンスを識別できるマスター名                  |
-| dbInstanceCandidateName | Body | String  | X  | DBインスタンスを識別できる予備マスター名               |
-| description             | Body | String  | X  | DBインスタンスに関する追加情報                         |
-| dbPort                  | Body | Number  | X  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                                |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                                 |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                           |
-| executeBackup      | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| useOnlineFailover  | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを削除する
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを再起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### リクエスト
-
-| 名前                | 種類   | 形式      | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| executeBackup     | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを強制再起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### リクエスト
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DBインスタンスを起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを停止する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスをバックアップする
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### リクエスト
-
-| 名前           | 種類   | 形式     | 必須 | 説明             |
-|--------------|------|--------|----|----------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子   |
-| backupName   | Body | String | O  | バックアップを識別できる名前 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスバックアップ後にエクスポート
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                     |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを複製する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                       |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                 |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                              |
-| description              | Body | String  | X  | DBインスタンスに関する追加情報                                                        |
-| dbFlavorId               | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                  |
-| dbPort                   | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `3306`<br/>- 最大値: `43306`        |
-| parameterGroupId         | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                     |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                 |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                           |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                            |
-| useDeletionProtection    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                               |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                               |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:原本DBインスタンス値                                      |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                  |
-| storage                  | Body | Object  | X  | データストレージ情報オブジェクト                                                           |    
-| storage.storageType      | Body | Enum    | X  | データストレージタイプ<br/>- 例: `General SSD`                        |
-| storage.storageSize      | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `20`<br/>- 最大値: `2048` |
-| backup                   | Body | Object  | X  | バックアップ情報オブジェクト                                                                 |
-| backup.backupPeriod      | Body | Number  | X  | バックアップ保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `730`       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `10`          |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                               |
-| backup.backupSchedules                   | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | バックアップ開始時刻<br/>- 例: `00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-"dbInstanceName": "db-instance-replicate",
-"description": "description",
-"dbPort": 11000,
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
 "network": {
-    "availabilityZone": "kr-pub-a"
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
 },
 "storage": {
-    "stroageSize": 100
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### DBインスタンスを昇格する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
+### オブジェクトストレージを利用したDBインスタンスの復元
 
 #### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 復元情報照会
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### リクエスト
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                      | 種類   | 形式       | 説明                                                                                                                                                                                       |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最古の復元可能時間                                                                                                                                                                                |
-| latestRestorableYmdt                    | Body | DateTime | 最新の復元可能時間                                                                                                                                                                                |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | バックアップ情報オブジェクト                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                                                               |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                                                  |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | テーブルロックを使用するかどうか                                                                                                                                                                         |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                                                |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`: 自動<br/>- `MANUAL`: 手動                                                                                                                           |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了している場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除されている場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                                                           |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンスの名前                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DBエンジンタイプ                                                                                                                                                                                |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                                                               |
-| restorableBackups.backup.binLogFileName | Body | String   | バイナリログファイル名                                                                                                                                                                              |
-| restorableBackups.backup.binLogPosition | Body | Number   | バイナリログファイル位置                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                                                               |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                                                               |
-| restorableBackups.restorableBinLogs     | Body | Array    | 該当バックアップを利用して復元可能なバイナリログ名リスト                                                                                                                                                             |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元される最後のクエリ照会
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 共通リクエスト
-
-| 名前           | 種類    | 形式   | 必須 | 説明                                                                                                           |
-|--------------|-------|------|----|--------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DBインスタンスの識別子                                                                                                 |
-| restoreType  | Query | Enum | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ |
-
-#### restoreTypeが`TIMESTAMP`の場合
-
-| 名前          | 種類    | 形式       | 必須 | 説明                                       |
-|-------------|-------|----------|----|------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreTypeが`BINLOG`の場合
-
-| 名前             | 種類    | 形式     | 必須 | 説明                |
-|----------------|-------|--------|----|-------------------|
-| backupId       | Query | UUID   | O  | 復元に使用するバックアップの識別子 |
-| binLogFileName | Query | String | O  | 復元に使用するバイナリログの名前  |
-| binLogPosition | Query | Number | O  | 復元に使用するバイナリログの位置  |
-
-#### レスポンス
-
-| 名前           | 種類   | 形式       | 説明                                  |
-|--------------|------|----------|-------------------------------------|
-| executedYmdt | Body | DateTime | クエリ実行日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 最後に実行したクエリ                          |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 共通リクエスト
-
-| 名前                       | 種類   | 形式      | 必須 | 説明                                                                                                                                         |
-|--------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                               |
-| restore                  | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                 |
-| restore.restoreType      | Body | Enum    | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ<br/>- `BACKUP`:既存に作成したバックアップを利用したスナップショット復元タイプ |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                                                                                       |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                                                                                                     |
-| description              | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                           |
-| dbFlavorId               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                             |
-| dbPort                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                                                                                                 |
-| parameterGroupId         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                              |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                        |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                            |
-| useHighAvailability      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                        |
-| pingInterval             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                         |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                                                                                        |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                             |
-| network.subnetId         | Body | UUID    | O  | サブネットの識別子                                                                                                                                  |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                               |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                               |
-| storage                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                              |
-| storage.storageType      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                         |
-| storage.storageSize      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                          |
-| backup                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                             |
-| backup.backupPeriod      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                              |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                        |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                               |
-| backup.useBackupLock                                | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| backup.backupSchedules                              | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O  | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護を行うかどうか<br>デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-
-#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                  | 種類   | 形式       | 必須 | 説明                                                                                |
-|---------------------|------|----------|----|-----------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
-
-| 名前                            | 種類   | 形式     | 必須 | 説明                |
-|-------------------------------|------|--------|----|-------------------|
-| restore.backupId              | Body | UUID   | O  | 復元に使用するバックアップの識別子 |
-| restore.binLog                | Body | Object | O  | バイナリログ情報オブジェクト    |
-| restore.binLog.binLogFileName | Body | String | O  | 復元に使用するバイナリログの名前  |
-| restore.binLog.binLogPosition | Body | Number | O  | 復元に使用するバイナリログの位置  |
-
-* バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
-
-| 名前               | 種類   | 形式   | 必須                         | 説明                |
-|------------------|------|------|----------------------------|-------------------|
-| restore.backupId | Body | UUID | O(restoreTypeが`BACKUP`の場合) | 復元に使用するバックアップの識別子 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### オブジェクトストレージから復元
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                       | 種類   | 形式      | 必須 | 説明                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| restore                  | Body | Object  | O  | 復元情報オブジェクト                                                          |
-| restore.tenantId         | Body | String  | O  | バックアップが保存されたオブジェクトストレージのテナントID                                      |
-| restore.username         | Body | String  | O  | NHN Cloud会員またはIAMメンバーID                                             |
-| restore.password         | Body | String  | O  | バックアップが保存されたオブジェクトストレージのAPIパスワード                                    |
-| restore.targetContainer  | Body | String  | O  | バックアップが保存されたオブジェクトストレージのコンテナ                                        |
-| restore.objectPath       | Body | String  | O  | コンテナに保存されたバックアップのパス                                                 |
-| dbVersion                | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                              |
-| description              | Body | String  | X  | DBインスタンスに対する追加情報                                                    |
-| dbFlavorId               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbPort                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`  |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                      |
-| network.subnetId         | Body | UUID    | O  | サブネットの識別子                                                           |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                        |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                        |
-| storage                  | Body | Object  | O  | ストレージ情報オブジェクト                                                       |
-| storage.storageType      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                  |
-| storage.storageSize      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                   |
-| backup                   | Body | Object  | O  | バックアップ情報オブジェクト                                                      |
-| backup.backupPeriod      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`        |
-| backup.useBackupLock                                | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| backup.backupSchedules                              | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O  | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### リクエスト
-
-| 名前                    | 種類   | 形式      | 必須 | 説明           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無      |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート |
+| dbVersion | String | Y | DBエンジンタイプ |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.tenantId | String | Y | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | String | Y | NHN CloudアカウントまたはメンバーアカウントまたはIAMメンバーID |
+| restore.password | String | Y | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | String | Y | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | String | Y | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-<p>
+---
+
+### DBインスタンスを削除する
+
+#### リクエスト
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 高可用性を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### リクエスト
-
-| 名前                  | 種類   | 形式      | 必須 | 説明                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                         |
-| useHighAvailability | Body | Boolean | O  | 高可用性を使用するかどうか                                        |
-| pingInterval        | Body | Number  | X  | 高可用性を使用する時、Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### 高可用性を再開する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
-```
+### DBインスタンスの詳細を表示
 
 #### リクエスト
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を一時停止する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を復旧する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を分離する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ストレージ情報を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前            | 種類   | 形式     | 説明                                                                                        |
-|---------------|------|--------|-------------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | データストレージタイプ                                                                               |
-| storageSize   | Body | Number | データストレージサイズ(GB)                                                                           |
-| storageStatus | Body | Enum   | データストレージの現在状態<br/>- `DETACHED`:取り付けられていない<br/>- `ATTACHED`:取り付けられている<br/>- `DELETED`:削除済み |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | String | DBインスタンスを識別できる名前 |
+| description | String | DBインスタンスの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| dbPort | Number | DBポート |
+| dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Boolean | DBインスタンス削除保護の有無 |
+| supportAuthenticationPlugin | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Boolean | DBバージョンアップグレードをサポートするかどうか |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
-### ストレージ情報を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### DBインスタンスを修正する
 
 #### リクエスト
 
-| 名前                | 種類   | 形式      | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| storageSize       | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値: `2048`                               |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbVersion | String | N | DBエンジンバージョンコード |
+| useDummy | Boolean | N | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷を遮断するかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスをバックアップする
+
+#### リクエスト
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"backupName": "backupName"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupName | String | Y | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### バックアップ情報を表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                                    | 種類   | 形式      | 説明               |
-|---------------------------------------|------|---------|------------------|
-| backupPeriod                          | Body | Number  | バックアップ保管期間(日)    |
-| ftwrlWaitTimeout                      | Body | Number  | クエリ遅延待機時間(秒)     |
-| backupRetryCount                      | Body | Number  | バックアップ再試行回数      |
-| replicationRegion                     | Body | Enum    | バックアップ複製リージョン    |
-| useBackupLock                         | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules                       | Body | Array   | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime      | Body | String  | バックアップ開始時刻       |
-| backupSchedules.backupWndDuration     | Body | Enum    | バックアップDuration   |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backupPeriod | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Number | バックアップ再試行回数 |
+| replicationRegion | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### バックアップ情報を修正する
 
+#### リクエスト
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前                                | 種類   | 形式      | 必須 | 説明                                                                                                                                                                                                                             |
-|-----------------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                   |
-| backupPeriod                      | Body | Number  | X  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                                     |
-| useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか                                                                                                                                                                                                               |
-| backupSchedules                   | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-"backupPeriod": 5,
-"useBackupLock": true,
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
 "backupSchedules": [
-    {
-        "backupWndBgnTime": "01:00:00",
-        "backupWndDuration": "TWO_HOURS"
-    }
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
 ]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### ネットワーク情報を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
+### DBインスタンスバックアップ後にエクスポート
 
 #### リクエスト
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### テスト用DBイメージメタの変更
+
+#### リクエスト
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                     | 種類   | 形式     | 説明                                                                                                                             |
-|------------------------|------|--------|--------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DBインスタンスを作成するアベイラビリティゾーン                                                                                                       |
-| subnet                 | Body | Object | サブネットオブジェクト                                                                                                                    |
-| subnet.subnetId        | Body | UUID   | サブネットの識別子                                                                                                                      |
-| subnet.subnetName      | Body | UUID   | サブネットの識別できる名前                                                                                                                  |
-| subnet.subnetCidr      | Body | UUID   | サブネットのCIDR                                                                                                                     |
-| endPoints              | Body | Array  | 接続情報リスト                                                                                                                        |
-| endPoints.domain       | Body | String | ドメイン                                                                                                                           |
-| endPoints.ipAddress    | Body | String | IPアドレス                                                                                                                         |
-| endPoints.endPointType | Body | Enum   | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`: (Deprecated)外部接続ドメイン<br>-`PRIVATE`: (Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ネットワーク情報を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式      | 必須 | 説明           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否       |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーリストを表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                           | 種類   | 形式       | 説明                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DBユーザーリスト                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DBユーザーの識別子                                                                                                                  |
-| dbUsers.dbUserName           | Body | String   | DBユーザーアカウント名                                                                                                                |
-| dbUsers.host                 | Body | String   | DBユーザーアカウントのホスト名                                                                                                            |
-| dbUsers.authorityType        | Body | Enum     | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/>                      |
-| dbUsers.dbUserStatus         | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `UPDATING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み         |
-| dbUsers.authenticationPlugin | Body | Enum     | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-| dbUsers.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBユーザーを作成する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserName           | Body | String | O  | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32`                                                          |
-| dbPassword           | Body | String | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| host                 | Body | String | O  | DBユーザーアカウントのホスト名<br/>- 例: `1.1.1.%`                                                                    |
-| authorityType        | Body | Enum   | O  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserId             | URL  | UUID   | O  | DBユーザーの識別子                                                                                             |
-| dbPassword           | Body | String | X  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| authorityType        | Body | Enum   | X  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを削除する
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子   |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### DBスキーマリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                       | 種類   | 形式       | 説明                                                                                             |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DBスキーマリスト                                                                                      |
-| dbSchemas.dbSchemaId     | Body | UUID     | DBスキーマの識別子                                                                                     |
-| dbSchemas.dbSchemaName   | Body | String   | DBスキーマ名                                                                                        |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DBスキーマの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbSchemas.createdYmdt    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                               |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSchemas | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### DBスキーマを作成する
 
+#### リクエスト
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前           | 種類   | 形式     | 必須 | 説明           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O  | DBスキーマ名      |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_ のみ使用可能、1～64文字、MySQLの予約語は不可 |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### DBスキーマを削除する
 
+#### リクエスト
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbSchemaId   | URL | UUID | O  | DBスキーマの識別子   |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーリストを表示
+
+#### リクエスト
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbUsers | Array | DBユーザーリスト |
+| dbUsers.dbUserId | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | String | DBユーザーアカウント名 |
+| dbUsers.host | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| dbUsers.dbUserStatus | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+---
+
+### DBユーザーを作成する
+
+#### リクエスト
+
+```http
+<!-- TERM-UNRESOLVED: DB 이미지 메타 (セクション「テスト用DBイメージメタの変更」— 発行済みJA先例なし) -->
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | String | Y | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Enum | Y | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーを修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Enum | N | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンス削除保護設定を変更する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 削除保護の有無 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスを強制再起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 高可用性を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"useHighAvailability": false,
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 高可用性を使用するかどうか |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を一時停止する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を復旧する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を再開する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を分離する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### ログファイルリスト表示
 
+#### リクエスト
+
 ```http
-GET /v3.0/db-instances/{dbInstanceId}/log-files
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類    | 形式    | 必須 | 説明                                                                                                                                                                                             |
-|--------------|-------|-------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DBインスタンスの識別子                                                                                                                                                                                   |
-| logFileTypes | Query | Array | X  | ログファイルタイプ種類一覧<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### レスポンス
 
-| 名前                   | 種類   | 形式       | 説明                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | ログファイルリスト                                                                                                                                                                                    |
-| logFiles.logFileName | Body | String   | ログファイル名                                                                                                                                                                                      |
-| logFiles.logFileType | Body | Enum     | ログファイルタイプ種類<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | ログファイルサイズ(Byte)                                                                                                                                                                              |
-| logFiles.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| logFiles | Array | ログファイルリスト |
+| logFiles.logFileName | String | ログファイル名 |
+| logFiles.logFileType | Enum | ログファイルタイプ種類<br/>- `ERROR`<br/>- `BINLOG`<br/>- `GENERAL`<br/>- `SLOW_QUERY`<br/>- `AUDIT`<br/>- `BACKUP` |
+| logFiles.logFileSize | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### ログファイルのエクスポート
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/log-files/export
-```
-
 #### リクエスト
 
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                     |
-| logFileNames    | Body | Array  | O  | ログファイル名リスト<br/>- 最小サイズ: `1`      |
-| tenantId        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID      |
-| password        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | ログファイルが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるログファイルのパス              |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | ログファイル名リスト |
+| tenantId | String | Y | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるログファイルのパス |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### ネットワーク情報を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"availabilityZone": "kr-pub-a",
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetName": "subnetName-example",
+},
+},
+{
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZone | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Object | サブネットオブジェクト |
+| subnet.subnetId | UUID | サブネットの識別子 |
+| subnet.subnetName | String | サブネットの識別できる名前 |
+| subnet.subnetCidr | String | サブネットのCIDR |
+| endPoints | Array | 接続情報リスト |
+| endPoints.domain | String | ドメイン |
+| endPoints.ipAddress | String | IPアドレス |
+| endPoints.endPointType | String | 接続情報タイプ |
+
+---
+
+### ネットワーク情報を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 外部接続可否 |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを昇格する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを複製する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Boolean | N | 外部接続可否 |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | N | ストレージ情報オブジェクト |
+| storage.storageType | Enum | N | データストレージタイプ |
+| storage.storageSize | Number | N | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | N | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを再起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷を遮断するかどうか<br/>- デフォルト値: `false` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 復元情報照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 復元される最後のクエリ照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| executedYmdt | DateTime | クエリ実行日時 |
+| lastQuery | String | 最後に実行したクエリ |
+
+---
+
+### DBインスタンスを復元する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+}
+}
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.restoreType | Enum | Y | 復元タイプ<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元` |
+| restore.binLog.binLogFileName | String | N | 復元に使用するバイナリログの名前 |
+| restore.binLog.binLogPosition | Object | N | 復元に使用するバイナリログの位置 |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DBインスタンス復元日時 |
+
+POST /v3.0/db-instances/{dbInstanceId}/restore
+
+#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+| restore.binLog | Object | N | 復元に使用するバイナリログ情報オブジェクト |
+
+復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
+
+#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを停止する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### ストレージ情報を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageType": "General SSD",
+"storageSize": 1,
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageType | Enum | データストレージタイプ |
+| storageSize | Number | データストレージサイズ(GB) |
+| storageStatus | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り付けられていない`<br/>- ATTACHED: `取り付けられている` |
+
+---
+
+### ストレージ情報を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2332,222 +2941,290 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### バックアップ状態
 
-| 状態           | 説明               |
-|--------------|------------------|
-| `BACKING_UP` | バックアップ中の場合       |
-| `COMPLETED`  | バックアップが完了している場合  |
-| `DELETING`   | バックアップが削除中の場合    |
-| `DELETED`    | バックアップが削除されている場合 |
-| `ERROR`      | エラーが発生した場合       |
+| 状態 | 説明 |
+|--------------|--------------|
+| `BACKING_UP` | バックアップ中の場合 |
+| `COMPLETED` | バックアップが完了している場合 |
+| `DELETING` | バックアップが削除中の場合 |
+| `DELETED` | バックアップが削除されている場合 |
+| `ERROR` | エラーが発生した場合 |
 
 ### バックアップリスト照会
 
+#### リクエスト
+
 ```http
-GET /v3.0/backups
+---
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類    | 形式     | 必須 | 説明                                                          |
-|--------------|-------|--------|----|-------------------------------------------------------------|
-| page         | Query | Number | O  | 照会するリストのページ<br/>- 最小値: `1`                                  |
-| size         | Query | Number | O  | 照会するリストのページサイズ<br/>- 最小値: `1`<br/>- 最大値: `100`              |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動<br/>- デフォルト値:全体 |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                              |
-| dbVersion    | Query | Enum   | X  | DBエンジンタイプ                                                   |
-
 #### レスポンス
 
-| 名前                   | 種類   | 形式       | 説明                               |
-|----------------------|------|----------|----------------------------------|
-| totalCounts          | Body | Number   | 全バックアップリスト数                      |
-| backups              | Body | Array    | バックアップリスト                        |
-| backups.backupId     | Body | UUID     | バックアップの識別子                       |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                   |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態                      |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                   |
-| backups.dbVersion    | Body | Enum     | DBエンジンタイプ                        |
-| backups.backupType   | Body | Enum     | バックアップタイプ                        |
-| backups.backupSize   | Body | Number   | バックアップのサイズ(Byte)                 |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### バックアップのエクスポート
-
-```http
-POST /v3.0/backups/{backupId}/export
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                       |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-> [注意]
-> 手動バックアップの場合、バックアップが行われたDBインスタンスが存在しない場合、バックアップをオブジェクトストレージにエクスポートすることができません。
-
----
-
-### バックアップを復元する
-
-```http
-POST /v3.0/backups/{backupId}/restore
-```
-
-#### リクエスト
-
-| 名前                                       | 種類   | 形式      | 必須 | 説明                                                                                                                                                                                                                             |
-|------------------------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | バックアップの識別子                                                                                                                                                                                                                     |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                           |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                        |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                  |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                                 |
-| dbPort                                   | Body | Integer | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                                                                                                                                                                                     |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                                  |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                            ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                            |
-| pingInterval                             | Body | Number  | X  | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                                                                                                         |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                                                                                                                                                                                  | 
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                 | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                  |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                   | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-
-{
-"dbInstanceName": "db-instance-restore",
-"dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-"dbPort": 10000,
-"parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-"network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-    "availabilityZone": "kr-pub-a"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
 },
-"storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
 },
-"backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [{
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR"
-    }
-    ]
+"totalCounts": 1,
+{
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
+]
 }
 ```
 
-</p>
 </details>
 
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全バックアップリスト数 |
+| backups | Array | バックアップリスト |
+| backups.backupId | UUID | バックアップの識別子 |
+| backups.backupName | String | バックアップを識別できる名前 |
+| backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤アイコン)` |
+| backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | String | DBエンジンタイプ |
+| backups.utilVersion | String | ユーティリティバージョン |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | DateTime | 作成日時 |
+| backups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップを削除する
 
+#### リクエスト
+
 ```http
-DELETE /v3.0/backups/{backupId}
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前       | 種類  | 形式   | 必須 | 説明         |
-|----------|-----|------|----|------------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### バックアップのエクスポート
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### バックアップを復元する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2555,405 +3232,464 @@ DELETE /v3.0/backups/{backupId}
 
 ### DBセキュリティグループ進行状態
 
-| 状態              | 説明          |
-|-----------------|-------------|
-| `NONE`          | 進行中の作業がない   |
+| 状態 | 説明 |
+|-----------------|--------------|
+| `NONE` | 進行中の作業がない |
 | `CREATING_RULE` | ルールポリシーの作成中 |
 | `UPDATING_RULE` | ルールポリシーの修正中 |
 | `DELETING_RULE` | ルールポリシーの削除中 |
 
 ### DBセキュリティグループリストを表示
 
-```http
-GET /v3.0/db-security-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                                   | 種類   | 形式       | 説明                               |
-|--------------------------------------|------|----------|----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DBセキュリティグループリスト                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前             |
-| dbSecurityGroups.description         | Body | String   | DBセキュリティグループの追加情報                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態              |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### DBセキュリティグループの詳細を表示
-
-```http
-GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
 #### レスポンス
 
-| 名前                  | 種類   | 形式       | 説明                                                                                                                |
-|---------------------|------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                                                                                                  |
-| dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前                                                                                              |
-| description         | Body | String   | DBセキュリティグループの追加情報                                                                                                 |
-| progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態                                                                                               |
-| rules               | Body | Array    | DBセキュリティグループルールリスト                                                                                                |
-| rules.ruleId        | Body | UUID     | DBセキュリティグループルールの識別子                                                                                               |
-| rules.description   | Body | String   | DBセキュリティグループルールの追加情報                                                                                              |
-| rules.direction     | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                         |
-| rules.etherType     | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                    |
-| rules.port          | Body | Object   | ポートオブジェクト                                                                                                         |
-| rules.port.portType | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。<br/>- `PORT`:指定されたポート値に設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number   | 最小ポート範囲                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 最大ポート範囲                                                                                                           |
-| rules.cidr          | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                  |
-| rules.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを作成する
 
-```http
-POST /v3.0/db-security-groups
-```
-
 #### リクエスト
 
-| 名前                  | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|---------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                    |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                   |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前                | 種類   | 形式   | 説明               |
-|-------------------|------|------|------------------|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
+```http
 ---
-
-### DBセキュリティグループを修正する
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                  | 種類   | 形式     | 必須 | 説明                   |
-|---------------------|------|--------|----|----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子     |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報    |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+{
+"description": "description-example",
+"description": "description-example",
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Array | Y | DBセキュリティグループルールリスト |
+| rules.direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | Y | ポートオブジェクト |
+| rules.port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | セキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
 
 ---
 
 ### DBセキュリティグループを削除する
 
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+---
+```
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
-### DBセキュリティグループルールを作成する
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+### DBセキュリティグループの詳細を表示
 
 #### リクエスト
 
-| 名前                | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|-------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                     |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"description": "description-example",
+{
+{
+"description": "description-example",
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DBセキュリティグループ |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroup.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroup.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroup.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroup.rules | Array | DBセキュリティグループルールリスト |
+| dbSecurityGroup.rules.ruleId | UUID | DBセキュリティグループルールの識別子 |
+| dbSecurityGroup.rules.description | String | DBセキュリティグループルールの追加情報 |
+| dbSecurityGroup.rules.direction | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| dbSecurityGroup.rules.etherType | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| dbSecurityGroup.rules.port | Object | ポートオブジェクト |
+| dbSecurityGroup.rules.port.portType | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| dbSecurityGroup.rules.port.minPort | Number | 最小ポート範囲 |
+| dbSecurityGroup.rules.port.maxPort | Number | 最大ポート範囲 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 修正日時 |
+| dbSecurityGroup.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
-### DBセキュリティグループルールを修正する
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
+### DBセキュリティグループを修正する
 
 #### リクエスト
 
-| 名前                | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|-------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                  |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
+```http
+---
+```
 
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+#### リクエストパラメータ
 
-<details><summary>例</summary>
-<p>
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### DBセキュリティグループルールを削除する
 
+#### リクエスト
+
 ```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類    | 形式    | 必須 | 説明                     |
-|-------------------|-------|-------|----|------------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子       |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBセキュリティグループルールを作成する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBセキュリティグループルールを修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2961,958 +3697,916 @@ DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 
 ### パラメータグループリストを表示
 
-```http
-GET /v3.0/parameter-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-| 名前        | 種類    | 形式   | 必須 | 説明        |
-|-----------|-------|------|----|-----------|
-| dbVersion | Query | Enum | X  | DBエンジンタイプ |
-
-#### レスポンス
-
-| 名前                                   | 種類   | 形式       | 説明                                                            |
-|--------------------------------------|------|----------|---------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                  |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                 |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                             |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                                |
-| parameterGroups.dbVersion            | Body | Enum     | DBエンジンタイプ                                                     |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                              |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
+```http
 ---
-
-### パラメータグループの詳細を表示
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
 #### レスポンス
 
-| 名前                            | 種類   | 形式       | 説明                                                                                              |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | パラメータグループの識別子                                                                                   |
-| parameterGroupName            | Body | String   | パラメータグループを識別できる名前                                                                               |
-| description                   | Body | String   | パラメータグループの追加情報                                                                                  |
-| dbVersion                     | Body | Enum     | DBエンジンタイプ                                                                                       |
-| parameterGroupStatus          | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要                                   |
-| parameters                    | Body | Array    | パラメータリスト                                                                                        |
-| parameters.parameterId        | Body | UUID     | パラメータ識別子                                                                                        |
-| parameters.parameterFileGroup | Body | Enum     | パラメータファイルグループタイプ<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld             |
-| parameters.parameterName      | Body | String   | パラメータ名                                                                                          |
-| parameters.fileParameterName  | Body | String   | パラメータファイル名                                                                                      |
-| parameters.value              | Body | String   | 現在設定されている値                                                                                      |
-| parameters.defaultValue       | Body | String   | デフォルト値                                                                                          |
-| parameters.allowedValue       | Body | String   | 許可された値                                                                                          |
-| parameters.updateType         | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:いつでも修正可能<br/>- `CONSTANT`:修正不可<br/>- `INIT_VARIABLE`: DBインスタンス作成時にのみ修正可能 |
-| parameters.applyType          | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体(再起動必要)               |
-| createdYmdt                   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                |
-| updatedYmdt                   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroups | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | String | DBエンジンタイプ |
+| parameterGroups.parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを作成する
 
-```http
-POST /v3.0/parameter-groups
-```
-
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
-| dbVersion          | Body | Enum   | O  | DBエンジンタイプ         |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+{
+"description": "description-example",
+"description": "description-example",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
+| dbVersion | String | Y | DBエンジンタイプ |
 
 #### レスポンス
 
-| 名前               | 種類   | 形式   | 説明            |
-|------------------|------|------|---------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
-### パラメータグループをコピーする
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
-```
+### パラメータグループを削除する
 
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子     |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前               | 種類   | 形式   | 説明            |
-|------------------|------|------|---------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroupName | String | パラメータグループを識別できる名前 |
+| description | String | パラメータグループの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Array | パラメータリスト |
+| parameters.parameterId | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | パラメータ名 |
+| parameters.fileParameterName | String | パラメータファイル名 |
+| parameters.value | String | 現在設定されている値 |
+| parameters.defaultValue | String | デフォルト値 |
+| parameters.allowedValue | String | 許可された値 |
+| parameters.updateType | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを修正する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子     |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
 
-<details><summary>例</summary>
-<p>
+### パラメータグループをコピーする
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+
 ---
 
 ### パラメータを修正する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
 #### リクエスト
 
-| 名前                             | 種類   | 形式     | 必須 | 説明            |
-|--------------------------------|------|--------|----|---------------|
-| parameterGroupId               | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters             | Body | Array  | O  | 変更するパラメータリスト  |
-| modifiedParameters.parameterId | Body | UUID   | O  | パラメータの識別子     |
-| modifiedParameters.value       | Body | String | O  | 変更するパラメータ値    |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-   "modifiedParameters": [
-       {
-           "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-           "value": "0"
-       }
-   ]
+{
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 変更するパラメータリスト |
+| modifiedParameters.parameterId | UUID | Y | パラメータの識別子 |
+| modifiedParameters.value | String | Y | 変更するパラメータ値 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ### パラメータグループを再設定する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### リクエスト
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### パラメータグループを削除する
-
-```http
-DELETE /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
 
-```http
-GET /v3.0/user-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                               |
-|--------------------------|------|----------|----------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                      |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                 |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### ユーザーグループの詳細を表示
-
-```http
-GET /v3.0/user-groups/{userGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類  | 形式   | 必須 | 説明           |
-|-------------|-----|------|----|--------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
 #### レスポンス
 
-| 名前                | 種類   | 形式       | 説明                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                              |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                          |
-| userGroupTypeCode | Body | Enum     | ユーザーグループの種類  <br /> `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ <br /> `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーをを含むユーザーグループ |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                             |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                            |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                          |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                          |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | DateTime | 作成日時 |
+| userGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを作成する
 
-```http
-POST /v3.0/user-groups
-```
-
 #### リクエスト
 
-| 名前            | 種類   | 形式      | 必須 | 説明                                                              |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                                |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト <br /> `selectAllYN`がtrueの場合、当該フィールドの値は無視されます |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体かどうか <br /> trueの場合、当該グループは全メンバーに対して設定されます          |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | Y | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | N | プロジェクトメンバー全体を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前          | 種類   | 形式   | 説明           |
-|-------------|------|------|--------------|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+
+---
+
+### ユーザーグループを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### ユーザーグループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"members": [
+{
+{
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+| userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Enum | ユーザーグループの種類<br/>- `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ<br/>- `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーを含むユーザーグループ |
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを修正する
 
-```http
-PUT /v3.0/user-groups/{userGroupId}
-```
-
 #### リクエスト
 
-| 名前            | 種類   | 形式      | 必須 | 説明                                                    |
-|---------------|------|---------|----|-------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                          |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                                      |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                     |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体かどうか<br /> trueの場合、当該グループは全メンバーに対して設定されます |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### ユーザーグループを削除する
-
-```http
-DELETE /v3.0/user-groups/{userGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前          | 種類  | 形式   | 必須 | 説明           |
-|-------------|-----|------|----|--------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | N | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | N | プロジェクトメンバー全体を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## 通知グループ
 
 ### 通知グループリストを表示
 
-```http
-GET /v3.0/notification-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                                       | 種類   | 形式       | 説明                               |
-|------------------------------------------|------|----------|----------------------------------|
-| notificationGroups                       | Body | Array    | 通知グループリスト                        |
-| notificationGroups.notificationGroupId   | Body | UUID     | 通知グループの識別子                       |
-| notificationGroups.notificationGroupName | Body | String   | 通知グループを識別できる名前                   |
-| notificationGroups.notifyEmail           | Body | Boolean  | メール通知                            |
-| notificationGroups.notifySms             | Body | Boolean  | SMS通知                            |
-| notificationGroups.isEnabled             | Body | Boolean  | 有効かどうか                           |
-| notificationGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### 通知グループの詳細を表示
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                  | 種類  | 形式   | 必須 | 説明         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-
 #### レスポンス
 
-| 名前                         | 種類   | 形式       | 説明                               |
-|----------------------------|------|----------|----------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                       |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                   |
-| notifyEmail                | Body | Boolean  | メール通知                            |
-| notifySms                  | Body | Boolean  | SMS通知                            |
-| isEnabled                  | Body | Boolean  | 有効化かどうか                          |
-| dbInstances                | Body | Array    | 監視対象DBインスタンスリスト                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                     |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                 |
-| userGroups                 | Body | Array    | ユーザーグループリスト                      |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                 |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-            {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }],
-    "userGroups": [
-            {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroups | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Boolean | メール通知 |
+| notificationGroups.notifySms | Boolean | SMS通知 |
+| notificationGroups.isEnabled | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを作成する
 
-```http
-POST /v3.0/notification-groups
-```
-
 #### リクエスト
 
-| 名前                    | 種類   | 形式      | 必須 | 説明                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前              |
-| notifyEmail           | Body | Boolean | X  | メール通知<br/>- デフォルト値: `true`  |
-| notifySms             | Body | Boolean | X  | SMS通知<br/>- デフォルト値: `true`  |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値: `true` |
-| dbInstanceIds         | Body | Array   | O  | 監視対象DBインスタンスの識別子リスト         |
-| userGroupIds          | Body | Array   | O  | ユーザーグループの識別子リスト             |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+{
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 通知グループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| notifyEmail | Boolean | N | メール通知<br/>- デフォルト値: `true` |
+| notifySms | Boolean | N | SMS通知<br/>- デフォルト値: `true` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Array | Y | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
-| 名前                  | 種類   | 形式   | 説明         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+
+---
+
+### 通知グループを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 通知グループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroupName | String | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | メール通知 |
+| notifySms | Boolean | SMS通知 |
+| isEnabled | Boolean | 有効かどうか |
+| dbInstances | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを修正する
 
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
-```
-
 #### リクエスト
 
-| 名前                    | 種類   | 形式      | 必須 | 説明                  |
-|-----------------------|------|---------|----|---------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子          |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前      |
-| notifyEmail           | Body | Boolean | X  | メール通知               |
-| notifySms             | Body | Boolean | X  | SMS通知               |
-| isEnabled             | Body | Boolean | X  | 有効かどうか              |
-| dbInstanceIds         | Body | Array   | X  | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト     |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### 通知グループを削除する
-
-```http
-DELETE /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
 
-| 名前                  | 種類  | 形式   | 必須 | 説明         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": true,
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知<br/>- デフォルト値: `false` |
+| notifySms | Boolean | N | SMS通知<br/>- デフォルト値: `false` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Array | N | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## モニタリング
 
-### Metricリストを表示
-
-```http
-GET /v3.0/metrics
-```
+### 統計情報の照会
 
 #### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                  | 種類   | 形式     | 説明        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metricリスト |
-| metrics.measureName | Body | Enum   | 照会指標タイプ   |
-| metrics.unit        | Body | String | 測定値単位     |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
+このAPIはレスポンス本文を返しません。
 
 ---
 
-### 統計情報の照会
-
-```http
-GET /v3.0/metric-statistics
-```
+### Metricリストを表示
 
 #### リクエスト
 
-| 名前           | 種類    | 形式       | 必須 | 説明                               |
-|--------------|-------|----------|----|----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                     |
-| measureNames | Query | Array    | O  | 照会指標リスト<br/>- 最小サイズ: `1`         |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 照会間隔                             |
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                | 種類   | 形式        | 説明      |
-|-----------------------------------|------|-----------|---------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.measureName      | Body | Enum      | 測定項目タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位   |
-| metricStatistics.values           | Body | Array     | 測定値リスト  |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間    |
-| metricStatistics.values.value     | Body | Object    | 測定値     |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"measureName": "measureName-example",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| metrics | Array | Metricリスト |
+| metrics.measureName | String | 照会指標タイプ |
+| metrics.unit | String | 測定値単位 |
 
 ---
 
@@ -3920,137 +4614,340 @@ GET /v3.0/metric-statistics
 
 ### イベントカテゴリー
 
-イベントはカテゴリに分類することができ、下記の通りです。
-
-| イベントカテゴリー   | 説明       |
-|-------------|----------|
-| ALL         | 全体       |
-| BACKUP      | バックアップ   |
-| DB_INSTANCE | DBインスタンス |
-| JOB         | 作業       |
-| TENANT      | テナント     |
-| MONITORING  | モニタリング   |
-
-### イベントリスト照会
-
-```http
-GET /v3.0/events
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                | 種類    | 形式       | 必須 | 説明                                                                                                                                           |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 照会するリストのページ<br/>- 最小値: `1`                                                                                                                   |
-| size              | Query | Number   | O  | 照会するリストのページサイズ<br/>- 最小値: `1`<br/>- 最大値: `100`                                                                                               |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                             |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                             |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `INSTANCE`: DBインスタンス<br/>- `BACKUP`:バックアップ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `TENANT`:テナント |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                                          |
-| keyword           | Query | String   | X  | イベントメッセージに含まれる文字列検索ワード                                                                                                                       |
-| ascendingOrder    | Query | Enum     | X  | イベントメッセージソート順序<br/>- `ASC`:昇順<br/>- `DESC`:降順<br/>- デフォルト値: `DESC`                                                                           |
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                                   |
-|--------------------------|------|----------|--------------------------------------|
-| totalCounts              | Body | Number   | 全イベントリストの数                           |
-| events                   | Body | Array    | イベントリスト                              |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                         |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ                         |
-| events.sourceId          | Body | String   | イベントソースの識別子                          |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                      |
-| events.messages          | Body | Array    | イベントメッセージリスト                         |
-| events.messages.langCode | Body | String   | 言語コード                                |
-| events.messages.message  | Body | String   | イベントメッセージ                            |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
 ---
+
+| イベントカテゴリー | 説明 |
+|-------------|---------|
+| ALL | 全体 |
+| BACKUP | バックアップ |
+| DB_INSTANCE | DBインスタンス |
+| JOB | 作業 |
+| TENANT | テナント |
+| MONITORING | モニタリング |
 
 ### 購読可能なイベントコード一覧表示
 
+#### リクエスト
+
 ```http
-GET /v3.0/event-codes
+イベントはカテゴリに分類することができ、下記の通りです。
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                           | 種類   | 形式    | 説明           |
-|------------------------------|------|-------|--------------|
-| eventCodes                   | Body | Array | イベントコードリスト   |
-| eventCodes.eventCode         | Body | Enum  | イベントコード      |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"eventCode": "ENUM_VALUE",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventCodes | Array | イベントコードリスト |
+| eventCodes.eventCode | Enum | イベントコード |
+| eventCodes.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
+---
+
+### イベントリスト照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+{
+{
+"langCode": "KO",
+}
+],
+],
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベントリストの数 |
+| events | Array | イベントリスト |
+| events.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 発生したイベントのタイプ |
+| events.sourceId | UUID | イベントソースの識別子 |
+| events.sourceName | String | イベントソースを識別できる名前 |
+| events.messages | Array | イベントメッセージリスト |
+| events.messages.langCode | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | イベントメッセージ |
+| events.eventYmdt | DateTime | イベント発生日時 |
+
+---
+
+## イベント購読
+
+### イベント購読リスト照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+],
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベント購読リストの数 |
+| eventSubscriptions | Array | イベント購読リスト |
+| eventSubscriptions.eventSubscriptionId | UUID | イベント購読の識別子 |
+| eventSubscriptions.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | イベント購読を識別できる名前 |
+| eventSubscriptions.enabled | Boolean | 有効かどうか |
+| eventSubscriptions.notifyEmail | Boolean | メール送信するかどうか |
+| eventSubscriptions.notifySms | Boolean | SMS送信するかどうか |
+| eventSubscriptions.eventCodes | Array | 購読するイベントコードリスト |
+| eventSubscriptions.sources | Array | 購読するイベントソースリスト |
+| eventSubscriptions.sources.sourceId | UUID | イベントソースの識別子 |
+| eventSubscriptions.sources.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | イベントを購読しているユーザーグループの識別子リスト |
+| eventSubscriptions.createdYmdt | DateTime | 作成日時 |
+
+---
+
+### イベント購読を作成する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | イベント購読を識別できる名前 |
+| enabled | Boolean | Y | 有効かどうか |
+| notifyEmail | Boolean | Y | メール送信するかどうか |
+| notifySms | Boolean | Y | SMS送信するかどうか |
+| eventCodes | Array | Y | 購読するイベントコードリスト |
+| sources | Array | Y | 購読するイベントソースリスト |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | イベントを購読するユーザーグループの識別子リスト |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | イベント購読の識別子 |
+
+---
+
+### イベント購読を削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### イベント購読を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | イベント購読を識別できる名前 |
+| enabled | Boolean | N | 有効かどうか |
+| notifyEmail | Boolean | N | メール送信するかどうか |
+| notifySms | Boolean | N | SMS送信するかどうか |
+| eventCodes | Array | N | 購読するイベントコードリスト |
+| sources | Array | N | 購読するイベントソースリスト |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | イベントを購読するユーザーグループの識別子リスト |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
 
 ---

--- a/ja/api-guide-v3.0.md
+++ b/ja/api-guide-v3.0.md
@@ -1,12 +1,15 @@
-## Database > RDS for MariaDB > APIガイド
+## RDS for MariaDB API ガイド
+
+**Database > RDS for MariaDB > API v3.0 ガイド**
 
 ## RDS for MariaDB API共通情報
 
 ### APIエンドポイント
 
-| リージョン           | エンドポイント                                       |
-|-----------------|-----------------------------------------------|
+| リージョン | エンドポイント |
+|------|----------|
 | 韓国(パンギョ)リージョン | https://kr1-rds-mariadb.api.nhncloudservice.com |
+
 
 ### 認証および権限
 
@@ -15,153 +18,178 @@ RDS for MariaDB APIを使用するには、User Access Keyが必要です。User
 User Access KeyとSecret Access Keyは、コンソールのAPIセキュリティ設定で発行できます。User Access Keyの発行及び使用に関する詳細は、[User Access Key](/nhncloud/ja/public-api/user-access-key)を参照してください。
 作成されたKeyはAppkeyと一緒にリクエストHeaderに含める必要があります。
 
-| 名前                         | 種類     | 形式     | 必須 | 説明                                                        |
-|----------------------------|--------|--------|----|-----------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O  | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
-| X-TC-AUTHENTICATION-ID     | Header | String | O  | APIセキュリティ設定メニューのUser Access Key ID                        |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O  | APIセキュリティ設定メニューのSecret Access Key                         |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | APIセキュリティ設定メニューのUser Access Key ID |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | APIセキュリティ設定メニューのSecret Access Key |
 
 またプロジェクトメンバーのロールによって呼び出すことができるAPIが制限されます。 `RDS for MariaDB ADMIN`、`RDS for MariaDB VIEWER`に区分して権限を付与できます。
 
 * `RDS for MariaDB ADMIN`権限はすべての機能を使用可能です。
 * `RDS for MariaDB VIEWER`権限は情報を照会する機能のみ使用可能です。
-    * DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
-    * ただし、通知グループとユーザーグループに関連する機能は使用可能です。
+* DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
+* ただし、通知グループとユーザーグループに関連する機能は使用可能です。
 
 APIリクエスト時、認証に失敗したり権限がない場合、次のようなエラーが発生します。
 
-| resultCode | resultMessage | 説明         |
-|------------|---------------|------------|
-| 80401      | Unauthorized  | 認証に失敗しました。 |
-| 80403      | Forbidden     | 権限がありません。  |
+| resultCode | resultMessage | 説明 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 認証に失敗しました。 |
+| 80403 | Forbidden | 権限がありません。 |
 
 ### レスポンス共通情報
 
 すべてのAPIリクエストに「200 OK」でレスポンスします。詳細なレスポンス結果はレスポンス本文のヘッダを参照します。
 
-#### レスポンス本文
+<details>
+  <summary><strong>成功レスポンス</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### フィールド
+</details>
 
-| 名前            | 形式      | 説明                                     |
-|---------------|---------|----------------------------------------|
-| resultCode    | Number  | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
-| resultMessage | String  | 結果メッセージ                                |
-| isSuccessful  | Boolean | 成否                                     |
+<details>
+  <summary><strong>失敗レスポンス</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| resultCode | Number | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
+| resultMessage | String | 結果メッセージ |
+| isSuccessful | Boolean | 成否 |
 ### DBエンジンタイプ
 
 | DBエンジンタイプ | 作成可否 | OBSからの復元可否 | 認証プラグインサポート情報 |
-|-----------------|----------|------------------|-----------------|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
 ## プロジェクト情報
 
-### リージョンリストを表示
-
-```http
-GET /v3.0/project/regions
-```
+### プロジェクトメンバーリストを表示
 
 #### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                 | 種類   | 形式      | 説明                                                                                     |
-|--------------------|------|---------|----------------------------------------------------------------------------------------|
-| regions            | Body | Array   | リージョンリスト                                                                               |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                                                                           |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### プロジェクトメンバーリストを表示
 
 ```http
 GET /v3.0/project/members
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                   | 種類   | 形式     | 説明                 |
-|----------------------|------|--------|--------------------|
-| members              | Body | Array  | プロジェクトメンバーリスト      |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子     |
-| members.memberName   | Body | String | プロジェクトメンバーの名前      |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号    |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | String | プロジェクトメンバーの名前 |
+| members.emailAddress | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | String | プロジェクトメンバーの電話番号 |
+
+---
+
+### リージョンリストを表示
+
+#### リクエスト
+
+```http
+GET /v3.0/project/regions
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| regions | Array | リージョンリスト |
+| regions.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Boolean | リージョンが有効かどうか |
 
 ---
 
@@ -169,47 +197,48 @@ GET /v3.0/project/members
 
 ### DBインスタンス仕様リストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                     | 種類   | 形式     | 説明             |
-|------------------------|------|--------|----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト  |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名    |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数         |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbFlavors | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Number | CPUコア数 |
 
 ---
 
@@ -217,49 +246,50 @@ GET /v3.0/db-flavors
 
 ### サブネットリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                       | 種類   | 形式      | 説明              |
-|--------------------------|------|---------|-----------------|
-| subnets                  | Body | Array   | サブネットリスト        |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子       |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前   |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR      |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| subnets | Array | サブネットリスト |
+| subnets.subnetId | UUID | サブネットの識別子 |
+| subnets.subnetName | String | サブネットの識別できる名前 |
+| subnets.subnetCidr | String | サブネットのCIDR |
+| subnets.usingGateway | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Number | 使用可能なIP数 |
 
 ---
 
@@ -267,45 +297,46 @@ GET /v3.0/network/subnets
 
 ### DBエンジンリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                           | 種類   | 形式      | 説明                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBエンジンリスト             |
-| dbVersions.dbVersion         | Body | String  | DBエンジンタイプ             |
-| dbVersions.dbVersionName     | Body | String  | DBエンジン名前              |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbVersions | Array | DBエンジンリスト |
+| dbVersions.dbVersion | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | String | DBエンジン名前 |
+| dbVersions.restorableFromObs | Boolean | オブジェクトストレージから復元可能かどうか |
 
 ---
 
@@ -313,78 +344,79 @@ GET /v3.0/db-versions
 
 ### ストレージタイプリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/storage-types
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前           | 種類   | 形式    | 説明          |
-|--------------|------|-------|-------------|
-| storageTypes | Body | Array | ストレージタイプリスト |
-
-<details><summary>例</summary>
-
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageTypes | Array | ストレージタイプリスト |
 
 ---
 
 ### ストレージリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/storages
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前       | 種類   | 形式    | 説明       |
-|----------|------|-------|----------|
-| storages | Body | Array | ストレージリスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storages": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storages": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storages | Array | ストレージリスト |
 
 ---
 
@@ -392,72 +424,75 @@ GET /v3.0/storages
 
 ### 作業状態
 
-| 状態名                | 説明                |
-|--------------------|-------------------|
-| `PREPARING`        | 作業が準備中の場合         |
-| `READY`            | 作業が準備完了している場合     |
-| `RUNNING`          | 作業が進行中の場合         |
-| `COMPLETED`        | 作業が完了している場合       |
-| `REGISTERED`       | 作業が登録されている場合      |
-| `WAIT_TO_REGISTER` | 作業登録待機中の場合        |
-| `INTERRUPTED`      | 作業進行中に割り込みが発生した場合 |
-| `CANCELED`         | 作業がキャンセルされた場合     |
-| `FAILED`           | 作業が失敗した場合         |
-| `ERROR`            | 作業進行中にエラーが発生した場合  |
-| `DELETED`          | 作業が削除された場合        |
-| `FAIL_TO_READY`    | 作業の準備に失敗した場合      |
+| 状態名 | 説明 |
+|--------------------|----------------------|
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了している場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了している場合 |
+| `REGISTERED` | 作業が登録されている場合 |
+| `WAIT_TO_REGISTER` | 作業登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業の準備に失敗した場合 |
 
 ### 作業情報の詳細表示
+
+#### リクエスト
 
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前    | 種類  | 形式   | 必須 | 説明     |
-|-------|-----|------|----|--------|
-| jobId | URL | UUID | O  | 作業の識別子 |
-
 #### レスポンス
 
-| 名前                             | 種類   | 形式       | 説明                               |
-|--------------------------------|------|----------|----------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                           |
-| jobStatus                      | Body | Enum     | 作業の現在状態                          |
-| resourceRelations              | Body | Array    | 関連リソースリスト                        |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ                        |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                       |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+| jobStatus | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 関連リソースリスト |
+| resourceRelations.resourceType | String | 関連リソースタイプ |
+| resourceRelations.resourceId | String | 関連リソースの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -465,103 +500,107 @@ GET /v3.0/jobs/{jobId}
 
 ### DBインスタンスグループリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                 | 種類   | 形式       | 説明                                                                     |
-|------------------------------------|------|----------|------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DBインスタンスグループリスト                                                        |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                       |
-| dbInstanceGroups.replicationType   | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                       |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                       |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `単一`<br/>- HIGH_AVAILABILITY: `高可用性(HA)` |
+| dbInstanceGroups.createdYmdt | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスグループの詳細を表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
-
 #### レスポンス
 
-| 名前                           | 種類   | 形式       | 説明                                                                                                                                      |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| replicationType              | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                                  |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `単一`<br/>- HIGH_AVAILABILITY: `高可用性(HA)` |
+| dbInstances | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -569,1762 +608,2332 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                  | 説明                             |
-|---------------------|--------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合               |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合                |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合           |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合              |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合              |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合             |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合      |
-| `SHUTDOWN`          | DBインスタンスが停止した場合                |
-| `DELETED`           | DBインスタンスが削除された場合               |
+| 状態 | 説明 |
+|---------------------|------------------------------|
+| `AVAILABLE` | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE` | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL` | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE` | DBインスタンスの作成に失敗した場合 |
+| `FAIL_TO_CONNECT` | DBインスタンスの接続に失敗した場合 |
+| `REPLICATION_STOP` | DBインスタンスの複製が中断した場合 |
+| `FAILOVER` | DBインスタンスが高可用性(HA)フェイルオーバーした場合 |
+| `SHUTDOWN` | DBインスタンスが停止した場合 |
+| `DELETED` | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                         | 説明             |
-|----------------------------|----------------|
-| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中   |
-| `BACKING_UP`               | バックアップ中        |
-| `CANCELING`                | キャンセル中         |
-| `CREATING`                 | 作成中            |
-| `CREATING_SCHEMA`          | DBスキーマ作成中	     |
-| `CREATING_USER`            | ユーザー作成中	       |
-| `DELETING`                 | 削除中            |
-| `DELETING_SCHEMA`          | DBスキーマ削除中      |
-| `DELETING_USER`            | ユーザー削除中        |
-| `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中      |
-| `MIGRATING`                | マイグレーション中      |
-| `MODIFYING`                | 修正中            |
-| `PREPARING`                | 準備中            |
-| `PROMOTING`                | 昇格中            |
-| `REBUILDING`               | 再構築中           |
-| `REPAIRING`                | 復旧中            |
-| `REPLICATING`              | 複製中            |
-| `RESTARTING`               | 再起動中           |
-| `RESTARTING_FORCIBLY`      | 強制再起動中         |
-| `RESTORING`                | 復元中            |
-| `STARTING`                 | 起動中            |
-| `STOPPING`                 | 停止中            |
-| `SYNCING_SCHEMA`           | DBスキーマ同期中      |
-| `SYNCING_USER`             | ユーザー同期中	       |
-| `UPDATING_USER`            | ユーザー修正中	       |
+| 状態 | 説明 |
+|----------------------------|--------------|
+| `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
+| `BACKING_UP` | バックアップ中 |
+| `CANCELING` | キャンセル中 |
+| `CREATING` | 作成中 |
+| `CREATING_SCHEMA` | DBスキーマ作成中 |
+| `CREATING_USER` | ユーザー作成中 |
+| `DELETING` | 削除中 |
+| `DELETING_SCHEMA` | DBスキーマ削除中 |
+| `DELETING_USER` | ユーザー削除中 |
+| `EXPORTING_BACKUP` | バックアップをエクスポート中 |
+| `FAILING_OVER` | フェイルオーバー中 |
+| `MIGRATING` | マイグレーション中 |
+| `MODIFYING` | 修正中 |
+| `PREPARING` | 準備中 |
+| `PROMOTING` | 昇格中 |
+| `REBUILDING` | 再構築中 |
+| `REPAIRING` | 復旧中 |
+| `REPLICATING` | 複製中 |
+| `RESTARTING` | 再起動中 |
+| `RESTARTING_FORCIBLY` | 強制再起動中 |
+| `RESTORING` | 復元中 |
+| `STARTING` | 起動中 |
+| `STOPPING` | 停止中 |
+| `SYNCING_SCHEMA` | DBスキーマ同期中 |
+| `SYNCING_USER` | ユーザー同期中 |
+| `UPDATING_USER` | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
+
+#### リクエスト
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                            | 種類   | 形式       | 説明                                                                                                                                      |
-|-------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                             |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                        |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                           |
-| dbInstances.dbVersion         | Body | Enum     | DBエンジンタイプ                                                                                                                               |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                                   |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                         |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBインスタンスの詳細を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類   | 形式       | 説明                                                                                                                                      |
-|-----------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DBインスタンスの識別子                                                                                                                            |
-| dbInstanceGroupId           | Body | UUID     | DBインスタンスグループの識別子                                                                                                                        |
-| dbInstanceName              | Body | String   | DBインスタンスを識別できる名前                                                                                                                        |
-| description                 | Body | String   | DBインスタンスの追加情報                                                                                                                           |
-| dbVersion                   | Body | Enum     | DBエンジンタイプ                                                                                                                               |
-| dbPort                      | Body | Number   | DBポート                                                                                                                                   |
-| dbInstanceType              | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus            | Body | Enum     | DBインスタンスの現在状態                                                                                                                           |
-| progressStatus              | Body | Enum     | DBインスタンスの現在作業進行状態                                                                                                                       |
-| dbFlavorId                  | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                          |
-| parameterGroupId            | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                       |
-| notificationGroupIds        | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                             |
-| useDeletionProtection       | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                         |
-| supportAuthenticationPlugin | Body | Boolean  | 認証プラグインサポートの有無                                                                                                                          |
-| needToApplyParameterGroup   | Body | Boolean  | 最新パラメータグループの適用が必要かどうか                                                                                                                   |
-| needMigration               | Body | Boolean  | マイグレーションが必要かどうか                                                                                                                         |
-| supportDbVersionUpgrade     | Body | Boolean  | DBのバージョンアップグレードをサポートするかどうか                                                                                                              |
-| createdYmdt                 | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-| updatedYmdt                 | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                        |
-
-<details><summary>例</summary>
-<p>
-
-```json
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstances | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | String | DBエンジンタイプ |
+| dbInstances.dbPort | Number | DBポート |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを作成する
 
+#### リクエスト
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                                       | 種類   | 形式      | 必須 | 説明                                                                  |
-|------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName                           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName                  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                                |
-| description                              | Body | String  | X  | DBインスタンスに関する追加情報                                                    |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbVersion                                | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbPort                                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| dbUserName                               | Body | String  | O  | DBユーザーアカウント名                                                        |
-| dbPassword                               | Body | String  | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                 |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval                             | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                     |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                       |
-| authenticationPlugin                     | Body | Enum    | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                   |
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                 | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                  |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                   | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-| 名前                     | 種類  | 形式     | 必須 | 説明                                        |
-|-------------------------|------|---------|----|--------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                              |
-| dbInstanceName          | Body | String  | X  | DBインスタンスを識別できるマスター名                  |
-| dbInstanceCandidateName | Body | String  | X  | DBインスタンスを識別できる予備マスター名               |
-| description             | Body | String  | X  | DBインスタンスに関する追加情報                         |
-| dbPort                  | Body | Number  | X  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                                |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                                 |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                           |
-| executeBackup      | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| useOnlineFailover  | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを削除する
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを再起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### リクエスト
-
-| 名前                | 種類   | 形式      | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| executeBackup     | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを強制再起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### リクエスト
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DBインスタンスを起動する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを停止する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスをバックアップする
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### リクエスト
-
-| 名前           | 種類   | 形式     | 必須 | 説明             |
-|--------------|------|--------|----|----------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子   |
-| backupName   | Body | String | O  | バックアップを識別できる名前 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスバックアップ後にエクスポート
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                     |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを複製する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### リクエスト
-
-| 名前                      | 種類  | 形式     | 必須 | 説明                                                                       |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                             |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                 |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                              |
-| description              | Body | String  | X  | DBインスタンスに関する追加情報                                                        |
-| dbFlavorId               | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                  |
-| dbPort                   | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `3306`<br/>- 最大値: `43306`        |
-| parameterGroupId         | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                     |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                 |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                           |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                            |
-| useDeletionProtection    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                               |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                               |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:原本DBインスタンス値                                      |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                  |
-| storage                  | Body | Object  | X  | データストレージ情報オブジェクト                                                           |    
-| storage.storageType      | Body | Enum    | X  | データストレージタイプ<br/>- 例: `General SSD`                        |
-| storage.storageSize      | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `20`<br/>- 最大値: `2048` |
-| backup                   | Body | Object  | X  | バックアップ情報オブジェクト                                                                 |
-| backup.backupPeriod      | Body | Number  | X  | バックアップ保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `730`       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `10`          |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                               |
-| backup.backupSchedules                   | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                                        |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | X  | バックアップ開始時刻<br/>- 例: `00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-"dbInstanceName": "db-instance-replicate",
-"description": "description",
-"dbPort": 11000,
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
 "network": {
-    "availabilityZone": "kr-pub-a"
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
 },
 "storage": {
-    "stroageSize": 100
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### DBインスタンスを昇格する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
+### オブジェクトストレージを利用したDBインスタンスの復元
 
 #### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 復元情報照会
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### リクエスト
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                      | 種類   | 形式       | 説明                                                                                                                                                                                       |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最古の復元可能時間                                                                                                                                                                                |
-| latestRestorableYmdt                    | Body | DateTime | 最新の復元可能時間                                                                                                                                                                                |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                                                           |
-| restorableBackups.backup                | Body | Object   | バックアップ情報オブジェクト                                                                                                                                                                           |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                                                               |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                                                  |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | テーブルロックを使用するかどうか                                                                                                                                                                         |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                                                |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`: 自動<br/>- `MANUAL`: 手動                                                                                                                           |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了している場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除されている場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                                                           |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンスの名前                                                                                                                                                                            |
-| restorableBackups.backup.dbVersion      | Body | String   | DBエンジンタイプ                                                                                                                                                                                |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                                                               |
-| restorableBackups.backup.binLogFileName | Body | String   | バイナリログファイル名                                                                                                                                                                              |
-| restorableBackups.backup.binLogPosition | Body | Number   | バイナリログファイル位置                                                                                                                                                                             |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                                                               |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                                                               |
-| restorableBackups.restorableBinLogs     | Body | Array    | 該当バックアップを利用して復元可能なバイナリログ名リスト                                                                                                                                                             |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元される最後のクエリ照会
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 共通リクエスト
-
-| 名前           | 種類    | 形式   | 必須 | 説明                                                                                                           |
-|--------------|-------|------|----|--------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DBインスタンスの識別子                                                                                                 |
-| restoreType  | Query | Enum | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ |
-
-#### restoreTypeが`TIMESTAMP`の場合
-
-| 名前          | 種類    | 形式       | 必須 | 説明                                       |
-|-------------|-------|----------|----|------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreTypeが`BINLOG`の場合
-
-| 名前             | 種類    | 形式     | 必須 | 説明                |
-|----------------|-------|--------|----|-------------------|
-| backupId       | Query | UUID   | O  | 復元に使用するバックアップの識別子 |
-| binLogFileName | Query | String | O  | 復元に使用するバイナリログの名前  |
-| binLogPosition | Query | Number | O  | 復元に使用するバイナリログの位置  |
-
-#### レスポンス
-
-| 名前           | 種類   | 形式       | 説明                                  |
-|--------------|------|----------|-------------------------------------|
-| executedYmdt | Body | DateTime | クエリ実行日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 最後に実行したクエリ                          |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 共通リクエスト
-
-| 名前                       | 種類   | 形式      | 必須 | 説明                                                                                                                                         |
-|--------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                               |
-| restore                  | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                 |
-| restore.restoreType      | Body | Enum    | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ<br/>- `BACKUP`:既存に作成したバックアップを利用したスナップショット復元タイプ |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                                                                                       |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                                                                                                     |
-| description              | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                           |
-| dbFlavorId               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                             |
-| dbPort                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                                                                                                 |
-| parameterGroupId         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                              |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                        |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                            |
-| useHighAvailability      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                        |
-| pingInterval             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                         |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                                                                                        |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                             |
-| network.subnetId         | Body | UUID    | O  | サブネットの識別子                                                                                                                                  |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                               |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                               |
-| storage                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                              |
-| storage.storageType      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                         |
-| storage.storageSize      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                          |
-| backup                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                             |
-| backup.backupPeriod      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                              |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                        |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                               |
-| backup.useBackupLock                                | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| backup.backupSchedules                              | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O  | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護を行うかどうか<br>デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-
-#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                  | 種類   | 形式       | 必須 | 説明                                                                                |
-|---------------------|------|----------|----|-----------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
-
-| 名前                            | 種類   | 形式     | 必須 | 説明                |
-|-------------------------------|------|--------|----|-------------------|
-| restore.backupId              | Body | UUID   | O  | 復元に使用するバックアップの識別子 |
-| restore.binLog                | Body | Object | O  | バイナリログ情報オブジェクト    |
-| restore.binLog.binLogFileName | Body | String | O  | 復元に使用するバイナリログの名前  |
-| restore.binLog.binLogPosition | Body | Number | O  | 復元に使用するバイナリログの位置  |
-
-* バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
-
-| 名前               | 種類   | 形式   | 必須                         | 説明                |
-|------------------|------|------|----------------------------|-------------------|
-| restore.backupId | Body | UUID | O(restoreTypeが`BACKUP`の場合) | 復元に使用するバックアップの識別子 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### オブジェクトストレージから復元
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                       | 種類   | 形式      | 必須 | 説明                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| restore                  | Body | Object  | O  | 復元情報オブジェクト                                                          |
-| restore.tenantId         | Body | String  | O  | バックアップが保存されたオブジェクトストレージのテナントID                                      |
-| restore.username         | Body | String  | O  | NHN Cloud会員またはIAMメンバーID                                             |
-| restore.password         | Body | String  | O  | バックアップが保存されたオブジェクトストレージのAPIパスワード                                    |
-| restore.targetContainer  | Body | String  | O  | バックアップが保存されたオブジェクトストレージのコンテナ                                        |
-| restore.objectPath       | Body | String  | O  | コンテナに保存されたバックアップのパス                                                 |
-| dbVersion                | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                              |
-| description              | Body | String  | X  | DBインスタンスに対する追加情報                                                    |
-| dbFlavorId               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbPort                   | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds             | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval             | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`  |
-| useDefaultNotification   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| network                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                      |
-| network.subnetId         | Body | UUID    | O  | サブネットの識別子                                                           |
-| network.usePublicAccess  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                        |
-| network.availabilityZone | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                        |
-| storage                  | Body | Object  | O  | ストレージ情報オブジェクト                                                       |
-| storage.storageType      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                  |
-| storage.storageSize      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                   |
-| backup                   | Body | Object  | O  | バックアップ情報オブジェクト                                                      |
-| backup.backupPeriod      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`        |
-| backup.useBackupLock                                | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| backup.backupSchedules                              | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime             | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndDuration            | Body | Enum    | O  | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### リクエスト
-
-| 名前                    | 種類   | 形式      | 必須 | 説明           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無      |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート |
+| dbVersion | String | Y | DBエンジンタイプ |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.tenantId | String | Y | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | String | Y | NHN CloudアカウントまたはメンバーアカウントまたはIAMメンバーID |
+| restore.password | String | Y | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | String | Y | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | String | Y | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-<details><summary>例</summary>
-<p>
+---
+
+### DBインスタンスを削除する
+
+#### リクエスト
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 高可用性を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### リクエスト
-
-| 名前                  | 種類   | 形式      | 必須 | 説明                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                         |
-| useHighAvailability | Body | Boolean | O  | 高可用性を使用するかどうか                                        |
-| pingInterval        | Body | Number  | X  | 高可用性を使用する時、Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### 高可用性を再開する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
-```
+### DBインスタンスの詳細を表示
 
 #### リクエスト
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を一時停止する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を復旧する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を分離する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ストレージ情報を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前            | 種類   | 形式     | 説明                                                                                        |
-|---------------|------|--------|-------------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | データストレージタイプ                                                                               |
-| storageSize   | Body | Number | データストレージサイズ(GB)                                                                           |
-| storageStatus | Body | Enum   | データストレージの現在状態<br/>- `DETACHED`:取り付けられていない<br/>- `ATTACHED`:取り付けられている<br/>- `DELETED`:削除済み |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | String | DBインスタンスを識別できる名前 |
+| description | String | DBインスタンスの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| dbPort | Number | DBポート |
+| dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Boolean | DBインスタンス削除保護の有無 |
+| supportAuthenticationPlugin | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Boolean | DBバージョンアップグレードをサポートするかどうか |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
-### ストレージ情報を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### DBインスタンスを修正する
 
 #### リクエスト
 
-| 名前                | 種類   | 形式      | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| storageSize       | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値: `2048`                               |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbVersion | String | N | DBエンジンバージョンコード |
+| useDummy | Boolean | N | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷を遮断するかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスをバックアップする
+
+#### リクエスト
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"backupName": "backupName"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupName | String | Y | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### バックアップ情報を表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                                    | 種類   | 形式      | 説明               |
-|---------------------------------------|------|---------|------------------|
-| backupPeriod                          | Body | Number  | バックアップ保管期間(日)    |
-| ftwrlWaitTimeout                      | Body | Number  | クエリ遅延待機時間(秒)     |
-| backupRetryCount                      | Body | Number  | バックアップ再試行回数      |
-| replicationRegion                     | Body | Enum    | バックアップ複製リージョン    |
-| useBackupLock                         | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules                       | Body | Array   | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime      | Body | String  | バックアップ開始時刻       |
-| backupSchedules.backupWndDuration     | Body | Enum    | バックアップDuration   |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backupPeriod | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Number | バックアップ再試行回数 |
+| replicationRegion | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### バックアップ情報を修正する
 
+#### リクエスト
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前                                | 種類   | 形式      | 必須 | 説明                                                                                                                                                                                                                             |
-|-----------------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                      | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                                   |
-| backupPeriod                      | Body | Number  | X  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                                                 |
-| backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                                     |
-| useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか                                                                                                                                                                                                               |
-| backupSchedules                   | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-"backupPeriod": 5,
-"useBackupLock": true,
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
 "backupSchedules": [
-    {
-        "backupWndBgnTime": "01:00:00",
-        "backupWndDuration": "TWO_HOURS"
-    }
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
 ]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
-### ネットワーク情報を表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
+### DBインスタンスバックアップ後にエクスポート
 
 #### リクエスト
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### テスト用DBイメージメタの変更
+
+#### リクエスト
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                     | 種類   | 形式     | 説明                                                                                                                             |
-|------------------------|------|--------|--------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DBインスタンスを作成するアベイラビリティゾーン                                                                                                       |
-| subnet                 | Body | Object | サブネットオブジェクト                                                                                                                    |
-| subnet.subnetId        | Body | UUID   | サブネットの識別子                                                                                                                      |
-| subnet.subnetName      | Body | UUID   | サブネットの識別できる名前                                                                                                                  |
-| subnet.subnetCidr      | Body | UUID   | サブネットのCIDR                                                                                                                     |
-| endPoints              | Body | Array  | 接続情報リスト                                                                                                                        |
-| endPoints.domain       | Body | String | ドメイン                                                                                                                           |
-| endPoints.ipAddress    | Body | String | IPアドレス                                                                                                                         |
-| endPoints.endPointType | Body | Enum   | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`: (Deprecated)外部接続ドメイン<br>-`PRIVATE`: (Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ネットワーク情報を修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式      | 必須 | 説明           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否       |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーリストを表示
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                           | 種類   | 形式       | 説明                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DBユーザーリスト                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DBユーザーの識別子                                                                                                                  |
-| dbUsers.dbUserName           | Body | String   | DBユーザーアカウント名                                                                                                                |
-| dbUsers.host                 | Body | String   | DBユーザーアカウントのホスト名                                                                                                            |
-| dbUsers.authorityType        | Body | Enum     | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/>                      |
-| dbUsers.dbUserStatus         | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `UPDATING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み         |
-| dbUsers.authenticationPlugin | Body | Enum     | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-| dbUsers.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBユーザーを作成する
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserName           | Body | String | O  | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32`                                                          |
-| dbPassword           | Body | String | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| host                 | Body | String | O  | DBユーザーアカウントのホスト名<br/>- 例: `1.1.1.%`                                                                    |
-| authorityType        | Body | Enum   | O  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを修正する
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserId             | URL  | UUID   | O  | DBユーザーの識別子                                                                                             |
-| dbPassword           | Body | String | X  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| authorityType        | Body | Enum   | X  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを削除する
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子   |
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### DBスキーマリストを表示
 
+#### リクエスト
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
 #### レスポンス
 
-| 名前                       | 種類   | 形式       | 説明                                                                                             |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DBスキーマリスト                                                                                      |
-| dbSchemas.dbSchemaId     | Body | UUID     | DBスキーマの識別子                                                                                     |
-| dbSchemas.dbSchemaName   | Body | String   | DBスキーマ名                                                                                        |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DBスキーマの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbSchemas.createdYmdt    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                               |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSchemas | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### DBスキーマを作成する
 
+#### リクエスト
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前           | 種類   | 形式     | 必須 | 説明           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O  | DBスキーマ名      |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_ のみ使用可能、1～64文字、MySQLの予約語は不可 |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### DBスキーマを削除する
 
+#### リクエスト
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbSchemaId   | URL | UUID | O  | DBスキーマの識別子   |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーリストを表示
+
+#### リクエスト
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbUsers | Array | DBユーザーリスト |
+| dbUsers.dbUserId | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | String | DBユーザーアカウント名 |
+| dbUsers.host | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| dbUsers.dbUserStatus | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+---
+
+### DBユーザーを作成する
+
+#### リクエスト
+
+```http
+<!-- TERM-UNRESOLVED: DB 이미지 메타 (セクション「テスト用DBイメージメタの変更」— 発行済みJA先例なし) -->
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | String | Y | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Enum | Y | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBユーザーを修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Enum | N | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全体権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンス削除保護設定を変更する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 削除保護の有無 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスを強制再起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 高可用性を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"useHighAvailability": false,
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 高可用性を使用するかどうか |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を一時停止する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を復旧する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を再開する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 高可用性を分離する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
 ### ログファイルリスト表示
 
+#### リクエスト
+
 ```http
-GET /v3.0/db-instances/{dbInstanceId}/log-files
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類    | 形式    | 必須 | 説明                                                                                                                                                                                             |
-|--------------|-------|-------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DBインスタンスの識別子                                                                                                                                                                                   |
-| logFileTypes | Query | Array | X  | ログファイルタイプ種類一覧<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### レスポンス
 
-| 名前                   | 種類   | 形式       | 説明                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | ログファイルリスト                                                                                                                                                                                    |
-| logFiles.logFileName | Body | String   | ログファイル名                                                                                                                                                                                      |
-| logFiles.logFileType | Body | Enum     | ログファイルタイプ種類<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | ログファイルサイズ(Byte)                                                                                                                                                                              |
-| logFiles.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                             |
-
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| logFiles | Array | ログファイルリスト |
+| logFiles.logFileName | String | ログファイル名 |
+| logFiles.logFileType | Enum | ログファイルタイプ種類<br/>- `ERROR`<br/>- `BINLOG`<br/>- `GENERAL`<br/>- `SLOW_QUERY`<br/>- `AUDIT`<br/>- `BACKUP` |
+| logFiles.logFileSize | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### ログファイルのエクスポート
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/log-files/export
-```
-
 #### リクエスト
 
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                     |
-| logFileNames    | Body | Array  | O  | ログファイル名リスト<br/>- 最小サイズ: `1`      |
-| tenantId        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID      |
-| password        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | ログファイルが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるログファイルのパス              |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | ログファイル名リスト |
+| tenantId | String | Y | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるログファイルのパス |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### ネットワーク情報を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"availabilityZone": "kr-pub-a",
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetName": "subnetName-example",
+},
+},
+{
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZone | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Object | サブネットオブジェクト |
+| subnet.subnetId | UUID | サブネットの識別子 |
+| subnet.subnetName | String | サブネットの識別できる名前 |
+| subnet.subnetCidr | String | サブネットのCIDR |
+| endPoints | Array | 接続情報リスト |
+| endPoints.domain | String | ドメイン |
+| endPoints.ipAddress | String | IPアドレス |
+| endPoints.endPointType | String | 接続情報タイプ |
+
+---
+
+### ネットワーク情報を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 外部接続可否 |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを昇格する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを複製する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Boolean | N | 外部接続可否 |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | N | ストレージ情報オブジェクト |
+| storage.storageType | Enum | N | データストレージタイプ |
+| storage.storageSize | Number | N | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | N | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを再起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | 複製遅延の解消を待機するかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷を遮断するかどうか<br/>- デフォルト値: `false` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### 復元情報照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 復元される最後のクエリ照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| executedYmdt | DateTime | クエリ実行日時 |
+| lastQuery | String | 最後に実行したクエリ |
+
+---
+
+### DBインスタンスを復元する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"imageId": "550e8400-e29b-41d4-a716-446655440000",
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+}
+}
+},
+"useDefaultNotification": false,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| imageId | UUID | N | イメージの識別子 |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.restoreType | Enum | Y | 復元タイプ<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元` |
+| restore.binLog.binLogFileName | String | N | 復元に使用するバイナリログの名前 |
+| restore.binLog.binLogPosition | Object | N | 復元に使用するバイナリログの位置 |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DBインスタンス復元日時 |
+
+POST /v3.0/db-instances/{dbInstanceId}/restore
+
+#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+| restore.binLog | Object | N | 復元に使用するバイナリログ情報オブジェクト |
+
+復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
+
+#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを起動する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBインスタンスを停止する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### ストレージ情報を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageType": "General SSD",
+"storageSize": 1,
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageType | Enum | データストレージタイプ |
+| storageSize | Number | データストレージサイズ(GB) |
+| storageStatus | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り付けられていない`<br/>- ATTACHED: `取り付けられている` |
+
+---
+
+### ストレージ情報を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2332,222 +2941,290 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### バックアップ状態
 
-| 状態           | 説明               |
-|--------------|------------------|
-| `BACKING_UP` | バックアップ中の場合       |
-| `COMPLETED`  | バックアップが完了している場合  |
-| `DELETING`   | バックアップが削除中の場合    |
-| `DELETED`    | バックアップが削除されている場合 |
-| `ERROR`      | エラーが発生した場合       |
+| 状態 | 説明 |
+|--------------|--------------|
+| `BACKING_UP` | バックアップ中の場合 |
+| `COMPLETED` | バックアップが完了している場合 |
+| `DELETING` | バックアップが削除中の場合 |
+| `DELETED` | バックアップが削除されている場合 |
+| `ERROR` | エラーが発生した場合 |
 
 ### バックアップリスト照会
 
+#### リクエスト
+
 ```http
-GET /v3.0/backups
+---
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前           | 種類    | 形式     | 必須 | 説明                                                          |
-|--------------|-------|--------|----|-------------------------------------------------------------|
-| page         | Query | Number | O  | 照会するリストのページ<br/>- 最小値: `1`                                  |
-| size         | Query | Number | O  | 照会するリストのページサイズ<br/>- 最小値: `1`<br/>- 最大値: `100`              |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動<br/>- デフォルト値:全体 |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                              |
-| dbVersion    | Query | Enum   | X  | DBエンジンタイプ                                                   |
-
 #### レスポンス
 
-| 名前                   | 種類   | 形式       | 説明                               |
-|----------------------|------|----------|----------------------------------|
-| totalCounts          | Body | Number   | 全バックアップリスト数                      |
-| backups              | Body | Array    | バックアップリスト                        |
-| backups.backupId     | Body | UUID     | バックアップの識別子                       |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                   |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態                      |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                   |
-| backups.dbVersion    | Body | Enum     | DBエンジンタイプ                        |
-| backups.backupType   | Body | Enum     | バックアップタイプ                        |
-| backups.backupSize   | Body | Number   | バックアップのサイズ(Byte)                 |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### バックアップのエクスポート
-
-```http
-POST /v3.0/backups/{backupId}/export
-```
-
-#### リクエスト
-
-| 名前              | 種類   | 形式     | 必須 | 説明                               |
-|-----------------|------|--------|----|----------------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                       |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ     |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-> [注意]
-> 手動バックアップの場合、バックアップが行われたDBインスタンスが存在しない場合、バックアップをオブジェクトストレージにエクスポートすることができません。
-
----
-
-### バックアップを復元する
-
-```http
-POST /v3.0/backups/{backupId}/restore
-```
-
-#### リクエスト
-
-| 名前                                       | 種類   | 形式      | 必須 | 説明                                                                                                                                                                                                                             |
-|------------------------------------------|------|---------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| backupId                                 | URL  | UUID    | O  | バックアップの識別子                                                                                                                                                                                                                     |
-| dbInstanceName           | Body | String  | O  | DBインスタンスを識別できる マスター名                                           |
-| dbInstanceCandidateName  | Body | String  | X  | DBインスタンスを識別できる 予備マスター名                                        |
-| description                              | Body | String  | X  | DBインスタンスの追加情報                                                                                                                                                                                                                  |
-| dbFlavorId                               | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                                                                                                                                                                 |
-| dbPort                                   | Body | Integer | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                                                                                                                                                                                     |
-| parameterGroupId                         | Body | UUID    | O  | パラメータグループの識別子                                                                                                                                                                                                                  |
-| dbSecurityGroupIds                       | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                                                                            ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                             | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                                                                                |
-| useHighAvailability                      | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                            |
-| pingInterval                             | Body | Number  | X  | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                                                                                                         |
-| useDefaultNotification                   | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                            |
-| useDeletionProtection                    | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                                                                                                                                                                                  | 
-| network                                  | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                         | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                  | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                 | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                  | Body | Object  | O  | ストレージ情報オブジェクト                                                                                                                                                                                                                  |    
-| storage.storageType                      | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                      | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| backup                                   | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                      | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                  | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                  | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                     | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                   | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime  | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-
-{
-"dbInstanceName": "db-instance-restore",
-"dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-"dbPort": 10000,
-"parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
-"network": {
-    "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-    "availabilityZone": "kr-pub-a"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
 },
-"storage": {
-    "storageType": "General SSD",
-    "storageSize": 20
 },
-"backup": {
-    "backupPeriod": 1,
-    "backupSchedules": [{
-        "backupWndBgnTime": "00:00:00",
-        "backupWndDuration": "HALF_AN_HOUR"
-    }
-    ]
+"totalCounts": 1,
+{
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
+]
 }
 ```
 
-</p>
 </details>
 
-#### レスポンス
-
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全バックアップリスト数 |
+| backups | Array | バックアップリスト |
+| backups.backupId | UUID | バックアップの識別子 |
+| backups.backupName | String | バックアップを識別できる名前 |
+| backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤アイコン)` |
+| backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | String | DBエンジンタイプ |
+| backups.utilVersion | String | ユーティリティバージョン |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | DateTime | 作成日時 |
+| backups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップを削除する
 
+#### リクエスト
+
 ```http
-DELETE /v3.0/backups/{backupId}
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前       | 種類  | 形式   | 必須 | 説明         |
-|----------|-----|------|----|------------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### バックアップのエクスポート
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### バックアップを復元する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性を使用する時、Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)リージョン` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2555,405 +3232,464 @@ DELETE /v3.0/backups/{backupId}
 
 ### DBセキュリティグループ進行状態
 
-| 状態              | 説明          |
-|-----------------|-------------|
-| `NONE`          | 進行中の作業がない   |
+| 状態 | 説明 |
+|-----------------|--------------|
+| `NONE` | 進行中の作業がない |
 | `CREATING_RULE` | ルールポリシーの作成中 |
 | `UPDATING_RULE` | ルールポリシーの修正中 |
 | `DELETING_RULE` | ルールポリシーの削除中 |
 
 ### DBセキュリティグループリストを表示
 
-```http
-GET /v3.0/db-security-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                                   | 種類   | 形式       | 説明                               |
-|--------------------------------------|------|----------|----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DBセキュリティグループリスト                  |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前             |
-| dbSecurityGroups.description         | Body | String   | DBセキュリティグループの追加情報                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態              |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### DBセキュリティグループの詳細を表示
-
-```http
-GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
 #### レスポンス
 
-| 名前                  | 種類   | 形式       | 説明                                                                                                                |
-|---------------------|------|----------|-------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                                                                                                  |
-| dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前                                                                                              |
-| description         | Body | String   | DBセキュリティグループの追加情報                                                                                                 |
-| progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態                                                                                               |
-| rules               | Body | Array    | DBセキュリティグループルールリスト                                                                                                |
-| rules.ruleId        | Body | UUID     | DBセキュリティグループルールの識別子                                                                                               |
-| rules.description   | Body | String   | DBセキュリティグループルールの追加情報                                                                                              |
-| rules.direction     | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                         |
-| rules.etherType     | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                    |
-| rules.port          | Body | Object   | ポートオブジェクト                                                                                                         |
-| rules.port.portType | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。<br/>- `PORT`:指定されたポート値に設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number   | 最小ポート範囲                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 最大ポート範囲                                                                                                           |
-| rules.cidr          | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                  |
-| rules.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを作成する
 
-```http
-POST /v3.0/db-security-groups
-```
-
 #### リクエスト
 
-| 名前                  | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|---------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                    |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                   |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前                | 種類   | 形式   | 説明               |
-|-------------------|------|------|------------------|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
+```http
 ---
-
-### DBセキュリティグループを修正する
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
-| 名前                  | 種類   | 形式     | 必須 | 説明                   |
-|---------------------|------|--------|----|----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子     |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報    |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+{
+"description": "description-example",
+"description": "description-example",
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Array | Y | DBセキュリティグループルールリスト |
+| rules.direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | Y | ポートオブジェクト |
+| rules.port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | セキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
 
 ---
 
 ### DBセキュリティグループを削除する
 
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+---
+```
 
-| 名前                | 種類  | 形式   | 必須 | 説明               |
-|-------------------|-----|------|----|------------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
-### DBセキュリティグループルールを作成する
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
+### DBセキュリティグループの詳細を表示
 
 #### リクエスト
 
-| 名前                | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|-------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                     |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"progressStatus": "NONE",
+"description": "description-example",
+{
+{
+"description": "description-example",
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DBセキュリティグループ |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroup.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroup.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroup.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroup.rules | Array | DBセキュリティグループルールリスト |
+| dbSecurityGroup.rules.ruleId | UUID | DBセキュリティグループルールの識別子 |
+| dbSecurityGroup.rules.description | String | DBセキュリティグループルールの追加情報 |
+| dbSecurityGroup.rules.direction | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| dbSecurityGroup.rules.etherType | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| dbSecurityGroup.rules.port | Object | ポートオブジェクト |
+| dbSecurityGroup.rules.port.portType | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| dbSecurityGroup.rules.port.minPort | Number | 最小ポート範囲 |
+| dbSecurityGroup.rules.port.maxPort | Number | 最大ポート範囲 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 修正日時 |
+| dbSecurityGroup.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroup.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
-### DBセキュリティグループルールを修正する
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
+### DBセキュリティグループを修正する
 
 #### リクエスト
 
-| 名前                | 種類   | 形式     | 必須 | 説明                                                                                                                                                                                   |
-|-------------------|------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                     |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                  |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                 |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                            |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                       |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                            |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                             |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                               |
+```http
+---
+```
 
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+#### リクエストパラメータ
 
-<details><summary>例</summary>
-<p>
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### DBセキュリティグループルールを削除する
 
+#### リクエスト
+
 ```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+---
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類    | 形式    | 必須 | 説明                     |
-|-------------------|-------|-------|----|------------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子       |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBセキュリティグループルールを作成する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前    | 種類   | 形式   | 説明            |
-|-------|------|------|---------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
+
+---
+
+### DBセキュリティグループルールを修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+},
+},
+"cidr": "192.168.0.0/24",
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | 作業の識別子 |
 
 ---
 
@@ -2961,958 +3697,916 @@ DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 
 ### パラメータグループリストを表示
 
-```http
-GET /v3.0/parameter-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-| 名前        | 種類    | 形式   | 必須 | 説明        |
-|-----------|-------|------|----|-----------|
-| dbVersion | Query | Enum | X  | DBエンジンタイプ |
-
-#### レスポンス
-
-| 名前                                   | 種類   | 形式       | 説明                                                            |
-|--------------------------------------|------|----------|---------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                  |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                 |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                             |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                                |
-| parameterGroups.dbVersion            | Body | Enum     | DBエンジンタイプ                                                     |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                              |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                              |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
+```http
 ---
-
-### パラメータグループの詳細を表示
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
 #### レスポンス
 
-| 名前                            | 種類   | 形式       | 説明                                                                                              |
-|-------------------------------|------|----------|-------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | パラメータグループの識別子                                                                                   |
-| parameterGroupName            | Body | String   | パラメータグループを識別できる名前                                                                               |
-| description                   | Body | String   | パラメータグループの追加情報                                                                                  |
-| dbVersion                     | Body | Enum     | DBエンジンタイプ                                                                                       |
-| parameterGroupStatus          | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要                                   |
-| parameters                    | Body | Array    | パラメータリスト                                                                                        |
-| parameters.parameterId        | Body | UUID     | パラメータ識別子                                                                                        |
-| parameters.parameterFileGroup | Body | Enum     | パラメータファイルグループタイプ<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld             |
-| parameters.parameterName      | Body | String   | パラメータ名                                                                                          |
-| parameters.fileParameterName  | Body | String   | パラメータファイル名                                                                                      |
-| parameters.value              | Body | String   | 現在設定されている値                                                                                      |
-| parameters.defaultValue       | Body | String   | デフォルト値                                                                                          |
-| parameters.allowedValue       | Body | String   | 許可された値                                                                                          |
-| parameters.updateType         | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:いつでも修正可能<br/>- `CONSTANT`:修正不可<br/>- `INIT_VARIABLE`: DBインスタンス作成時にのみ修正可能 |
-| parameters.applyType          | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体(再起動必要)               |
-| createdYmdt                   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                |
-| updatedYmdt                   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroups | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | String | DBエンジンタイプ |
+| parameterGroups.parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを作成する
 
-```http
-POST /v3.0/parameter-groups
-```
-
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
-| dbVersion          | Body | Enum   | O  | DBエンジンタイプ         |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+{
+"description": "description-example",
+"description": "description-example",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
+| dbVersion | String | Y | DBエンジンタイプ |
 
 #### レスポンス
 
-| 名前               | 種類   | 形式   | 説明            |
-|------------------|------|------|---------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
-### パラメータグループをコピーする
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
-```
+### パラメータグループを削除する
 
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子     |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
+```http
+---
 ```
 
-</p>
-</details>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前               | 種類   | 形式   | 説明            |
-|------------------|------|------|---------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroupName | String | パラメータグループを識別できる名前 |
+| description | String | パラメータグループの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Array | パラメータリスト |
+| parameters.parameterId | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | パラメータ名 |
+| parameters.fileParameterName | String | パラメータファイル名 |
+| parameters.value | String | 現在設定されている値 |
+| parameters.defaultValue | String | デフォルト値 |
+| parameters.allowedValue | String | 許可された値 |
+| parameters.updateType | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを修正する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
 #### リクエスト
 
-| 名前                 | 種類   | 形式     | 必須 | 説明                |
-|--------------------|------|--------|----|-------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子     |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報    |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameter-group"
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
+---
 
-<details><summary>例</summary>
-<p>
+### パラメータグループをコピーする
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+{
+"cidr": "192.168.0.0/24",
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長さ: `100` |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+
 ---
 
 ### パラメータを修正する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
 #### リクエスト
 
-| 名前                             | 種類   | 形式     | 必須 | 説明            |
-|--------------------------------|------|--------|----|---------------|
-| parameterGroupId               | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters             | Body | Array  | O  | 変更するパラメータリスト  |
-| modifiedParameters.parameterId | Body | UUID   | O  | パラメータの識別子     |
-| modifiedParameters.value       | Body | String | O  | 変更するパラメータ値    |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-   "modifiedParameters": [
-       {
-           "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-           "value": "0"
-       }
-   ]
+{
+{
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 変更するパラメータリスト |
+| modifiedParameters.parameterId | UUID | Y | パラメータの識別子 |
+| modifiedParameters.value | String | Y | 変更するパラメータ値 |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ### パラメータグループを再設定する
 
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### リクエスト
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### パラメータグループを削除する
-
-```http
-DELETE /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前               | 種類  | 形式   | 必須 | 説明            |
-|------------------|-----|------|----|---------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
 
-```http
-GET /v3.0/user-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                               |
-|--------------------------|------|----------|----------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                      |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                 |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### ユーザーグループの詳細を表示
-
-```http
-GET /v3.0/user-groups/{userGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前          | 種類  | 形式   | 必須 | 説明           |
-|-------------|-----|------|----|--------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
 #### レスポンス
 
-| 名前                | 種類   | 形式       | 説明                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                              |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                          |
-| userGroupTypeCode | Body | Enum     | ユーザーグループの種類  <br /> `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ <br /> `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーをを含むユーザーグループ |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                             |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                            |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                          |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                          |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | DateTime | 作成日時 |
+| userGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを作成する
 
-```http
-POST /v3.0/user-groups
-```
-
 #### リクエスト
 
-| 名前            | 種類   | 形式      | 必須 | 説明                                                              |
-|---------------|------|---------|----|-----------------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                                |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト <br /> `selectAllYN`がtrueの場合、当該フィールドの値は無視されます |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体かどうか <br /> trueの場合、当該グループは全メンバーに対して設定されます          |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5"]
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
 }
 ```
 
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | Y | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | N | プロジェクトメンバー全体を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前          | 種類   | 形式   | 説明           |
-|-------------|------|------|--------------|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+
+---
+
+### ユーザーグループを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### ユーザーグループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"members": [
+{
+{
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+| userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Enum | ユーザーグループの種類<br/>- `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ<br/>- `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーを含むユーザーグループ |
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを修正する
 
-```http
-PUT /v3.0/user-groups/{userGroupId}
-```
-
 #### リクエスト
 
-| 名前            | 種類   | 形式      | 必須 | 説明                                                    |
-|---------------|------|---------|----|-------------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                          |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                                      |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                     |
-| selectAllYN   | Body | Boolean | X  | プロジェクトメンバー全体かどうか<br /> trueの場合、当該グループは全メンバーに対して設定されます |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": ["1321e759-2ef3-4b85-9921-b13e918b24b5","f9064b09-2b15-442e-a4b0-3a5a2754555e"]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### ユーザーグループを削除する
-
-```http
-DELETE /v3.0/user-groups/{userGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-| 名前          | 種類  | 形式   | 必須 | 説明           |
-|-------------|-----|------|----|--------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | N | プロジェクトメンバーの識別子リスト |
+| selectAllYN | Boolean | N | プロジェクトメンバー全体を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## 通知グループ
 
 ### 通知グループリストを表示
 
-```http
-GET /v3.0/notification-groups
-```
-
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                                       | 種類   | 形式       | 説明                               |
-|------------------------------------------|------|----------|----------------------------------|
-| notificationGroups                       | Body | Array    | 通知グループリスト                        |
-| notificationGroups.notificationGroupId   | Body | UUID     | 通知グループの識別子                       |
-| notificationGroups.notificationGroupName | Body | String   | 通知グループを識別できる名前                   |
-| notificationGroups.notifyEmail           | Body | Boolean  | メール通知                            |
-| notificationGroups.notifySms             | Body | Boolean  | SMS通知                            |
-| notificationGroups.isEnabled             | Body | Boolean  | 有効かどうか                           |
-| notificationGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
+```http
 ---
-
-### 通知グループの詳細を表示
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                  | 種類  | 形式   | 必須 | 説明         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
-
 #### レスポンス
 
-| 名前                         | 種類   | 形式       | 説明                               |
-|----------------------------|------|----------|----------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                       |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                   |
-| notifyEmail                | Body | Boolean  | メール通知                            |
-| notifySms                  | Body | Boolean  | SMS通知                            |
-| isEnabled                  | Body | Boolean  | 有効化かどうか                          |
-| dbInstances                | Body | Array    | 監視対象DBインスタンスリスト                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                     |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                 |
-| userGroups                 | Body | Array    | ユーザーグループリスト                      |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                 |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-            {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }],
-    "userGroups": [
-            {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroups | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Boolean | メール通知 |
+| notificationGroups.notifySms | Boolean | SMS通知 |
+| notificationGroups.isEnabled | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを作成する
 
-```http
-POST /v3.0/notification-groups
-```
-
 #### リクエスト
 
-| 名前                    | 種類   | 形式      | 必須 | 説明                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前              |
-| notifyEmail           | Body | Boolean | X  | メール通知<br/>- デフォルト値: `true`  |
-| notifySms             | Body | Boolean | X  | SMS通知<br/>- デフォルト値: `true`  |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値: `true` |
-| dbInstanceIds         | Body | Array   | O  | 監視対象DBインスタンスの識別子リスト         |
-| userGroupIds          | Body | Array   | O  | ユーザーグループの識別子リスト             |
+```http
+---
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65"],
-    "userGroupIds": ["1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"]
+{
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 通知グループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| notifyEmail | Boolean | N | メール通知<br/>- デフォルト値: `true` |
+| notifySms | Boolean | N | SMS通知<br/>- デフォルト値: `true` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Array | Y | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
-| 名前                  | 種類   | 形式   | 説明         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+
+---
+
+### 通知グループを削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### 通知グループの詳細を表示
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+},
+{
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroupName | String | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | メール通知 |
+| notifySms | Boolean | SMS通知 |
+| isEnabled | Boolean | 有効かどうか |
+| dbInstances | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを修正する
 
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
-```
-
 #### リクエスト
 
-| 名前                    | 種類   | 形式      | 必須 | 説明                  |
-|-----------------------|------|---------|----|---------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子          |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前      |
-| notifyEmail           | Body | Boolean | X  | メール通知               |
-| notifySms             | Body | Boolean | X  | SMS通知               |
-| isEnabled             | Body | Boolean | X  | 有効かどうか              |
-| dbInstanceIds         | Body | Array   | X  | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト     |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": ["ed5cb985-526f-4c54-9ae0-40288593de65", "d51b7da0-682f-47ff-b588-b739f6adc740"]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+```http
 ---
-
-### 通知グループを削除する
-
-```http
-DELETE /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### リクエスト
+#### リクエストパラメータ
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
 
-| 名前                  | 種類  | 形式   | 必須 | 説明         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": true,
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知<br/>- デフォルト値: `false` |
+| notifySms | Boolean | N | SMS通知<br/>- デフォルト値: `false` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Array | N | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
 ---
 
 ## モニタリング
 
-### Metricリストを表示
-
-```http
-GET /v3.0/metrics
-```
+### 統計情報の照会
 
 #### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                  | 種類   | 形式     | 説明        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metricリスト |
-| metrics.measureName | Body | Enum   | 照会指標タイプ   |
-| metrics.unit        | Body | String | 測定値単位     |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
+このAPIはレスポンス本文を返しません。
 
 ---
 
-### 統計情報の照会
-
-```http
-GET /v3.0/metric-statistics
-```
+### Metricリストを表示
 
 #### リクエスト
 
-| 名前           | 種類    | 形式       | 必須 | 説明                               |
-|--------------|-------|----------|----|----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                     |
-| measureNames | Query | Array    | O  | 照会指標リスト<br/>- 最小サイズ: `1`         |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 照会間隔                             |
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                                | 種類   | 形式        | 説明      |
-|-----------------------------------|------|-----------|---------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.measureName      | Body | Enum      | 測定項目タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位   |
-| metricStatistics.values           | Body | Array     | 測定値リスト  |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間    |
-| metricStatistics.values.value     | Body | Object    | 測定値     |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"measureName": "measureName-example",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| metrics | Array | Metricリスト |
+| metrics.measureName | String | 照会指標タイプ |
+| metrics.unit | String | 測定値単位 |
 
 ---
 
@@ -3920,137 +4614,340 @@ GET /v3.0/metric-statistics
 
 ### イベントカテゴリー
 
-イベントはカテゴリに分類することができ、下記の通りです。
-
-| イベントカテゴリー   | 説明       |
-|-------------|----------|
-| ALL         | 全体       |
-| BACKUP      | バックアップ   |
-| DB_INSTANCE | DBインスタンス |
-| JOB         | 作業       |
-| TENANT      | テナント     |
-| MONITORING  | モニタリング   |
-
-### イベントリスト照会
-
-```http
-GET /v3.0/events
-```
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前                | 種類    | 形式       | 必須 | 説明                                                                                                                                           |
-|-------------------|-------|----------|----|----------------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 照会するリストのページ<br/>- 最小値: `1`                                                                                                                   |
-| size              | Query | Number   | O  | 照会するリストのページサイズ<br/>- 最小値: `1`<br/>- 最大値: `100`                                                                                               |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                             |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                             |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `INSTANCE`: DBインスタンス<br/>- `BACKUP`:バックアップ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `TENANT`:テナント |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                                          |
-| keyword           | Query | String   | X  | イベントメッセージに含まれる文字列検索ワード                                                                                                                       |
-| ascendingOrder    | Query | Enum     | X  | イベントメッセージソート順序<br/>- `ASC`:昇順<br/>- `DESC`:降順<br/>- デフォルト値: `DESC`                                                                           |
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                                   |
-|--------------------------|------|----------|--------------------------------------|
-| totalCounts              | Body | Number   | 全イベントリストの数                           |
-| events                   | Body | Array    | イベントリスト                              |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                         |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ                         |
-| events.sourceId          | Body | String   | イベントソースの識別子                          |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                      |
-| events.messages          | Body | Array    | イベントメッセージリスト                         |
-| events.messages.langCode | Body | String   | 言語コード                                |
-| events.messages.message  | Body | String   | イベントメッセージ                            |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
 ---
+
+| イベントカテゴリー | 説明 |
+|-------------|---------|
+| ALL | 全体 |
+| BACKUP | バックアップ |
+| DB_INSTANCE | DBインスタンス |
+| JOB | 作業 |
+| TENANT | テナント |
+| MONITORING | モニタリング |
 
 ### 購読可能なイベントコード一覧表示
 
+#### リクエスト
+
 ```http
-GET /v3.0/event-codes
+イベントはカテゴリに分類することができ、下記の通りです。
 ```
 
-#### リクエスト
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前                           | 種類   | 形式    | 説明           |
-|------------------------------|------|-------|--------------|
-| eventCodes                   | Body | Array | イベントコードリスト   |
-| eventCodes.eventCode         | Body | Enum  | イベントコード      |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+{
+{
+"eventCode": "ENUM_VALUE",
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventCodes | Array | イベントコードリスト |
+| eventCodes.eventCode | Enum | イベントコード |
+| eventCodes.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
+---
+
+### イベントリスト照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+{
+{
+"langCode": "KO",
+}
+],
+],
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベントリストの数 |
+| events | Array | イベントリスト |
+| events.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 発生したイベントのタイプ |
+| events.sourceId | UUID | イベントソースの識別子 |
+| events.sourceName | String | イベントソースを識別できる名前 |
+| events.messages | Array | イベントメッセージリスト |
+| events.messages.langCode | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | イベントメッセージ |
+| events.eventYmdt | DateTime | イベント発生日時 |
+
+---
+
+## イベント購読
+
+### イベント購読リスト照会
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+"totalCounts": 1,
+{
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+],
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベント購読リストの数 |
+| eventSubscriptions | Array | イベント購読リスト |
+| eventSubscriptions.eventSubscriptionId | UUID | イベント購読の識別子 |
+| eventSubscriptions.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | イベント購読を識別できる名前 |
+| eventSubscriptions.enabled | Boolean | 有効かどうか |
+| eventSubscriptions.notifyEmail | Boolean | メール送信するかどうか |
+| eventSubscriptions.notifySms | Boolean | SMS送信するかどうか |
+| eventSubscriptions.eventCodes | Array | 購読するイベントコードリスト |
+| eventSubscriptions.sources | Array | 購読するイベントソースリスト |
+| eventSubscriptions.sources.sourceId | UUID | イベントソースの識別子 |
+| eventSubscriptions.sources.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | イベントを購読しているユーザーグループの識別子リスト |
+| eventSubscriptions.createdYmdt | DateTime | 作成日時 |
+
+---
+
+### イベント購読を作成する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | イベント購読を識別できる名前 |
+| enabled | Boolean | Y | 有効かどうか |
+| notifyEmail | Boolean | Y | メール送信するかどうか |
+| notifySms | Boolean | Y | SMS送信するかどうか |
+| eventCodes | Array | Y | 購読するイベントコードリスト |
+| sources | Array | Y | 購読するイベントソースリスト |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | イベントを購読するユーザーグループの識別子リスト |
+
+#### レスポンス
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+},
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | イベント購読の識別子 |
+
+---
+
+### イベント購読を削除する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### イベント購読を修正する
+
+#### リクエスト
+
+```http
+---
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+{
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+{
+"eventCode": "ENUM_VALUE",
+"eventCode": "ENUM_VALUE",
+}
+],
+"dbInstanceIds": [],
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | イベント購読を識別できる名前 |
+| enabled | Boolean | N | 有効かどうか |
+| notifyEmail | Boolean | N | メール送信するかどうか |
+| notifySms | Boolean | N | SMS送信するかどうか |
+| eventCodes | Array | N | 購読するイベントコードリスト |
+| sources | Array | N | 購読するイベントソースリスト |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | イベントを購読するユーザーグループの識別子リスト |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
 
 ---

--- a/ja/api-guide-v4.0-gov.md
+++ b/ja/api-guide-v4.0-gov.md
@@ -73,7 +73,60 @@ APIリクエスト時、認証に失敗したり権限がない場合、次の�
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
+
 ## プロジェクト情報
+
+### プロジェクトメンバーリストを表示
+
+```http
+GET /v4.0/project/members
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | プロジェクトメンバーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | Body | String | プロジェクトメンバーの名前 |
+| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
 
 ### リージョンリストを表示
 
@@ -83,9 +136,9 @@ GET /v4.0/project/regions
 
 #### 必要権限
 
-| 権限名                                     | 説明         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | プロジェクト情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | リージョンリストを表示 |
 
 #### リクエスト
 
@@ -93,11 +146,11 @@ GET /v4.0/project/regions
 
 #### レスポンス
 
-| 名前               | 種類 | 形式    | 説明                                                                       |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | リージョンリスト                                                                    |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                                                                          |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| regions | Body | Array | リージョンリスト |
+| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
 
 <details><summary>例</summary>
 <p>
@@ -112,58 +165,7 @@ GET /v4.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### プロジェクトメンバーリストを表示
-
-```http
-GET /v4.0/project/members
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明       |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | プロジェクト情報照会 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                 | 種類 | 形式   | 説明            |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | プロジェクトメンバーリスト    |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子  |
-| members.memberName   | Body | String | プロジェクトメンバーの名前   |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "isEnabled": false
         }
     ]
 }
@@ -173,7 +175,6 @@ GET /v4.0/project/members
 </details>
 
 ---
-
 ## DBインスタンスの仕様
 
 ### DBインスタンス仕様リストを表示
@@ -184,8 +185,8 @@ GET /v4.0/db-flavors
 
 #### 必要権限
 
-| 権限名                                     | 説明             |
-|-------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbFlavor.List | DBインスタンス仕様リスト表示 |
 
 #### リクエスト
@@ -194,13 +195,13 @@ GET /v4.0/db-flavors
 
 #### レスポンス
 
-| 名前                   | 種類 | 形式   | 説明            |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名   |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Body | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Body | Number | CPUコア数 |
 
 <details><summary>例</summary>
 <p>
@@ -214,9 +215,9 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -238,8 +239,8 @@ GET /v4.0/network/subnets
 
 #### 必要権限
 
-| 権限名                                    | 説明      |
-|------------------------------------------|-----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Network.List | サブネットリスト表示 |
 
 #### リクエスト
@@ -248,14 +249,14 @@ GET /v4.0/network/subnets
 
 #### レスポンス
 
-| 名前                     | 種類 | 形式    | 説明             |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | サブネットリスト         |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子       |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前  |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR        |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | サブネットリスト |
+| subnets.subnetId | Body | UUID | サブネットの識別子 |
+| subnets.subnetName | Body | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | Body | String | サブネットのCIDR |
+| subnets.usingGateway | Body | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
 
 <details><summary>例</summary>
 <p>
@@ -269,11 +270,11 @@ GET /v4.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
@@ -294,8 +295,8 @@ GET /v4.0/db-versions
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|--------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbVersion.List | DBエンジンリスト表示 |
 
 #### リクエスト
@@ -304,11 +305,11 @@ GET /v4.0/db-versions
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式    | 説明                  |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBエンジンリスト            |
-| dbVersions.dbVersion         | Body | String  | DBエンジンタイプ            |
-| dbVersions.dbVersionName     | Body | String  | DBエンジン名            |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DBエンジンリスト |
+| dbVersions.dbVersion | Body | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | Body | String | DBエンジン名 |
 | dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
 
 <details><summary>例</summary>
@@ -323,9 +324,9 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
@@ -346,8 +347,8 @@ GET /v4.0/storage-types
 
 #### 必要権限
 
-| 権限名                                    | 説明              |
-|------------------------------------------|-------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Storage.List | データストレージタイプリスト表示 |
 
 #### リクエスト
@@ -356,8 +357,8 @@ GET /v4.0/storage-types
 
 #### レスポンス
 
-| 名前         | 種類 | 形式  | 説明           |
-|--------------|------|-------|----------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | データストレージタイプリスト |
 
 <details><summary>例</summary>
@@ -409,29 +410,29 @@ GET /v4.0/jobs/{jobId}
 
 #### 必要権限
 
-| 権限名                               | 説明        |
-|-------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Job.Get | 作業情報詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前  | 種類 | 形式 | 必須 | 説明    |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 作業の識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                           | 種類 | 形式     | 説明                              |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                         |
-| jobStatus                      | Body | Enum     | 作業の現在状態                       |
-| resourceRelations              | Body | Array    | 関連リソースリスト                       |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ                       |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                      |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 作業の識別子 |
+| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 関連リソースリスト |
+| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
+| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -443,16 +444,16 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -460,7 +461,6 @@ GET /v4.0/jobs/{jobId}
 </details>
 
 ---
-
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
@@ -471,8 +471,8 @@ GET /v4.0/db-instance-groups
 
 #### 必要権限
 
-| 権限名                                            | 説明             |
-|--------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.List | DBインスタンスグループリスト表示 |
 
 #### リクエスト
@@ -481,13 +481,13 @@ GET /v4.0/db-instance-groups
 
 #### レスポンス
 
-| 名前                               | 種類 | 形式     | 説明                                                                     |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DBインスタンスグループリスト                                                          |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                        |
-| dbInstanceGroups.replicationType   | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -501,10 +501,10 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -523,30 +523,30 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 必要権限
 
-| 権限名                                           | 説明             |
-|-------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.Get | DBインスタンスグループ詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明            |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式     | 説明                                                                                                                                  |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| replicationType              | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                                 |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                           |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -558,17 +558,17 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -581,48 +581,48 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                | 説明                         |
+| 状態                  | 説明                           |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合         |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合               |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合          |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合         |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合         |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合            |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合     |
-| `SHUTDOWN`          | DBインスタンスが停止した場合               |
-| `DELETED`           | DBインスタンスが削除された場合            |
+| `AVAILABLE`         | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE`     | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合 |
+| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合 |
+| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合 |
+| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合 |
+| `SHUTDOWN`          | DBインスタンスが停止した場合 |
+| `DELETED`           | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                       | 説明         |
+| 状態                         | 説明           |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
-| `BACKING_UP`               | バックアップ中       |
-| `CANCELING`                | キャンセル中       |
-| `CREATING`                 | 作成中       |
-| `CREATING_SCHEMA`          | DBスキーマ作成中	 |
-| `CREATING_USER`            | ユーザー作成中	    |
-| `DELETING`                 | 削除中       |
+| `BACKING_UP`               | バックアップ中 |
+| `CANCELING`                | キャンセル中 |
+| `CREATING`                 | 作成中 |
+| `CREATING_SCHEMA`          | DBスキーマ作成中 |
+| `CREATING_USER`            | ユーザー作成中 |
+| `DELETING`                 | 削除中 |
 | `DELETING_SCHEMA`          | DBスキーマ削除中 |
-| `DELETING_USER`            | ユーザー削除中   |
+| `DELETING_USER`            | ユーザー削除中 |
 | `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中    |
-| `MIGRATING`                | マイグレーション中   |
-| `MODIFYING`                | 修正中       |
-| `PREPARING`                | 準備中       |
-| `PROMOTING`                | 昇格中       |
-| `REBUILDING`               | 再構築中      |
-| `REPAIRING`                | 復旧中       |
-| `REPLICATING`              | 複製中       |
-| `RESTARTING`               | 再起動中          |
-| `RESTARTING_FORCIBLY`      | 強制再起動中        |
-| `RESTORING`                | 復元中       |
-| `STARTING`                 | 起動中       |
-| `STOPPING`                 | 停止中       |
+| `FAILING_OVER`             | フェイルオーバー中 |
+| `MIGRATING`                | マイグレーション中 |
+| `MODIFYING`                | 修正中 |
+| `PREPARING`                | 準備中 |
+| `PROMOTING`                | 昇格中 |
+| `REBUILDING`               | 再構築中 |
+| `REPAIRING`                | 復旧中 |
+| `REPLICATING`              | 複製中 |
+| `RESTARTING`               | 再起動中 |
+| `RESTARTING_FORCIBLY`      | 強制再起動中 |
+| `RESTORING`                | 復元中 |
+| `STARTING`                 | 起動中 |
+| `STOPPING`                 | 停止中 |
 | `SYNCING_SCHEMA`           | DBスキーマ同期中 |
-| `SYNCING_USER`             | ユーザー同期中	   |
-| `UPDATING_USER`            | ユーザー修正中	    |
+| `SYNCING_USER`             | ユーザー同期中 |
+| `UPDATING_USER`            | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
 
@@ -632,8 +632,8 @@ GET /v4.0/db-instances
 
 #### 必要権限
 
-| 権限名                                       | 説明          |
-|---------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.List | DBインスタンスリスト表示 |
 
 #### リクエスト
@@ -642,20 +642,20 @@ GET /v4.0/db-instances
 
 #### レスポンス
 
-| 名前                          | 種類 | 形式     | 説明                                                                                                                                  |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                          |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                       |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                          |
-| dbInstances.dbVersion         | Body | Enum     | DBエンジンタイプ                                                                                                                            |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                               |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                   |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | Body | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | Body | Enum | DBエンジンタイプ |
+| dbInstances.dbPort | Body | Number | DBポート |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Body | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -669,19 +669,366 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを作成する
+
+```http
+POST /v4.0/db-instances
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | データストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | データストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### オブジェクトストレージを利用したDBインスタンスの復元
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | O | DBポート |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Body | Object | O | データストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.tenantId | Body | String | O | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | Body | String | O | NHN Cloud会員またはIAMメンバーID |
+| restore.password | Body | String | O | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | Body | String | O | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | Body | String | O | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | DBインスタンスの削除 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "deleteAutoBackup": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -698,43 +1045,43 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                        | 種類 | 形式     | 説明                                                                                                                                  |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstanceGroupId           | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| dbInstanceName              | Body | String   | DBインスタンスを識別できる名前                                                                                                                       |
-| description                 | Body | String   | DBインスタンスの追加情報                                                                                                                          |
-| dbVersion                   | Body | Enum     | DBエンジンタイプ                                                                                                                            |
-| dbPort                      | Body | Number   | DBポート                                                                                                                               |
-| dbInstanceType              | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus            | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| progressStatus              | Body | Enum     | DBインスタンスの現在作業進行状態                                                                                                                |
-| dbFlavorId                  | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                     |
-| parameterGroupId            | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                           |
-| dbSecurityGroupIds          | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                       |
-| notificationGroupIds        | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                          |
-| useDeletionProtection       | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                     |
-| useSlowQueryAnalysis        | Body | Boolean  | Slow query分析を行うかどうか                                                                                                                     |
-| supportAuthenticationPlugin | Body | Boolean  | 認証プラグインサポートの有無                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 最新パラメータグループの適用が必要かどうか                                                                                                                  |
-| needMigration               | Body | Boolean  | マイグレーションが必要かどうか                                                                                                                        |
-| supportDbVersionUpgrade     | Body | Boolean  | DBのバージョンアップグレードをサポートするかどうか                                                                                                             |
-| createdYmdt                 | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| description | Body | String | DBインスタンスの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| dbPort | Body | Number | DBポート |
+| dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Body | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Body | Boolean | DBインスタンス削除保護の有無 |
+| useSlowQueryAnalysis | Body | Boolean | Slow query分析を行うかどうか |
+| supportAuthenticationPlugin | Body | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Body | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Body | Boolean | DBのバージョンアップグレードをサポートするかどうか |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -746,135 +1093,36 @@ GET /v4.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
     "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
+    "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
     "needToApplyParameterGroup": false,
     "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
-
----
-
-### DBインスタンスを作成する
-
-```http
-POST /v4.0/db-instances
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
-
-#### リクエスト
-
-| 名前                                           | 種類   | 形式      | 必須 | 説明                                                                  |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName                      | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                             |
-| description                                  | Body | String  | X  | DBインスタンスに関する追加情報                                                    |
-| dbFlavorId                                   | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbVersion                                    | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbPort                                       | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| dbUserName                                   | Body | String  | O  | DBユーザーアカウント名                                                        |
-| dbPassword                                   | Body | String  | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                 |
-| parameterGroupId                             | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability                          | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval                                 | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`        |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                     |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                       |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | スロークエリ分析の有無<br/>- デフォルト値: `true`                                    |
-| authenticationPlugin                         | Body | Enum    | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                   |
-| network                                      | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                             | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                     | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                      | Body | Object  | O  | データストレージ情報オブジェクト                                                                                                                                                                                                               |    
-| storage.storageType                          | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                          | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                                                                                                                                                             |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージ自動拡張を行うかどうか                                                                                                                                                                                                               |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                                                                                                                                                                                      |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                                                                                                                                                                                |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                                                                                                                                                                              |
-| backup                                       | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                          | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                       | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
 
 ---
 
@@ -886,38 +1134,49 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
 
 #### リクエスト
 
-| 名前                     | 種類  | 形式     | 必須 | 説明                                         |
-|-------------------------|------|---------|----|---------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                               |
-| dbInstanceName          | Body | String  | X  | DBインスタンスを識別できる マスター名                   |
-| dbInstanceCandidateName | Body | String  | X  | DBインスタンスを識別できる 予備マスター名 |
-| description             | Body | String  | X  | DBインスタンスに関する追加情報                          |
-| dbPort                  | Body | Number  | X  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Slow query分析を行うかどうか |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                         |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                            |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                        |
-| executeBackup      | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| useOnlineFailover  | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか |
+| useDummy | Body | Boolean | X | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
 }
 ```
 
@@ -926,426 +1185,9 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | DBインスタンスの削除 |
-
-#### リクエスト
-
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値：`false` |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | DBインスタンスの再起動 |
-
-#### リクエスト
-
-| 名前              | 種類 | 形式    | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| executeBackup     | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-### DBインスタンスを強制再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明             |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式    | 必須 | 説明                                                                      |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DBインスタンスを起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明         |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | DBインスタンスの起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 必要権限
-
-| 権限名                                       | 説明         |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | DBインスタンスの停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを複製する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明         |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
-
-#### リクエスト
-
-| 名前                                         | 種類 | 形式    | 必須 | 説明                                                                      |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる名前                                                 |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                       |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                 |
-| dbPort                                       | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `3306`<br/>- 最大値: `43306`        |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                    |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                          |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                            |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                               |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                        |
-| network                                      | Body | Object  | O  | ネットワーク情報オブジェクト                                                              |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:原本DBインスタンス値                                     |
-| network.availabilityZone                     | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                  |
-| storage                                      | Body | Object  | X  | データストレージ情報オブジェクト                                                          |    
-| storage.storageType                          | Body | Enum    | X  | データストレージタイプ<br/>- デフォルト値:原本DBインスタンス値<br/>- 例: `General SSD`                        |
-| storage.storageSize                          | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `20`<br/>- 最大値: `2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                       |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージ自動拡張を行うかどうか   <br/>- デフォルト値:原本DBインスタンス値                                                          |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `50`<br/>- 最大値: `95`                               |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最大値: `4096`                                         |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `10`<br/>- 最大値: `1440`                         |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                                |
-| backup.backupPeriod                          | Body | Number  | X  | バックアップ保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | バックアップ開始時刻<br/>- 例: `00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを昇格する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明         |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | DBインスタンスの昇格 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスの再構築
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | DBインスタンスの再構築 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 復元情報照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                    | 種類 | 形式     | 説明                                                                                                                                                                         |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最古の復元可能時間                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | 最新の復元可能時間                                                                                                                                                                               |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                                               |
-| restorableBackups.backup                | Body | Object   | バックアップ情報オブジェクト                                                                                                                                                                   |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                                      |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | テーブルロックを使用するかどうか                                                                                                                                                               |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                                      |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了している場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除されている場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                                            |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンスの名前                                                                                                                                                             |
-| restorableBackups.backup.dbVersion      | Body | String   | DBエンジンタイプ                                                                                                                                                                   |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                                                   |
-| restorableBackups.backup.binLogFileName | Body | String   | バイナリログファイル名                                                                                                                                                              |
-| restorableBackups.backup.binLogPosition | Body | Number   | バイナリログファイル位置                                                                                                                                                              |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                                                   |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                                                   |
-| restorableBackups.restorableBinLogs     | Body | Array    | 該当バックアップを利用して復元可能なバイナリログ名リスト                                                                                                                                                            |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元される最後のクエリ照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### 共通リクエスト
-
-| 名前         | 種類  | 形式 | 必須 | 説明                                                                                                                        |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DBインスタンスの識別子                                                                                                              |
-| restoreType  | Query | Enum | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ |
-
-#### restoreTypeが`TIMESTAMP`の場合
-
-| 名前        | 種類  | 形式     | 必須 | 説明                                      |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreTypeが`BINLOG`の場合
-
-| 名前           | 種類  | 形式   | 必須 | 説明               |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 復元に使用するバックアップの識別子  |
-| binLogFileName | Query | String | O  | 復元に使用するバイナリログ名 |
-| binLogPosition | Query | Number | O  | 復元に使用するバイナリログ位置 |
-
-#### レスポンス
-
-| 名前         | 種類 | 形式     | 説明                                 |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | クエリ実行日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 最後に実行したクエリ                         |
 
 <details><summary>例</summary>
 <p>
@@ -1357,701 +1199,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
----
-
-### 復元
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明         |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
-
-#### 共通リクエスト
-
-| 名前                                                | 種類 | 形式    | 必須 | 説明                                                                                                                                                                    |
-|-----------------------------------------------------|------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                          |
-| restore                                             | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                                              |
-| restore.restoreType                                 | Body | Enum    | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ<br/>- `BACKUP`:既存に作成したバックアップを利用したスナップショット復元タイプ                                                                                                                                                                                                                                                                                                            |
-| dbInstanceName                                      | Body | String  | O  | DBインスタンスを識別できる マスター名                                                                                                                                               |
-| dbInstanceCandidateName                             | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                                                                                                                             |
-| description                                         | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                                                                                                    |
-| dbFlavorId                                          | Body | UUID    | X  | DBインスタンス仕様の識別子                                                                                                                                                       |
-| dbPort | Body | Number | X | DBポート<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`3306`<br/>- 最大値：`43306` |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子<br/>- デフォルト値：原本DBインスタンスの値 |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                      |
-| userGroupIds                                        | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                        |
-| useHighAvailability                                 | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                                  |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                      |
-| useDefaultNotification                              | Body | Boolean | X  | 基本アラームを使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護の有無<br>デフォルト値: `false`                                                                                                                                                |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                                                                                                                      |
-| network                                             | Body | Object  | X  | ネットワーク情報オブジェクト                                                                                                                                                            |
-| network.subnetId                                    | Body | UUID    | X  | サブネットの識別子<br/>- デフォルト値: 原本DBインスタンスの値                                                                                                                                                              |
-| network.usePublicAccess                             | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                           |
-| network.availabilityZone                            | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`<br/>- デフォルト値: ランダム選択                                                                                                                 |
-| storage                                             | Body | Object  | X  | ストレージ情報オブジェクト                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| storage.storageType | Body | Enum | X | データストレージタイプ<br/>- デフォルト値：原本DBインスタンスの値<br/>- 例：`General SSD` |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`20`<br/>- 最大値：`2048` |
-| storage.storageAutoscale                            | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                                                                                                     |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張の使用有無 |
-| storage.storageAutoscale.threshold | Body | Number | X | 自動拡張条件(%)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`50`<br/>- 最大値：`95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | X | 自動拡張最大サイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最大値：`4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | X | 自動拡張クールダウン時間(分)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`10`<br/>- 最大値：`1440` |
-| backup                                              | Body | Object  | X  | バックアップ情報オブジェクト                                                                                                                                                              |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`0`<br/>- 最大値：`730` |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                   |
-| backup.backupRetryCount                             | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                              |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`<span style="color:#313338">: 30分</span><br/>- `ONE_HOUR`<span style="color:#313338">: 1時間</span><br/>- `ONE_HOUR_AND_HALF`<span style="color:#313338">: 1時間30分</span><br/>- `TWO_HOURS`<span style="color:#313338">: 2時間</span><br/>- `TWO_HOURS_AND_HALF`<span style="color:#313338">: 2時間30分</span><br/>- `THREE_HOURS`<span style="color:#313338">: 3時間</span> |
-
-#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                | 種類 | 形式     | 必須 | 説明                                                                                           |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
-
-| 名前                          | 種類 | 形式   | 必須 | 説明               |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 復元に使用するバックアップの識別子  |
-| restore.binLog                | Body | Object | O  | バイナリログ情報オブジェクト    |
-| restore.binLog.binLogFileName | Body | String | O  | 復元に使用するバイナリログの名前 |
-| restore.binLog.binLogPosition | Body | Number | O  | 復元に使用するバイナリログの位置 |
-
-* バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
-
-| 名前             | 種類 | 形式 | 必須                         | 説明            |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreTypeが`BACKUP`の場合) | 復元に使用するバックアップの識別子 |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-
----
-
-### オブジェクトストレージから復元
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### 必要権限
-
-| 権限名                                                 | 説明                    |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
-
-#### リクエスト
-
-| 名前                                                | 種類 | 形式    | 必須 | 説明                                                                                   |
-|-----------------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O  | 復元情報オブジェクト                                                                             |
-| restore.tenantId                                    | Body | String  | O  | バックアップが保存されたオブジェクトストレージのテナントID                                                              |
-| restore.username                                    | Body | String  | O  | NHN Cloud会員またはIAMメンバーID                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| restore.password                                    | Body | String  | O  | バックアップが保存されたオブジェクトストレージのAPIパスワード                                                          |
-| restore.targetContainer                             | Body | String  | O  | バックアップが保存されたオブジェクトストレージのコンテナ                                                              |
-| restore.objectPath                                  | Body | String  | O  | コンテナに保存されたバックアップのパス                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| dbVersion                                           | Body | Enum    | O  | DBエンジンタイプ                                                                             |
-| dbInstanceName                                      | Body | String  | O  | DBインスタンスを識別できる マスター名                                                              |
-| dbInstanceCandidateName                             | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                                            |
-| description                                         | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| dbFlavorId                                          | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                      |
-| dbPort                                              | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                            |
-| parameterGroupId | Body | UUID    | O  | パラメータグループの識別子                                                                         |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                     |
-| userGroupIds                                        | Body | Array   | X  | ユーザーグループの識別子リスト                                                                       |
-| useHighAvailability                                 | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`       |
-| useDefaultNotification                              | Body | Boolean | X  | 基本アラームを使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護の有無<br>デフォルト値: `false`                                                               |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                                     |
-| network                                             | Body | Object  | O  | ネットワーク情報オブジェクト                                                                           |
-| network.subnetId                                    | Body | UUID    | O  | サブネットの識別子                                                                             |
-| network.usePublicAccess                             | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                          |
-| network.availabilityZone                            | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                |
-| storage                                             | Body | Object  | O  | データストレージ情報オブジェクト                                                                       |
-| storage.storageType                                 | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                     |
-| storage.storageSize                                 | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                     |
-| storage.storageAutoscale                            | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                    |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | ストレージ自動拡張を行うかどうか                                                                         |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                                            |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                                      |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                                      |
-| backup                                              | Body | Object  | O  | バックアップ情報オブジェクト                                                                             |
-| backup.backupPeriod                                 | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                           |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                             | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`             |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`<span style="color:#313338">: 30分</span><br/>- `ONE_HOUR`<span style="color:#313338">: 1時間</span><br/>- `ONE_HOUR_AND_HALF`<span style="color:#313338">: 1時間30分</span><br/>- `TWO_HOURS`<span style="color:#313338">: 2時間</span><br/>- `TWO_HOURS_AND_HALF`<span style="color:#313338">: 2時間30分</span><br/>- `THREE_HOURS`<span style="color:#313338">: 3時間</span> |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-
----
-
-
-### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無    |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 高可用性の状態
-
-| 状態                               | 説明                               |
-|----------------------------------|---------------------------------|
-| `CREATED`                        | 高可用性が作成された場合                    |
-| `STABLE`                         | 高可用性が正常な場合                    |
-| `PAUSING`                        | 高可用性が一時停止中の場合               |
-| `PAUSED`                         | 高可用性が一時停止された場合                 |
-| `PAUSED_DUE_TO_TASK`             | タスクにより高可用性が一時停止された場合         |
-| `DISABLE_MASTER_IN_REPLICATION`  | マスターの異常なレプリケーションの検知により高可用性が中断された場合     |
-| `DISABLE_MHA_PROCESS`            | 高可用性プロセスが中断された場合               |
-| `DISABLE_REPLICATION_STOP`       | レプリケーションの中断により高可用性が中断された場合         |
-| `DISABLE_REPLICATION_DELAY`      | レプリケーションの遅延により高可用性が中断された場合         |
-| `MASTER_FAILURE_DETECTION`       | マスターの障害が検知された場合                 |
-| `FAILOVER_STARTED`               | フェイルオーバーが開始された場合                   |
-| `FAILOVER_FAILED`                | フェイルオーバーが失敗した場合                   |
-| `FAILOVER_COMPLETED`             | フェイルオーバーが完了した場合                   |
-| `DELETED`                        | 高可用性が削除された場合                   |
-
----
-
-### 高可用性情報の照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
-
-| 権限名                                              | 説明         |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンスの詳細照会 |
-
-#### リクエスト
-
-このAPIはリクエストボディを必要としません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                  | 種類   | 形式      | 説明                                                                                                                  |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | 高可用性の使用有無                                                                                                          |
-| haStatus            | Body | Enum    | 高可用性の状態                                                                                                          |
-| pingInterval        | Body | Number  | Ping間隔(秒)                                                                                                           |
-| pingType            | Body | Enum    | Pingタイプ<br/>- `INSERT`<br/>- `SELECT`                                                                                |                                                                                              |
-
-<details><summary>例</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
----
-
-### 高可用性を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明      |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
-
-#### リクエスト
-
-| 名前                | 種類 | 形式    | 必須 | 説明                                                 |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                       |
-| useHighAvailability | Body | Boolean | O  | 高可用性を使用するかどうか                                       |
-| pingInterval        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- `INSERT`<br/>- `SELECT`         |
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できるスタンバイマスター名 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を再開する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明         |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | 高可用性の再開 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を一時停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明         |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | 高可用性の一時停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を復旧する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明      |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | 高可用性の復旧 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を分離する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明      |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | 高可用性の分離 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ストレージ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                 | 種類 | 形式    | 説明                                                                                 |
-|--------------------------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | データストレージタイプ                                                                        |
-| storageSize                          | Body | Number  | データストレージサイズ(GB)                                                                      |
-| storageStatus                        | Body | Enum    | データストレージの現在状態<br/>- `DETACHED`:取り付けられていない<br/>- `ATTACHED`:取り付けられている<br/>- `DELETED`:削除済み |
-| storageAutoscale                     | Body | Object  | データストレージ自動拡張オブジェクト                                                                  |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか                                                                       |
-| storageAutoscale.threshold           | Body | Number  | 自動拡張条件(%)                                                                          |
-| storageAutoscale.maxStorageSize      | Body | Number  | 自動拡張最大サイズ(GB)                                                                      |
-| storageAutoscale.cooldownTime        | Body | Number  | 自動拡張クールダウン時間(分)                                                                      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### ストレージ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                                 | 種類 | 形式    | 必須 | 説明                                                                      |
-|--------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-| storageSize                          | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値: `2048`                          |
-| useOnlineFailover                    | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                       |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージの自動拡張を行うかどうか                                                            |
-| storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                               |
-| storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                         |
-| storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                         |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
 
 ---
 
@@ -2063,30 +1216,30 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 必要権限
 
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | バックアップ情報を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                              | 種類 | 形式    | 説明           |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | バックアップ保管期間(日)    |
-| ftwrlWaitTimeout                  | Body | Number  | クエリ遅延待機時間(秒) |
-| backupRetryCount                  | Body | Number  | バックアップ再試行回数    |
-| replicationRegion                 | Body | Enum    | バックアップ複製リージョン     |
-| useBackupLock                     | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules                   | Body | Array   | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime  | Body | String  | バックアップ開始時刻     |
-| backupSchedules.backupWndDuration | Body | Enum    | バックアップDuration    |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Body | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Body | Number | バックアップ再試行回数 |
+| replicationRegion | Body | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Body | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Body | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>例</summary>
 <p>
@@ -2099,14 +1252,14 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2114,7 +1267,6 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 </p>
 </details>
-
 
 ---
 
@@ -2126,520 +1278,51 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 必要権限
 
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                                  | 種類 | 形式    | 必須 | 説明                                                                                                                                                                                                                        |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                              |
-| backupPeriod                          | Body | Number  | X  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか                                                                                                                                                                                                              |
-| backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                 |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupPeriod": 5,
-    "useBackupLock": true,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ネットワーク情報表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                   | 種類 | 形式   | 説明                                                                                                                                    |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DBインスタンスを作成するアベイラビリティゾーン                                                                                                                   |
-| subnet                 | Body | Object | サブネットオブジェクト                                                                                                                                |
-| subnet.subnetId        | Body | UUID   | サブネットの識別子                                                                                                                              |
-| subnet.subnetName      | Body | UUID   | サブネットの識別できる名前                                                                                                                 |
-| subnet.subnetCidr      | Body | UUID   | サブネットのCIDR                                                                                                                               |
-| endPoints              | Body | Array  | 接続情報リスト                                                                                                                              |
-| endPoints.domain       | Body | String | ドメイン                                                                                                                                   |
-| endPoints.ipAddress    | Body | String | IPアドレス                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`: (Deprecated)外部接続ドメイン<br>-`PRIVATE`: (Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ネットワーク情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前            | 種類 | 形式    | 必須 | 説明         |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明                |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | DBインスタンス内のユーザーリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                           | 種類   | 形式       | 説明                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DBユーザーリスト                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DBユーザーの識別子                                                                                                                  |
-| dbUsers.dbUserName           | Body | String   | DBユーザーアカウント名                                                                                                                |
-| dbUsers.host                 | Body | String   | DBユーザーアカウントのホスト名                                                                                                            |
-| dbUsers.authorityType        | Body | Enum     | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/>                      |
-| dbUsers.dbUserStatus         | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `UPDATING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み         |
-| dbUsers.authenticationPlugin | Body | Enum     | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-| dbUsers.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBユーザーを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | DBインスタンス内のユーザーを作成 |
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserName           | Body | String | O  | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32`                                                          |
-| dbPassword           | Body | String | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| host                 | Body | String | O  | DBユーザーアカウントのホスト名<br/>- 例: `1.1.1.%`                                                                    |
-| authorityType        | Body | Enum   | O  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | DBインスタンス内のユーザーを修正 |
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserId             | URL  | UUID   | O  | DBユーザーの識別子                                                                                             |
-| dbPassword           | Body | String | X  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| authorityType        | Body | Enum   | X  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | DBインスタンス内のユーザーを削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBスキーマリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明                |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | DBインスタンス内のスキーマリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                                                                                             |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DBスキーマリスト                                                                                      |
-| dbSchemas.dbSchemaId     | Body | UUID     | DBスキーマの識別子                                                                                     |
-| dbSchemas.dbSchemaName   | Body | String   | DBスキーマ名                                                                                        |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DBスキーマの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbSchemas.createdYmdt    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                               |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBスキーマを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明               |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | DBインスタンス内のスキーマを作成 |
-
-#### リクエスト
-
-| 名前         | 種類 | 形式   | 必須 | 説明         |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O  | DBスキーマ名  |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBスキーマを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明               |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | DBインスタンス内のスキーマを削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbSchemaId   | URL | UUID | O  | DBスキーマの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ログファイルリスト表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明                  |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | DBインスタンス内のログファイルリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類  | 形式  | 必須 | 説明                                                                                                                                                                                            |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DBインスタンスの識別子                                                                                                                                                                                  |
-| logFileTypes | Query | Array | X  | ログファイルタイプ種類一覧<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### レスポンス
-
-| 名前                 | 種類 | 形式     | 説明                                                                                                                                                                                         |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | ログファイルリスト                                                                                                                                                                                   |
-| logFiles.logFileName | Body | String   | ログファイル名                                                                                                                                                                                   |
-| logFiles.logFileType | Body | Enum     | ログファイルタイプ種類<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | ログファイルサイズ(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ログファイルの内容照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### 必要な権限
-
 | 権限名 | 説明 |
-|-----------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.Get | DBインスタンス内のログファイル内容照会 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | バックアップ情報を修正する |
 
 #### リクエスト
-
-このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| logFileName | URL | String | O | ログファイル名 |
-| logFileType | Query | Enum | O | ログファイルタイプの種類<br/>- `ERROR`：error.log<br/>- `BINLOG`：mysql-bin<br/>- `GENERAL`：general.log<br/>- `SLOW_QUERY`：slow_query.log<br/>- `AUDIT`：server_audit.log<br/>- `BACKUP`：xtra_full.log |
+| backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
+| backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|---------|------|--------|--------------------------|
-| content | Body | String | ログファイルの内容(最大65533 Bytes) |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -2651,7 +1334,7 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "content": "..."
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2659,57 +1342,7 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 </details>
 
 ---
-
-### ログファイルのエクスポート
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明                 |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | DBインスタンス内のログファイルをエクスポート |
-
-#### リクエスト
-
-| 名前            | 種類 | 形式   | 必須 | 説明                           |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                 |
-| logFileNames    | Body | Array  | O  | ログファイル名リスト<br/>- 最小サイズ: `1`      |
-| tenantId        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID      |
-| password        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | ログファイルが保存されるオブジェクトストレージのコンテナ   |
-| objectPath      | Body | String | O  | コンテナに保存されるログファイルのパス          |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### BinLog一覧照会
+### バイナリログ一覧照会
 
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
@@ -2718,26 +1351,25 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 #### 必要な権限
 
 | 権限名 | 説明 |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | BinLog一覧照会 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | バイナリログ一覧照会 |
 
 #### リクエスト
 
 このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| deletable | Query | Boolean | X | 削除可能なBinLogのみ照会するかどうか<br/>- `true`：最後のBinLogを除く<br/>- `false`：全体<br/>- デフォルト値：`false` |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|------------------------|------|----------|-----------------------------------|
+|-----|-----|-----|-----|
 | binLogs | Body | Array | BinLogファイル一覧 |
 | binLogs.binLogFileName | Body | String | BinLogファイル名 |
 | binLogs.binLogFileSize | Body | Number | BinLogファイルサイズ(Byte) |
-| binLogs.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| binLogs.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
 <p>
@@ -2751,9 +1383,9 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2764,7 +1396,7 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 ---
 
-### BinLog削除
+### バイナリログ削除
 
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
@@ -2773,14 +1405,14 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | BinLog削除 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | バイナリログ削除 |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------------|------|--------|----|---------------------------------------|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 | lastBinLogFileName | Body | String | O | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
 
 <details><summary>例</summary>
@@ -2799,22 +1431,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 このAPIはレスポンスボディを返しません。
 
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
 ### 証明書ファイル一覧照会
@@ -2826,7 +1442,7 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 #### 必要な権限
 
 | 権限名 | 説明 |
-|--------------------------------------------------------|---------------|
+|-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.List | 証明書ファイル一覧照会 |
 
 #### リクエスト
@@ -2834,18 +1450,18 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-----|------|----|---------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
+|-----|-----|-----|-----|
 | certificates | Body | Array | 証明書ファイル一覧 |
 | certificates.fileName | Body | String | 証明書ファイル名 |
-| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- `CA_FILE`：CA証明書<br/>- `CERT_FILE`：証明書<br/>- `KEY_FILE`：秘密鍵 |
+| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
 | certificates.fileSize | Body | Number | 証明書ファイルサイズ(Byte) |
-| certificates.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| certificates.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
 <p>
@@ -2859,10 +1475,10 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
-            "fileName": "ca.pem",
+            "fileName": "fileName-example",
             "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "fileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2882,16 +1498,16 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|-------------|
+|-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.Export | 証明書ファイルエクスポート |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| certificateTypes | Body | Array | O | アップロードする証明書タイプ<br/>- `CA_FILE`：CA証明書<br/>- `CERT_FILE`：証明書<br/>- `KEY_FILE`：秘密鍵 |
-| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID |
+| certificateTypes | Body | Array | O | アップロードする証明書タイプ一覧 |
+| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
 | username | Body | String | O | NHN CloudメンバーまたはIAMメンバーID |
 | password | Body | String | O | 証明書ファイルが保存されるObject StorageのAPIパスワード |
 | targetContainer | Body | String | O | 証明書ファイルが保存されるObject Storageのコンテナ |
@@ -2902,12 +1518,12 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 ```json
 {
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
+    "certificateTypes": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -2917,64 +1533,8 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストされたジョブの識別子 |
-
----
-
-## バックアップ
-
-### バックアップ状態
-
-| 状態         | 説明         |
-|--------------|--------------|
-| `BACKING_UP` | バックアップ中の場合   |
-| `COMPLETED`  | バックアップが完了している場合 |
-| `DELETING`   | バックアップが削除中の場合 |
-| `DELETED`    | バックアップが削除されている場合 |
-| `ERROR`      | エラーが発生した場合 |
-
-### バックアップ詳細照会
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### 必要な権限
-
-| 権限名 | 説明 |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | バックアップ詳細照会 |
-
-#### リクエスト
-
-このAPIはリクエストボディを要求しません。
-
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O | バックアップの識別子 |
-
-#### レスポンス
-
-| 名前 | 種類 | 形式 | 説明 |
-|-------------------------|------|----------|-----------------|
-| backup | Body | Object | バックアップ詳細情報 |
-| backup.backupId | Body | UUID | バックアップの識別子 |
-| backup.regionCode | Body | Enum | リージョンコード |
-| backup.backupName | Body | String | バックアップを識別できる名前 |
-| backup.backupStatus | Body | Enum | バックアップの現在のステータス |
-| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| backup.dbVersion | Body | Enum | DBエンジンバージョン |
-| backup.backupType | Body | Enum | バックアップタイプ |
-| backup.backupMethodType | Body | Enum | バックアップ方式 |
-| backup.backupFileType | Body | Enum | バックアップファイルタイプ |
-| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backup.isReplicable | Body | Boolean | レプリケーション可否 |
-| backup.binLogFileName | Body | String | バイナリログファイル名 |
-| backup.binLogPosition | Body | Number | バイナリログ位置 |
-| backup.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -2986,23 +1546,1990 @@ GET /v4.0/backups/{backupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマリストを表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | DBスキーマリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエストボディを要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | Body | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | Body | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Body | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | 作成日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマを作成する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | DBスキーマを作成する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbSchemaName | Body | String | O | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | DBスキーマを削除する |
+
+#### リクエスト
+
+このAPIはリクエストボディを要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbSchemaId | URL | UUID | O | DBスキーマの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーリストを表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | DBユーザーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DBユーザーリスト |
+| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
+| dbUsers.host | Body | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Body | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Body | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを作成する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | DBユーザーを作成する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | Body | String | O | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | DBユーザーを削除する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | DBユーザーを修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+| dbPassword | Body | String | X | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Body | Enum | X | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス削除保護設定を変更する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DBインスタンス削除保護設定を変更する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスを強制再起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | DBインスタンスを強制再起動する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### 高可用性情報の照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 高可用性情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| haStatus | Body | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Body | Number | Ping間隔(秒) |
+| pingType | Body | String | Pingタイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useHighAvailability | Body | Boolean | O | 高可用性を使用するかどうか |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長: `1`<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を一時停止する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | 高可用性の一時停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を復旧する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | 高可用性の復旧 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を再開する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | 高可用性の再開 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を分離する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | 高可用性の分離 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### ログファイルリスト表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | ログファイルリスト表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | ログファイルリスト |
+| logFiles.logFileName | Body | String | ログファイル名 |
+| logFiles.logFileType | Body | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | Body | DateTime | 作成日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### ログファイルのエクスポート
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | ログファイルのエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | ログファイル名リスト |
+| tenantId | Body | String | O | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるログファイルのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### ログファイルの内容照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | ログファイルの内容照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| logFileName | URL | UUID | O | ログファイル名 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| content | Body | String | ログファイルの内容(最大65533 bytes) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスメンテナンスリストを表示する
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | DBインスタンスメンテナンスリストを表示する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | メンテナンスリストの件数 |
+| maintenances | Body | Array | メンテナンスリスト |
+| maintenances.maintenanceId | Body | UUID | メンテナンスID |
+| maintenances.dbInstanceId | Body | UUID | DBインスタンスID |
+| maintenances.category | Body | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| maintenances.description | Body | String | メンテナンスの説明 |
+| maintenances.type | Body | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| maintenances.payload | Body | Object | メンテナンスタイプに応じたPayload |
+| maintenances.required | Body | Boolean | メンテナンスが必須かどうか |
+| maintenances.deadlineYmdt | Body | DateTime | メンテナンスの強制適用日時 |
+| maintenances.status | Body | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
+| maintenances.addedYmdt | Body | DateTime | メンテナンススケジュール登録日時 |
+| maintenances.executionStartedYmdt | Body | DateTime | メンテナンス開始日時 |
+| maintenances.executionCompletedYmdt | Body | DateTime | メンテナンス終了日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンスを即時実行する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | DBインスタンスメンテナンスを即時実行する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| configId | Body | String | O | 設定ID |
+| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | Body | String | X | メンテナンスの説明 |
+| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンスを予約する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | DBインスタンスメンテナンスを予約する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| configId | Body | String | O | 設定ID |
+| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | Body | String | X | メンテナンスの説明 |
+| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスメンテナンスを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | DBインスタンスメンテナンスを削除する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| maintenanceId | URL | UUID | O | メンテナンスID |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### ネットワーク情報表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | ネットワーク情報表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Body | Object | サブネットオブジェクト |
+| subnet.subnetId | Body | UUID | サブネットの識別子 |
+| subnet.subnetName | Body | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | Body | String | サブネットのCIDR |
+| endPoints | Body | Array | 接続情報リスト |
+| endPoints.domain | Body | String | ドメイン |
+| endPoints.ipAddress | Body | String | IPアドレス |
+| endPoints.endPointType | Body | String | 接続情報タイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### ネットワーク情報を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | ネットワーク情報を修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを昇格する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | DBインスタンスの昇格 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの再構築
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | DBインスタンスの再構築 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを複製する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大の長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否 |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | X | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | X | データストレージタイプ |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | X | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
     "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを再起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | DBインスタンスの再起動 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB インスタンス復元情報照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB インスタンス復元情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 最古の復元可能時間 |
+| latestRestorableYmdt | Body | DateTime | 最新の復元可能時間 |
+| restorableBackups | Body | Array | 復元可能なバックアップリスト |
+| restorableBackups.backup | Body | Object | バックアップ情報オブジェクト |
+| restorableBackups.backup.backupId | Body | UUID | バックアップの識別子 |
+| restorableBackups.backup.backupName | Body | String | バックアップ名 |
+| restorableBackups.backup.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| restorableBackups.backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
+| restorableBackups.backup.dbVersion | Body | Enum | DBエンジンタイプ |
+| restorableBackups.backup.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | バックアップサイズ |
+| restorableBackups.backup.useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
+| restorableBackups.backup.failoverCount | Body | Number | フェイルオーバー回数 |
+| restorableBackups.backup.binLogFileName | Body | String | バイナリログファイル名 |
+| restorableBackups.backup.binLogPosition | Body | Object | バイナリログファイル位置 |
+| restorableBackups.backup.createdYmdt | Body | DateTime | バックアップ作成日時 |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | バックアップ更新日時 |
+| restorableBackups.restorableBinLogs | Body | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backup": {
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "MYSQL_V8036",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
+            "restorableBinLogs": []
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 復元される最後のクエリ照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 復元される最後のクエリ照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | クエリ実行日時 |
+| lastQuery | Body | String | 最後に実行したクエリ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスの復元
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに対する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
+| dbPort | Body | Number | X | DBポート |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Body | Object | X | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
+| storage.storageType | Body | Enum | X | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Body | Object | X | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
+| network.subnetId | Body | UUID | X | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
+| backup | Body | Object | X | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.restoreType | Body | Enum | O | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
+| restore.binLog.binLogFileName | Body | String | X | 復元に使用するバイナリログ名 |
+| restore.binLog.binLogPosition | Body | Object | X | 復元に使用するバイナリログ位置 |
+| useDefaultNotification | Body | Boolean | X | 基本アラームを使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
+
+#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+| restore.binLog | Body | Object | X | バイナリログ情報オブジェクト |
+
+バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
+
+#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | DBインスタンスの起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを停止する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | DBインスタンスの停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### ストレージ情報を表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | ストレージ情報を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| storageType | Body | String | データストレージタイプ |
+| storageSize | Body | Number | データストレージサイズ(GB) |
+| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
+| storageAutoscale | Body | Object | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか |
+| storageAutoscale.threshold | Body | Number | 自動拡張条件(%) |
+| storageAutoscale.maxStorageSize | Body | Number | 自動拡張最大サイズ(GB) |
+| storageAutoscale.cooldownTime | Body | Number | 自動拡張クールダウン時間(分) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
     }
 }
 ```
@@ -3012,6 +3539,86 @@ GET /v4.0/backups/{backupId}
 
 ---
 
+### ストレージ情報を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | ストレージ情報を修正する |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+| storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+## バックアップ
+
+### バックアップ状態
+
+| 状態           | 説明           |
+|--------------|--------------|
+| `BACKING_UP` | バックアップ中の場合     |
+| `COMPLETED`  | バックアップが完了している場合   |
+| `DELETING`   | バックアップが削除中の場合 |
+| `DELETED`    | バックアップが削除されている場合   |
+| `ERROR`      | エラーが発生した場合   |
+
 ### バックアップリスト照会
 
 ```http
@@ -3020,37 +3627,30 @@ GET /v4.0/backups
 
 #### 必要権限
 
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.List | バックアップリスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類  | 形式   | 必須 | 説明                                                     |
-|-------------------|-------|----------|----|------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動<br/>- デフォルト値:全体 |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                        |
-| dbVersion    | Query | Enum   | X  | DBエンジンタイプ                                               |
-
 #### レスポンス
 
-| 名前                 | 種類 | 形式     | 説明                              |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 全バックアップリスト数                     |
-| backups              | Body | Array    | バックアップリスト                           |
-| backups.backupId     | Body | UUID     | バックアップの識別子                         |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                  |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態                       |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                 |
-| backups.dbVersion    | Body | Enum     | DBエンジンタイプ                        |
-| backups.backupType   | Body | Enum     | バックアップタイプ                           |
-| backups.backupSize   | Body | Number   | バックアップのサイズ(Byte)                      |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全バックアップリスト数 |
+| backups | Body | Array | バックアップリスト |
+| backups.backupId | Body | UUID | バックアップの識別子 |
+| backups.backupName | Body | String | バックアップを識別できる名前 |
+| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | Body | Enum | DBエンジンタイプ |
+| backups.utilVersion | Body | String | ユーティリティバージョン |
+| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | Body | DateTime | 作成日時 |
+| backups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3065,15 +3665,16 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3092,89 +3693,182 @@ POST /v4.0/backups
 
 #### 必要権限
 
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Create | バックアップの作成 |
 
-#### 共通リクエスト
-
-| 名前             | 種類 | 形式   | 必須 | 説明                                                                                         |
-|------------------|------|--------|----|--------------------------------------------------------------------------------------------|
-| backupName       | Body | String | O  | バックアップを識別できる名前                                                                             |
-| backupMethodType | Body | Enum | O | バックアップ方式タイプ種類<br/>- `FULL`：全体バックアップ<br/>- `INCREMENTAL`：増分バックアップ<br/>- `SNAPSHOT`：スナップショットバックアップ |
-
-#### 全体バックアップ(backupMethodTypeが`FULL`の場合)
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DBインスタンスの識別子 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
-#### 増分バックアップ(backupMethodTypeが`INCREMENTAL`の場合)
-
-| 名前         | 種類 | 形式 | 必須 | 説明       |
-|--------------|------|------|----|------------|
-| baseBackupId | Body | UUID | O  | 基準バックアップの識別子 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-
-#### スナップショットバックアップ(backupMethodTypeが`SNAPSHOT`の場合)
+#### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O | DBインスタンスの識別子 |
-
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| baseBackupId | Body | UUID | X | 原本バックアップの識別子 |
+| dbInstanceId | Body | UUID | X | DBインスタンスの識別子 |
+| backupMethodType | Body | Enum | O | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップの削除
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | バックアップの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップ詳細照会
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | バックアップ詳細照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| backup | Body | Object | バックアップ詳細情報 |
+| backup.backupId | Body | UUID | バックアップの識別子 |
+| backup.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| backup.backupName | Body | String | バックアップを識別できる名前 |
+| backup.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
+| backup.dbVersion | Body | Enum | DBエンジンバージョン |
+| backup.utilVersion | Body | String | ユーティリティバージョン |
+| backup.backupType | Body | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
+| backup.isReplicable | Body | Boolean | レプリケーション可否 |
+| backup.binLogFileName | Body | String | バイナリログファイル名 |
+| backup.binLogPosition | Body | Object | バイナリログ位置 |
+| backup.createdYmdt | Body | DateTime | 作成日時 |
+| backup.updatedYmdt | Body | DateTime | 修正日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "MYSQL_V8036",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3186,31 +3880,31 @@ POST /v4.0/backups/{backupId}/export
 
 #### 必要権限
 
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Export | バックアップエクスポート |
 
 #### リクエスト
 
-| 名前            | 種類 | 形式   | 必須 | 説明                        |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                   |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ   |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス          |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3219,12 +3913,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
-> [注意]
-> 手動バックアップの場合、バックアップが行われたDBインスタンスが存在しない場合、バックアップをオブジェクトストレージにエクスポートすることができません。
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3236,70 +3944,95 @@ POST /v4.0/backups/{backupId}/restore
 
 #### 必要権限
 
-| 権限名                                      | 説明    |
-|--------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Restore | バックアップの復元 |
 
-#### リクエスト
+#### 共通リクエスト
 
-| 名前                                         | 種類 | 形式    | 必須 | 説明                                                                |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O  | バックアップの識別子                                                           |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる マスター名                                           |
-| dbInstanceCandidateName                      | Body | String  | X  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                         |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                 |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値：原本DBインスタンスの値                                                   |
-| dbPort | Body | Integer | X | DBポート<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`3306`<br/>- 最大値：`43306` |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値：原本DBインスタンスの値                                                      |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                  ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                    |
-| useHighAvailability                          | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                       |
-| pingInterval                                 | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                             | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`      |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                         | 
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                  |
-| network                                      | Body | Object  | X  | ネットワーク情報オブジェクト                                                        |
-| network.subnetId | Body | UUID | X | サブネットの識別子<br/>- デフォルト値：原本DBインスタンスの値 |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`<br/>- デフォルト値：ランダム選択                            |
-| storage                                      | Body | Object  | X  | データストレージ情報オブジェクト                                                    |    
-| storage.storageType | Body | Enum | X | データストレージタイプ<br/>- デフォルト値：原本DBインスタンスの値<br/>- 例：`General SSD` |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`20`<br/>- 最大値：`2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値：原本DBインスタンスの値 |
-| storage.storageAutoscale.threshold | Body | Number | X | 自動拡張条件(%)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`50`<br/>- 最大値：`95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | X | 自動拡張最大サイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最大値：`4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | X | 自動拡張クールダウン時間(分)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`10`<br/>- 最大値：`1440` |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                          |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`0`<br/>- 最大値：`730` |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト<br/>- デフォルト値：原本DBインスタンスの値                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbPort | Body | Number | X | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Body | Object | X | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| network.subnetId | Body | UUID | X | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
+| storage | Body | Object | X | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageType | Body | Enum | X | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | X | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules | Body | Array | X | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
         "storageType": "General SSD",
-        "storageSize": 20
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -3315,50 +4048,38 @@ POST /v4.0/backups/{backupId}/restore
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
----
+<details><summary>例</summary>
+<p>
 
-### バックアップを削除する
-
-```http
-DELETE /v4.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 必要権限
-
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | バックアップの削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前     | 種類 | 形式 | 必須 | 説明    |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+</p>
+</details>
 
 ---
-
 ## DBセキュリティグループ
 
 ### DBセキュリティグループ進行状態
 
-| 状態            | 説明         |
-|-----------------|--------------|
-| `NONE`          | 進行中の作業がない  |
-| `CREATING_RULE` | ルールポリシーの作成中 |
-| `UPDATING_RULE` | ルールポリシーの修正中 |
-| `DELETING_RULE` | ルールポリシーの削除中 |
+| 状態              | 説明               |
+|-----------------|------------------|
+| `NONE`          | 進行中の作業がない        |
+| `CREATING_RULE` | ルールポリシーの作成中      |
+| `UPDATING_RULE` | ルールポリシーの修正中      |
+| `DELETING_RULE` | ルールポリシーの削除中      |
 
 ### DBセキュリティグループリストを表示
 
@@ -3368,30 +4089,26 @@ GET /v4.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                            | 説明           |
-|--------------------------------------------------|----------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.List | DBセキュリティグループリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-
 #### レスポンス
 
-| 名前                                 | 種類 | 形式     | 説明                              |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DBセキュリティグループリスト                     |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                   |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前            |
-| dbSecurityGroups.description         | Body | String   | DBセキュリティグループの追加情報               |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態              |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | DBセキュリティグループリストの総数 |
+| dbSecurityGroups | Body | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | Body | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3403,101 +4120,17 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBセキュリティグループの詳細を表示
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明           |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | DBセキュリティグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式 | 必須 | 説明          |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
-#### レスポンス
-
-| 名前                | 種類 | 形式     | 説明                                                                                                               |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                                                                                                    |
-| dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前                                                                                             |
-| description         | Body | String   | DBセキュリティグループの追加情報                                                                                                |
-| progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態                                                                                               |
-| rules               | Body | Array    | DBセキュリティグループルールリスト                                                                                                   |
-| rules.ruleId        | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                 |
-| rules.description   | Body | String   | DBセキュリティグループルールの追加情報                                                                                             |
-| rules.direction     | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                     |
-| rules.etherType     | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | ポートオブジェクト                                                                                                            |
-| rules.port.portType | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。<br/>- `PORT`:指定されたポート値に設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number   | 最小ポート範囲                                                                                                          |
-| rules.port.maxPort  | Body | Number   | 最大ポート範囲                                                                                                         |
-| rules.cidr          | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                   |
-| rules.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
 }
 ```
 
@@ -3514,46 +4147,44 @@ POST /v4.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Create | DBセキュリティグループの作成 |
 
 #### リクエスト
 
-| 名前                | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                   |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                         |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Body | Array | O | DBセキュリティグループルールリスト |
+| rules.direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Body | Object | O | ポートオブジェクト |
+| rules.port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | DBセキュリティグループルールの追加情報 |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
@@ -3564,48 +4195,9 @@ POST /v4.0/db-security-groups
 
 #### レスポンス
 
-| 名前              | 種類 | 形式 | 説明          |
-|-------------------|------|------|---------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
----
-
-### DBセキュリティグループを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
-
-#### リクエスト
-
-| 名前                | 種類 | 形式   | 必須 | 説明                  |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子       |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
 
 <details><summary>例</summary>
 <p>
@@ -3616,13 +4208,13 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
 
 ---
 
@@ -3634,21 +4226,66 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 必要権限
 
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Delete | DBセキュリティグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明          |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### DBセキュリティグループの詳細を表示
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | DBセキュリティグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
+| description | Body | String | DBセキュリティグループの追加情報 |
+| progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| rules | Body | Array | DBセキュリティグループルールリスト |
+| rules.ruleId | Body | UUID | DBセキュリティグループルールの識別子 |
+| rules.description | Body | String | DBセキュリティグループルールの追加情報 |
+| rules.direction | Body | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Body | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Body | Object | ポートオブジェクト |
+| rules.port.portType | Body | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Body | Number | 最小ポート範囲 |
+| rules.port.maxPort | Body | Number | 最大ポート範囲 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 作成日時 |
+| rules.updatedYmdt | Body | DateTime | 修正日時 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3659,7 +4296,114 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBセキュリティグループを修正する
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBセキュリティグループルールを削除する
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | DBセキュリティグループルールの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -3676,26 +4420,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 必要権限
 
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
 
 #### リクエスト
 
-| 名前              | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                          |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Body | Object | O | ポートオブジェクト |
+| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 <details><summary>例</summary>
 <p>
@@ -3705,11 +4446,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3718,9 +4460,26 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3732,27 +4491,24 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### 必要権限
 
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
 
 #### リクエスト
 
-| 名前              | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                          |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                       |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Body | Object | O | ポートオブジェクト |
+| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 <details><summary>例</summary>
 <p>
@@ -3762,9 +4518,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "DB_PORT"
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3773,41 +4532,28 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
----
+<details><summary>例</summary>
+<p>
 
-### DBセキュリティグループルールを削除する
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 必要権限
-
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DBセキュリティグループルールの削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類  | 形式  | 必須 | 説明                |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子     |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+</p>
+</details>
 
 ---
-
 ## パラメータグループ
 
 ### パラメータグループリストを表示
@@ -3818,30 +4564,28 @@ GET /v4.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                           | 説明          |
-|-------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.List | パラメータグループリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前      | 種類  | 形式 | 必須 | 説明     |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DBエンジンタイプ |
-
 #### レスポンス
 
-| 名前                                 | 種類 | 形式     | 説明                                                              |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                      |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                    |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                            |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                               |
-| parameterGroups.dbVersion            | Body | Enum     | DBエンジンタイプ                                                        |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | パラメータグループの総数 |
+| parameterGroups | Body | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | Body | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | Body | Enum | DBエンジンタイプ |
+| parameterGroups.parameterGroupType | Body | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3853,15 +4597,17 @@ GET /v4.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3869,88 +4615,6 @@ GET /v4.0/parameter-groups
 
 </p>
 </details>
-
-
----
-
-### パラメータグループの詳細を表示
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | パラメータグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類 | 形式     | 説明                                                                                                   |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | パラメータグループの識別子                                                                                         |
-| parameterGroupName            | Body | String   | パラメータグループを識別できる名前                                                                              |
-| description                   | Body | String   | パラメータグループの追加情報                                                                                 |
-| dbVersion                     | Body | Enum     | DBエンジンタイプ                                                                                             |
-| parameterGroupStatus          | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要                                    |
-| parameters                    | Body | Array    | パラメータリスト                                                                                              |
-| parameters.parameterId        | Body | UUID     | パラメータ識別子                                                                                             |
-| parameters.parameterFileGroup | Body | Enum     | パラメータファイルグループタイプ<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | パラメータ名                                                                                              |
-| parameters.fileParameterName  | Body | String   | パラメータファイル名                                                                                           |
-| parameters.value              | Body | String   | 現在設定されている値                                                                                     |
-| parameters.defaultValue       | Body | String   | デフォルト値                                                                                                  |
-| parameters.allowedValue       | Body | String   | 許可された値                                                                                         |
-| parameters.updateType         | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:いつでも修正可能<br/>- `CONSTANT`:修正不可<br/>- `INIT_VARIABLE`: DBインスタンス作成時にのみ修正可能 |
-| parameters.applyType          | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体(再起動必要)                   |
-| createdYmdt                   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
 
 ---
 
@@ -3962,25 +4626,26 @@ POST /v4.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Create | パラメータグループの作成 |
 
 #### リクエスト
 
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-| dbVersion          | Body | Enum   | O  | DBエンジンタイプ           |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -3989,89 +4654,10 @@ POST /v4.0/parameter-groups
 
 #### レスポンス
 
-| 名前             | 種類 | 形式 | 説明         |
-|------------------|------|------|--------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | パラメータグループの識別子 |
 
----
-
-### パラメータグループをコピーする
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明         |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | パラメータグループコピーする |
-
-#### リクエスト
-
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子       |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前             | 種類 | 形式 | 説明         |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
----
-
-### パラメータグループを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子       |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
 <details><summary>例</summary>
 <p>
 
@@ -4081,107 +4667,8 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### パラメータを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                           | 種類 | 形式   | 必須 | 説明         |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters             | Body | Array  | O  | 変更するパラメータリスト |
-| modifiedParameters.parameterId | Body | UUID   | O  | パラメータの識別子  |
-| modifiedParameters.value       | Body | String | O  | 変更するパラメータ値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### パラメータグループをリセットする
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明          |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | パラメータグループのリセット |
-
-#### リクエスト
-
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4198,21 +4685,65 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### 必要権限
 
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Delete | パラメータグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの詳細を表示
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | パラメータグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| description | Body | String | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Body | Array | パラメータリスト |
+| parameters.parameterId | Body | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Body | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | パラメータ名 |
+| parameters.fileParameterName | Body | String | パラメータファイル名 |
+| parameters.value | Body | String | 現在設定されている値 |
+| parameters.defaultValue | Body | String | デフォルト値 |
+| parameters.allowedValue | Body | String | 許可された値 |
+| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4223,7 +4754,27 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4232,6 +4783,172 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ---
 
+### パラメータグループを修正する
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループをコピーする
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | パラメータグループコピーする |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### パラメータを修正する
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
+| modifiedParameters.parameterId | Body | UUID | O | パラメータの識別子 |
+| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループをリセットする
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | パラメータグループのリセット |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
@@ -4242,8 +4959,8 @@ GET /v4.0/user-groups
 
 #### 必要権限
 
-| 権限名                                      | 説明         |
-|--------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.List | ユーザーグループリスト表示 |
 
 #### リクエスト
@@ -4252,13 +4969,14 @@ GET /v4.0/user-groups
 
 #### レスポンス
 
-| 名前                     | 種類 | 形式     | 説明                              |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                       |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | ユーザーグループリストの総数 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | Body | DateTime | 作成日時 |
+| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4270,74 +4988,15 @@ GET /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ユーザーグループの詳細を表示
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明         |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | ユーザーグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前        | 種類 | 形式 | 必須 | 説明        |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
-#### レスポンス
-
-| 名前              | 種類 | 形式     | 説明                                                                                                      |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                             |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                         |
-| userGroupTypeCode | Body | Enum     | ユーザーグループの種類 <br /> `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ <br /> `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーを含むユーザーグループ |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                              |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                            |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4354,34 +5013,26 @@ POST /v4.0/user-groups
 
 #### 必要権限
 
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Create | ユーザーグループの作成 |
 
 #### リクエスト
 
-| 名前          | 種類 | 形式    | 必須 | 説明                                                      |
-|---------------|------|---------|----|-----------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                     |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト <br /> `selectAll`がtrueの場合、該当フィールドの値は無視される |
-| selectAll     | Body | Boolean | X  | プロジェクトメンバー全員かどうか <br /> trueの場合、該当グループは全メンバーに対して設定される       |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
+| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4390,52 +5041,9 @@ POST /v4.0/user-groups
 
 #### レスポンス
 
-| 名前        | 種類 | 形式 | 説明        |
-|-------------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | ユーザーグループの識別子 |
-
----
-
-### ユーザーグループを修正する
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | ユーザーグループの修正 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式    | 必須 | 説明                                               |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                      |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                                     |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                  |
-| selectAll     | Body | Boolean | X  | プロジェクトメンバー全員かどうか <br /> trueの場合、該当グループは全メンバーに対して設定される |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
 
 <details><summary>例</summary>
 <p>
@@ -4446,7 +5054,8 @@ PUT /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4463,19 +5072,55 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### 必要権限
 
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Delete | ユーザーグループの削除 |
 
 #### リクエスト
 
-| 名前        | 種類 | 形式 | 必須 | 説明        |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### ユーザーグループの詳細を表示
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | ユーザーグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Body | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4486,7 +5131,17 @@ DELETE /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4495,6 +5150,46 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ---
 
+### ユーザーグループを修正する
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | ユーザーグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
+| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## 通知グループ
 
 ### 通知グループリストを表示
@@ -4505,8 +5200,8 @@ GET /v4.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                              | 説明        |
-|----------------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.List | 通知グループリスト表示 |
 
 #### リクエスト
@@ -4515,16 +5210,16 @@ GET /v4.0/notification-groups
 
 #### レスポンス
 
-| 名前                                     | 種類 | 形式     | 説明                              |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 通知グループリスト                        |
-| notificationGroups.notificationGroupId   | Body | UUID     | 通知グループの識別子                      |
-| notificationGroups.notificationGroupName | Body | String   | 通知グループを識別できる名前                  |
-| notificationGroups.notifyEmail           | Body | Boolean  | メール通知                           |
-| notificationGroups.notifySms             | Body | Boolean  | SMS通知                           |
-| notificationGroups.isEnabled             | Body | Boolean  | 有効かどうか                           |
-| notificationGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4538,13 +5233,13 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -4555,43 +5250,51 @@ GET /v4.0/notification-groups
 
 ---
 
-### アラームグループの詳細を表示
+### 通知グループを作成する
 
 ```http
-GET /v4.0/notification-groups/{notificationGroupId}
+POST /v4.0/notification-groups
 ```
 
 #### 必要権限
 
-| 権限名                                             | 説明        |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | 通知グループ詳細表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Create | 通知グループの作成 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Body | Array | O | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
 
-| 名前                | 種類 | 形式 | 必須 | 説明       |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
-| 名前                       | 種類 | 形式     | 説明                              |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                      |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                  |
-| notifyEmail                | Body | Boolean  | メール通知                           |
-| notifySms                  | Body | Boolean  | SMS通知                           |
-| isEnabled                  | Body | Boolean  | 有効かどうか                           |
-| dbInstances                | Body | Array    | 監視対象DBインスタンスリスト                |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                    |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                |
-| userGroups                 | Body | Array    | ユーザーグループリスト                       |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -4603,25 +5306,7 @@ GET /v4.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4630,120 +5315,7 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
-### アラームグループを作成する
-
-```http
-POST /v4.0/notification-groups
-```
-
-#### 必要権限
-
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Create | 通知グループの作成 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                        |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前             |
-| notifyEmail           | Body | Boolean | X  | メール通知<br/>- デフォルト値: `true`  |
-| notifySms             | Body | Boolean | X  | SMS通知<br/>- デフォルト値: `true`  |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 監視対象DBインスタンスの識別子リスト     |
-| userGroupIds          | Body | Array   | O  | ユーザーグループの識別子リスト            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前                | 種類 | 形式 | 説明       |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-
----
-
-### アラームグループを修正する
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | 通知グループの修正 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                  |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子          |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前     |
-| notifyEmail           | Body | Boolean | X  | メール通知              |
-| notifySms             | Body | Boolean | X  | SMS通知              |
-| isEnabled             | Body | Boolean | X  | 有効かどうか               |
-| dbInstanceIds         | Body | Array   | X  | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### アラームグループを削除する
+### 通知グループを削除する
 
 ```http
 DELETE /v4.0/notification-groups/{notificationGroupId}
@@ -4751,21 +5323,61 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### 必要権限
 
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Delete | 通知グループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類 | 形式 | 必須 | 説明       |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### 通知グループの詳細を表示
+
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | 通知グループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | メール通知の有無 |
+| notifySms | Body | Boolean | SMS通知の有無 |
+| isEnabled | Body | Boolean | 有効かどうか |
+| dbInstances | Body | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4776,7 +5388,26 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4785,7 +5416,75 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
+### 通知グループを修正する
+
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | 通知グループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Body | Array | X | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## モニタリング
+
+### 統計情報照会
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | 統計情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### Metricリスト表示
 
@@ -4795,9 +5494,9 @@ GET /v4.0/metrics
 
 #### 必要権限
 
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 統計情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | Metricリスト表示 |
 
 #### リクエスト
 
@@ -4805,11 +5504,11 @@ GET /v4.0/metrics
 
 #### レスポンス
 
-| 名前                | 種類 | 形式   | 説明      |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metricリスト |
-| metrics.measureName | Body | Enum   | 照会指標タイプ |
-| metrics.unit        | Body | String | 測定値単位  |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metricリスト |
+| metrics.measureName | Body | String | 照会指標タイプ |
+| metrics.unit | Body | String | 測定値単位 |
 
 <details><summary>例</summary>
 <p>
@@ -4823,74 +5522,8 @@ GET /v4.0/metrics
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 統計情報照会
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 統計情報照会 |
-
-#### リクエスト
-
-| 名前         | 種類  | 形式     | 必須 | 説明                              |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                    |
-| measureNames | Query | Array    | O  | 照会指標リスト<br/>- 最小サイズ: `1`         |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 照会間隔                           |
-
-#### レスポンス
-
-| 名前                              | 種類 | 形式      | 説明     |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.measureName      | Body | Enum      | 測定項目タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位 |
-| metricStatistics.values           | Body | Array     | 測定値リスト |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間  |
-| metricStatistics.values.value     | Body | Object    | 測定値    |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
@@ -4907,102 +5540,14 @@ GET /v4.0/metric-statistics
 
 イベントはカテゴリに分類することができ、下記の通りです。
 
-| イベントカテゴリー  | 説明    |
+| イベントカテゴリー    | 説明      |
 |-------------|---------|
-| ALL         | 全体    |
-| BACKUP      | バックアップ    |
+| ALL         | 全体      |
+| BACKUP      | バックアップ      |
 | DB_INSTANCE | DBインスタンス |
-| JOB         | 作業    |
-| TENANT      | テナント   |
-| MONITORING  | モニタリング  |
-
-### イベントリスト照会
-
-```http
-GET /v4.0/events
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明      |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | イベントリスト表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類  | 形式     | 必須 | 説明                                                                                                                                 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `INSTANCE`: DBインスタンス<br/>- `BACKUP`:バックアップ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `TENANT`:テナント |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                               |
-| keyword           | Query | String   | X  | イベントメッセージに含まれる文字列検索ワード                                                                                                                      |
-| ascendingOrder    | Query | Enum     | X  | イベントメッセージソート順序<br/>- `ASC`:昇順<br/>- `DESC`:降順<br/>- デフォルト値: `DESC`                                                                 |
-
-#### レスポンス
-
-| 名前                     | 種類 | 形式     | 説明                                  |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 全イベントリストの数                          |
-| events                   | Body | Array    | イベントリスト                              |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                         |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ                         |
-| events.sourceId          | Body | String   | イベントソースの識別子                         |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                     |
-| events.messages          | Body | Array    | イベントメッセージリスト                          |
-| events.messages.langCode | Body | String   | 言語コード                               |
-| events.messages.message  | Body | String   | イベントメッセージ                             |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+| JOB         | 作業      |
+| TENANT      | テナント     |
+| MONITORING  | モニタリング    |
 
 ### 購読可能なイベントコード一覧表示
 
@@ -5012,9 +5557,9 @@ GET /v4.0/event-codes
 
 #### 必要権限
 
-| 権限名                                  | 説明      |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | イベントリスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 購読可能なイベントコード一覧表示 |
 
 #### リクエスト
 
@@ -5022,11 +5567,11 @@ GET /v4.0/event-codes
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式  | 説明        |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | イベントコードリスト |
-| eventCodes.eventCode         | Body | Enum  | イベントコード    |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | イベントコードリスト |
+| eventCodes.eventCode | Body | Enum | イベントコード |
+| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>例</summary>
 <p>
@@ -5040,8 +5585,73 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### イベントリスト照会
+
+```http
+GET /v4.0/events
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Event.List | イベントリスト照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全イベントリストの数 |
+| events | Body | Array | イベントリスト |
+| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | 発生したイベントのタイプ |
+| events.sourceId | Body | UUID | イベントソースの識別子 |
+| events.sourceName | Body | String | イベントソースを識別できる名前 |
+| events.messages | Body | Array | イベントメッセージリスト |
+| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | イベントメッセージ |
+| events.eventYmdt | Body | DateTime | イベント発生日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5062,35 +5672,29 @@ GET /v4.0/event-subscriptions
 #### 必要な権限
 
 | 権限名 | 説明 |
-|---------------------------------------------------------|---------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.List | イベント購読一覧照会 |
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| eventSubscriptionId | Query | UUID | X | イベント購読の識別子 |
-| eventSubscriptionName | Query | String | X | イベント購読を識別できる名前 |
-| userGroupId | Query | UUID | X | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-----------------------------------------------|------|----------|---------------------|
+|-----|-----|-----|-----|
 | totalCounts | Body | Number | 全イベント購読一覧数 |
 | eventSubscriptions | Body | Array | イベント購読一覧 |
 | eventSubscriptions.eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリタイプ |
+| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | イベント購読を識別できる名前 |
-| eventSubscriptions.enabled                    | Body | Boolean  | 有効かどうか              |
+| eventSubscriptions.enabled | Body | Boolean | 有効かどうか |
 | eventSubscriptions.notifyEmail | Body | Boolean | メール送信の有無 |
 | eventSubscriptions.notifySms | Body | Boolean | SMS送信の有無 |
 | eventSubscriptions.eventCodes | Body | Array | 購読するイベントコード一覧 |
 | eventSubscriptions.sources | Body | Array | 購読するイベントソース一覧 |
 | eventSubscriptions.sources.sourceId | Body | UUID | イベントソースの識別子 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴーリタイプ |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | イベント購読中のユーザーグループの識別子一覧 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 作成日時 |
 
@@ -5107,25 +5711,23 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
             "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
+            "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
                 }
             ],
             "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
+                "550e8400-e29b-41d4-a716-446655440000"
             ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5145,22 +5747,22 @@ POST /v4.0/event-subscriptions
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Create | イベント購読作成 |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------------------|------|---------|----|-----------------------------------------|
-| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ |
-| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前<br/>- 最大長：`100` |
-| enabled                      | Body | Boolean | O  | 有効かどうか                                |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前 |
+| enabled | Body | Boolean | O | 有効かどうか |
 | notifyEmail | Body | Boolean | O | メール送信の有無 |
 | notifySms | Body | Boolean | O | SMS送信の有無 |
 | eventCodes | Body | Array | O | 購読するイベントコード一覧 |
 | sources | Body | Array | O | 購読するイベントソース一覧 |
 | sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ |
+| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | userGroupIds | Body | Array | O | イベント購読するユーザーグループの識別子一覧 |
 
 <details><summary>例</summary>
@@ -5168,23 +5770,19 @@ POST /v4.0/event-subscriptions
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5194,7 +5792,7 @@ POST /v4.0/event-subscriptions
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-----------------------|------|------|-------------|
+|-----|-----|-----|-----|
 | eventSubscriptionId | Body | UUID | イベント購読の識別子 |
 
 <details><summary>例</summary>
@@ -5207,86 +5805,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### イベント購読修正
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
-
-| 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | イベント購読修正 |
-
-#### リクエスト
-
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------------------|------|---------|----|-----------------------------------|
-| eventSubscriptionId | URL | UUID | O | イベント購読の識別子 |
-| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ |
-| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
-| enabled                      | Body | Boolean | X  | 有効かどうか                          |
-| notifyEmail | Body | Boolean | X | メール送信の有無 |
-| notifySms | Body | Boolean | X | SMS送信の有無 |
-| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
-| sources | Body | Array | X | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | X | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | X | イベントカテゴリータイプ |
-| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンスボディを返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5304,18 +5823,107 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | イベント購読削除 |
 
 #### リクエスト
 
+このAPIはリクエスト本文を要求しません。
+
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId | URL | UUID | O | イベント購読の識別子 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンスボディを返しません。
+
+---
+
+### イベント購読修正
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | イベント購読修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
+| enabled | Body | Boolean | X | 有効かどうか |
+| notifyEmail | Body | Boolean | X | メール送信の有無 |
+| notifySms | Body | Boolean | X | SMS送信の有無 |
+| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
+| sources | Body | Array | X | 購読するイベントソース一覧 |
+| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
+| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンスボディを返しません。
+
+---
+
+## アベイラビリティゾーン
+
+### アベイラビリティゾーン一覧照会
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | アベイラビリティゾーン一覧照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | アベイラビリティゾーン一覧 |
+| availabilityZones.availabilityZoneName | Body | String | アベイラビリティゾーン名 |
+| availabilityZones.zoneState | Body | Object | アベイラビリティゾーンの状態 |
+| availabilityZones.zoneState.available | Body | Boolean | アベイラビリティゾーンの使用可否 |
 
 <details><summary>例</summary>
 <p>
@@ -5326,7 +5934,15 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "availabilityZones": [
+        {
+            "availabilityZoneName": "availabilityZoneName-example",
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
 }
 ```
 

--- a/ja/api-guide-v4.0-gov.md
+++ b/ja/api-guide-v4.0-gov.md
@@ -1,86 +1,106 @@
-## Database > RDS for MariaDB > APIガイド
+## RDS for MariaDB API ガイド
+
+**Database > RDS for MariaDB > API v4.0 ガイド**
 
 ## RDS for MariaDB API共通情報
 
 ### APIエンドポイント
 
-| リージョン            | エンドポイント           |
-|------------------|-------------------|
+| リージョン | エンドポイント |
+|------|----------|
 | 韓国(パンギョ)リージョン | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
 
-### 認証及び権限
+
+### 認証および権限
 
 RDS for MariaDBは、API呼び出し時の認証/認可のためにUser Access Keyトークンを使用します。User Access Keyトークンは、User Access Keyに基づいて発行されるBearerタイプの一時的なアクセストークンです。User Access Keyトークンの発行及び使用に関する詳細は、[User Access Keyトークン](/nhncloud/ja/public-api/user-access-key-token)を参照してください。
 発行されたトークンはAppkeyと一緒にリクエストHeaderに含める必要があります。
 
-| 名前                  | 種類     | 形式     | 必須 | 説明                                                        |
-|---------------------|--------|--------|----|-----------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public APIで発行されたBearerタイプトークン                             |
-
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public APIで発行されたBearerタイプトークン |
 
 また、プロジェクトメンバーのロールによって呼び出すことができるAPIが制限されます。 `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`で区分して権限を付与できます。
 
 * `RDS for MariaDB ADMIN`権限は全ての機能を使用可能です。
 * `RDS for MariaDB VIEWER`権限は情報を照会する機能のみ使用可能です。
-    * DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
-    * ただし、通知グループとユーザーグループに関連する機能は使用可能です。
+* DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
+* ただし、通知グループとユーザーグループに関連する機能は使用可能です。
 
 APIリクエスト時、認証に失敗したり権限がない場合、次のようなエラーが発生します。
 
-| resultCode | resultMessage | 説明         |
-|------------|---------------|------------|
-| 80401      | Unauthorized  | 認証に失敗しました。 |
-| 80403      | Forbidden     | 権限がありません。  |
+| resultCode | resultMessage | 説明 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 認証に失敗しました。 |
+| 80403 | Forbidden | 権限がありません。 |
 
 ### レスポンス共通情報
 
 すべてのAPIリクエストに「200 OK」でレスポンスします。詳細なレスポンス結果はレスポンス本文のヘッダを参照します。
 
-#### レスポンス本文
+<details>
+  <summary><strong>成功レスポンス</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### フィールド
-| 名前            | 形式      | 説明                                     |
-|---------------|---------|----------------------------------------|
-| resultCode    | Number  | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
-| resultMessage | String  | 結果メッセージ                                |
-| isSuccessful  | Boolean | 成否                                     |
+</details>
 
+<details>
+  <summary><strong>失敗レスポンス</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| resultCode | Number | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
+| resultMessage | String | 結果メッセージ |
+| isSuccessful | Boolean | 成否 |
 ### DBエンジンタイプ
 
 | DBエンジンタイプ | 作成可否 | OBSからの復元可否 | 認証プラグインサポート情報 |
-|-----------------|----------|------------------|-----------------|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
-
 ## プロジェクト情報
 
 ### プロジェクトメンバーリストを表示
-
-```http
-GET /v4.0/project/members
-```
 
 #### 必要権限
 
@@ -90,49 +110,50 @@ GET /v4.0/project/members
 
 #### リクエスト
 
+```http
+GET /v4.0/project/members
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| members | Body | Array | プロジェクトメンバーリスト |
-| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| members.memberName | Body | String | プロジェクトメンバーの名前 |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | String | プロジェクトメンバーの名前 |
+| members.emailAddress | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | String | プロジェクトメンバーの電話番号 |
 
 ---
 
 ### リージョンリストを表示
-
-```http
-GET /v4.0/project/regions
-```
 
 #### 必要権限
 
@@ -142,46 +163,48 @@ GET /v4.0/project/regions
 
 #### リクエスト
 
+```http
+GET /v4.0/project/regions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| regions | Body | Array | リージョンリスト |
-| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
-| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| regions | Array | リージョンリスト |
+| regions.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Boolean | リージョンが有効かどうか |
+
 ---
+
 ## DBインスタンスの仕様
 
 ### DBインスタンス仕様リストを表示
-
-```http
-GET /v4.0/db-flavors
-```
 
 #### 必要権限
 
@@ -191,51 +214,52 @@ GET /v4.0/db-flavors
 
 #### リクエスト
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DBインスタンス仕様リスト |
-| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
-| dbFlavors.ram | Body | Number | メモリ容量(MB) |
-| dbFlavors.vcpus | Body | Number | CPUコア数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbFlavorName": "dbFlavorName-example",
-            "ram": 1,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbFlavors | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Number | CPUコア数 |
 
 ---
 
 ## ネットワーク
 
 ### サブネットリストを表示
-
-```http
-GET /v4.0/network/subnets
-```
 
 #### 必要権限
 
@@ -245,53 +269,54 @@ GET /v4.0/network/subnets
 
 #### リクエスト
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | サブネットリスト |
-| subnets.subnetId | Body | UUID | サブネットの識別子 |
-| subnets.subnetName | Body | String | サブネットを識別できる名前 |
-| subnets.subnetCidr | Body | String | サブネットのCIDR |
-| subnets.usingGateway | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| subnets | Array | サブネットリスト |
+| subnets.subnetId | UUID | サブネットの識別子 |
+| subnets.subnetName | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | String | サブネットのCIDR |
+| subnets.usingGateway | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Number | 使用可能なIP数 |
 
 ---
 
 ## DBエンジン
 
 ### DBエンジンリストを表示
-
-```http
-GET /v4.0/db-versions
-```
 
 #### 必要権限
 
@@ -301,49 +326,50 @@ GET /v4.0/db-versions
 
 #### リクエスト
 
+```http
+GET /v4.0/db-versions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DBエンジンリスト |
-| dbVersions.dbVersion | Body | String | DBエンジンタイプ |
-| dbVersions.dbVersionName | Body | String | DBエンジン名 |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MYSQL_V8036",
-            "dbVersionName": "dbVersionName-example",
-            "restorableFromObs": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbVersions | Array | DBエンジンリスト |
+| dbVersions.dbVersion | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | String | DBエンジン名 |
+| dbVersions.restorableFromObs | Boolean | オブジェクトストレージから復元可能かどうか |
 
 ---
 
 ## データストレージ
 
 ### データストレージタイプリストを表示
-
-```http
-GET /v4.0/storage-types
-```
 
 #### 必要権限
 
@@ -353,33 +379,38 @@ GET /v4.0/storage-types
 
 #### リクエスト
 
+```http
+GET /v4.0/storage-types
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | データストレージタイプリスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageTypes | Array | データストレージタイプリスト |
 
 ---
 
@@ -387,26 +418,22 @@ GET /v4.0/storage-types
 
 ### 作業状態
 
-| 状態名              | 説明                 |
+| 状態名 | 説明 |
 |--------------------|----------------------|
-| `PREPARING`        | 作業が準備中の場合       |
-| `READY`            | 作業が準備完了している場合    |
-| `RUNNING`          | 作業が進行中の場合       |
-| `COMPLETED`        | 作業が完了している場合      |
-| `REGISTERED`       | 作業が登録されている場合     |
-| `WAIT_TO_REGISTER` | 作業登録待機中の場合     |
-| `INTERRUPTED`      | 作業進行中に割り込みが発生した場合 |
-| `CANCELED`         | 作業がキャンセルされた場合    |
-| `FAILED`           | 作業が失敗した場合         |
-| `ERROR`            | 作業進行中にエラーが発生した場合 |
-| `DELETED`          | 作業が削除された場合         |
-| `FAIL_TO_READY`    | 作業の準備に失敗した場合     |
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了している場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了している場合 |
+| `REGISTERED` | 作業が登録されている場合 |
+| `WAIT_TO_REGISTER` | 作業登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業の準備に失敗した場合 |
 
 ### 作業情報の詳細表示
-
-```http
-GET /v4.0/jobs/{jobId}
-```
 
 #### 必要権限
 
@@ -416,58 +443,62 @@ GET /v4.0/jobs/{jobId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 作業の識別子 |
-| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 関連リソースリスト |
-| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
-| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+| jobStatus | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 関連リソースリスト |
+| resourceRelations.resourceType | String | 関連リソースタイプ |
+| resourceRelations.resourceId | String | 関連リソースの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
+
 ---
+
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
-
-```http
-GET /v4.0/db-instance-groups
-```
 
 #### 必要権限
 
@@ -477,49 +508,50 @@ GET /v4.0/db-instance-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DBインスタンスグループリスト |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstanceGroups.createdYmdt | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスグループの詳細を表示
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 必要権限
 
@@ -529,51 +561,58 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
-| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstances | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -581,54 +620,50 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                  | 説明                           |
+| 状態 | 説明 |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合 |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合 |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合 |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合 |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合 |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合 |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合 |
-| `SHUTDOWN`          | DBインスタンスが停止した場合 |
-| `DELETED`           | DBインスタンスが削除された場合 |
+| `AVAILABLE` | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE` | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL` | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE` | DBインスタンス作成に失敗した場合 |
+| `FAIL_TO_CONNECT` | DBインスタンス接続に失敗した場合 |
+| `REPLICATION_STOP` | DBインスタンスの複製が中断した場合 |
+| `FAILOVER` | DBインスタンスが高可用性フェイルオーバーした場合 |
+| `SHUTDOWN` | DBインスタンスが停止した場合 |
+| `DELETED` | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                         | 説明           |
+| 状態 | 説明 |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
-| `BACKING_UP`               | バックアップ中 |
-| `CANCELING`                | キャンセル中 |
-| `CREATING`                 | 作成中 |
-| `CREATING_SCHEMA`          | DBスキーマ作成中 |
-| `CREATING_USER`            | ユーザー作成中 |
-| `DELETING`                 | 削除中 |
-| `DELETING_SCHEMA`          | DBスキーマ削除中 |
-| `DELETING_USER`            | ユーザー削除中 |
-| `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中 |
-| `MIGRATING`                | マイグレーション中 |
-| `MODIFYING`                | 修正中 |
-| `PREPARING`                | 準備中 |
-| `PROMOTING`                | 昇格中 |
-| `REBUILDING`               | 再構築中 |
-| `REPAIRING`                | 復旧中 |
-| `REPLICATING`              | 複製中 |
-| `RESTARTING`               | 再起動中 |
-| `RESTARTING_FORCIBLY`      | 強制再起動中 |
-| `RESTORING`                | 復元中 |
-| `STARTING`                 | 起動中 |
-| `STOPPING`                 | 停止中 |
-| `SYNCING_SCHEMA`           | DBスキーマ同期中 |
-| `SYNCING_USER`             | ユーザー同期中 |
-| `UPDATING_USER`            | ユーザー修正中 |
+| `BACKING_UP` | バックアップ中 |
+| `CANCELING` | キャンセル中 |
+| `CREATING` | 作成中 |
+| `CREATING_SCHEMA` | DBスキーマ作成中 |
+| `CREATING_USER` | ユーザー作成中 |
+| `DELETING` | 削除中 |
+| `DELETING_SCHEMA` | DBスキーマ削除中 |
+| `DELETING_USER` | ユーザー削除中 |
+| `EXPORTING_BACKUP` | バックアップをエクスポート中 |
+| `FAILING_OVER` | フェイルオーバー中 |
+| `MIGRATING` | マイグレーション中 |
+| `MODIFYING` | 修正中 |
+| `PREPARING` | 準備中 |
+| `PROMOTING` | 昇格中 |
+| `REBUILDING` | 再構築中 |
+| `REPAIRING` | 復旧中 |
+| `REPLICATING` | 複製中 |
+| `RESTARTING` | 再起動中 |
+| `RESTARTING_FORCIBLY` | 強制再起動中 |
+| `RESTORING` | 復元中 |
+| `STARTING` | 起動中 |
+| `STOPPING` | 停止中 |
+| `SYNCING_SCHEMA` | DBスキーマ同期中 |
+| `SYNCING_USER` | ユーザー同期中 |
+| `UPDATING_USER` | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
-
-```http
-GET /v4.0/db-instances
-```
 
 #### 必要権限
 
@@ -638,62 +673,64 @@ GET /v4.0/db-instances
 
 #### リクエスト
 
+```http
+GET /v4.0/db-instances
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| dbInstances.description | Body | String | DBインスタンスの追加情報 |
-| dbInstances.dbVersion | Body | Enum | DBエンジンタイプ |
-| dbInstances.dbPort | Body | Number | DBポート |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| dbInstances.progressStatus | Body | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを作成する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstances | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | String | DBエンジンタイプ |
+| dbInstances.dbPort | Number | DBポート |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | DateTime | 修正日時 |
 
-```http
-POST /v4.0/db-instances
-```
+---
+
+### DBインスタンスを作成する
 
 #### 必要権限
 
@@ -701,143 +738,143 @@ POST /v4.0/db-instances
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
-| dbPort | Body | Number | O | DBポート<br/>- 最小値: 3306、最大値: 43306 |
-| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
-| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | O | データストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | データストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+POST /v4.0/db-instances
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE",
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 1800,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### オブジェクトストレージを利用したDBインスタンスの復元
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
 
 #### 必要権限
 
@@ -845,147 +882,148 @@ POST /v4.0/db-instances/restore-from-obs
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | O | DBポート |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| storage | Body | Object | O | データストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | ストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.tenantId | Body | String | O | バックアップが保存されたオブジェクトストレージのテナントID |
-| restore.username | Body | String | O | NHN Cloud会員またはIAMメンバーID |
-| restore.password | Body | String | O | バックアップが保存されたオブジェクトストレージのAPIパスワード |
-| restore.targetContainer | Body | String | O | バックアップが保存されたオブジェクトストレージのコンテナ |
-| restore.objectPath | Body | String | O | コンテナに保存されたバックアップのパス |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート |
+| dbVersion | String | Y | DBエンジンタイプ |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.tenantId | String | Y | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| restore.password | String | Y | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | String | Y | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | String | Y | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "MYSQL_V8036",
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを削除する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
+---
+
+### DBインスタンスを削除する
 
 #### 必要権限
 
@@ -995,53 +1033,58 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "deleteAutoBackup": false
+"deleteAutoBackup": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの詳細を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1051,86 +1094,89 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| description | Body | String | DBインスタンスの追加情報 |
-| dbVersion | Body | Enum | DBエンジンタイプ |
-| dbPort | Body | Number | DBポート |
-| dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| progressStatus | Body | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
-| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
-| useDeletionProtection | Body | Boolean | DBインスタンス削除保護の有無 |
-| useSlowQueryAnalysis | Body | Boolean | Slow query分析を行うかどうか |
-| supportAuthenticationPlugin | Body | Boolean | 認証プラグインサポートの有無 |
-| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用が必要かどうか |
-| needMigration | Body | Boolean | マイグレーションが必要かどうか |
-| supportDbVersionUpgrade | Body | Boolean | DBのバージョンアップグレードをサポートするかどうか |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": false,
-    "supportAuthenticationPlugin": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": false,
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | String | DBインスタンスを識別できる名前 |
+| description | String | DBインスタンスの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| dbPort | Number | DBポート |
+| dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Boolean | DBインスタンス削除保護の有無 |
+| useSlowQueryAnalysis | Boolean | Slow query分析を行うかどうか |
+| supportAuthenticationPlugin | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Boolean | DBのバージョンアップグレードをサポートするかどうか |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1140,79 +1186,84 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | X | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか |
-| useDummy | Body | Boolean | X | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
-| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>- デフォルト値: `false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>- デフォルト値: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "useSlowQueryAnalysis": false,
-    "useDummy": false,
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useSlowQueryAnalysis": false,
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbVersion | String | N | DBエンジンバージョンコード |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか |
+| useDummy | Boolean | N | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1222,59 +1273,62 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | バックアップ保管期間(日) |
-| ftwrlWaitTimeout | Body | Number | クエリ遅延待機時間(秒) |
-| backupRetryCount | Body | Number | バックアップ再試行回数 |
-| replicationRegion | Body | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules | Body | Array | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時刻 |
-| backupSchedules.backupWndDuration | Body | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1,
-    "backupRetryCount": 1,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backupPeriod | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Number | バックアップ再試行回数 |
+| replicationRegion | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### バックアップ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1284,71 +1338,77 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
-| backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "backupPeriod": 0,
-    "ftwrlWaitTimeout": 0,
-    "backupRetryCount": 0,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ### バイナリログ一覧照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1356,53 +1416,56 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLogファイル一覧 |
-| binLogs.binLogFileName | Body | String | BinLogファイル名 |
-| binLogs.binLogFileSize | Body | Number | BinLogファイルサイズ(Byte) |
-| binLogs.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "binLogs": [
-        {
-            "binLogFileName": "binLogFileName-example",
-            "binLogFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"binLogs": [
+{
+"binLogFileName": "binLogFileName-example",
+"binLogFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| binLogs | Array | BinLogファイル一覧 |
+| binLogs.binLogFileName | String | BinLogファイル名 |
+| binLogs.binLogFileSize | Number | BinLogファイルサイズ(Byte) |
+| binLogs.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### バイナリログ削除
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1410,36 +1473,42 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "lastBinLogFileName": "mysql-bin.000010"
+"lastBinLogFileName": "mysql-bin.000010"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### 証明書ファイル一覧照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1447,55 +1516,58 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| certificates | Body | Array | 証明書ファイル一覧 |
-| certificates.fileName | Body | String | 証明書ファイル名 |
-| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | 証明書ファイルサイズ(Byte) |
-| certificates.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "certificates": [
-        {
-            "fileName": "fileName-example",
-            "certificateType": "CA_FILE",
-            "fileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"certificates": [
+{
+"fileName": "fileName-example",
+"certificateType": "CA_FILE",
+"fileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| certificates | Array | 証明書ファイル一覧 |
+| certificates.fileName | String | 証明書ファイル名 |
+| certificates.certificateType | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | 証明書ファイルサイズ(Byte) |
+| certificates.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### 証明書ファイルエクスポート
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1503,65 +1575,70 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| certificateTypes | Body | Array | O | アップロードする証明書タイプ一覧 |
-| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
-| username | Body | String | O | NHN CloudメンバーまたはIAMメンバーID |
-| password | Body | String | O | 証明書ファイルが保存されるObject StorageのAPIパスワード |
-| targetContainer | Body | String | O | 証明書ファイルが保存されるObject Storageのコンテナ |
-| objectPath | Body | String | O | コンテナに保存される証明書ファイルのパス |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "certificateTypes": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"certificateTypes": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | アップロードする証明書タイプ一覧 |
+| tenantId | String | Y | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | 証明書ファイルが保存されるObject StorageのAPIパスワード |
+| targetContainer | String | Y | 証明書ファイルが保存されるObject Storageのコンテナ |
+| objectPath | String | Y | コンテナに保存される証明書ファイルのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBスキーマリストを表示
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1569,55 +1646,58 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DBスキーマリスト |
-| dbSchemas.dbSchemaId | Body | UUID | DBスキーマの識別子 |
-| dbSchemas.dbSchemaName | Body | String | DBスキーマ名 |
-| dbSchemas.dbSchemaStatus | Body | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSchemaName": "dbSchemaName-example",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSchemas | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### DBスキーマを作成する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1625,55 +1705,60 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSchemaName": "dbSchemaName-example"
+"dbSchemaName": "dbSchemaName-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBスキーマを削除する
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1681,43 +1766,46 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbSchemaId | URL | UUID | O | DBスキーマの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbSchemaId | URL | UUID | Y | DBスキーマの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 必要権限
 
@@ -1727,63 +1815,66 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DBユーザーリスト |
-| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
-| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
-| dbUsers.host | Body | String | DBユーザーアカウントのホスト名 |
-| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
-| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
-| dbUsers.authenticationPlugin | Body | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| dbUsers.tlsOption | Body | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "host": "192.168.0.1",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "authenticationPlugin": "NATIVE",
-            "tlsOption": "NONE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbUsers | Array | DBユーザーリスト |
+| dbUsers.dbUserId | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | String | DBユーザーアカウント名 |
+| dbUsers.host | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| dbUsers.dbUserStatus | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 ---
 
 ### DBユーザーを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 必要権限
 
@@ -1793,63 +1884,68 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
-| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| host | Body | String | O | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
-| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "host": "192.168.0.1",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | String | Y | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Enum | Y | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -1859,43 +1955,46 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | DBユーザーの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -1905,60 +2004,65 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | DBユーザーの識別子 |
-| dbPassword | Body | String | X | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| authorityType | Body | Enum | X | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | DBユーザーの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbPassword": "dbPassword",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Enum | N | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 必要権限
 
@@ -1968,22 +2072,32 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 削除保護の有無 |
 
 #### レスポンス
 
@@ -1993,10 +2107,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DBインスタンスを強制再起動する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2005,24 +2115,29 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ### 高可用性情報の照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2030,114 +2145,122 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| haStatus | Body | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
-| pingInterval | Body | Number | Ping間隔(秒) |
-| pingType | Body | String | Pingタイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": false,
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "pingType": "pingType-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"useHighAvailability": false,
+"haStatus": "CREATED",
+"pingInterval": 1,
+"pingType": "pingType-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| useHighAvailability | Boolean | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| haStatus | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Number | Ping間隔(秒) |
+| pingType | String | Pingタイプ |
 
 ---
 
 ### 高可用性を修正する
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useHighAvailability | Body | Boolean | O | 高可用性を使用するかどうか |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"pingInterval": 1
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 高可用性を使用するかどうか |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長: `1`<br/>- 最大長: `100` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "useHighAvailability": false,
-    "pingInterval": 1
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を一時停止する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2145,44 +2268,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を復旧する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2190,44 +2316,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を再開する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2235,44 +2364,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を分離する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2280,41 +2412,45 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### ログファイルリスト表示
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
+---
+
+### ログファイルリスト表示
 
 #### 必要権限
 
@@ -2324,53 +2460,56 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | ログファイルリスト |
-| logFiles.logFileName | Body | String | ログファイル名 |
-| logFiles.logFileType | Body | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | ログファイルサイズ(Byte) |
-| logFiles.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "logFileName-example",
-            "logFileType": "ERROR",
-            "logFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"logFiles": [
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"logFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| logFiles | Array | ログファイルリスト |
+| logFiles.logFileName | String | ログファイル名 |
+| logFiles.logFileType | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### ログファイルのエクスポート
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
 
 #### 必要権限
 
@@ -2380,63 +2519,68 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | ログファイル名リスト |
-| tenantId | Body | String | O | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | ログファイルが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるログファイルのパス |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "logFileNames": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"logFileNames": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | ログファイル名リスト |
+| tenantId | String | Y | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるログファイルのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ログファイルの内容照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
 
 #### 必要権限
 
@@ -2446,42 +2590,46 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| logFileName | URL | UUID | O | ログファイル名 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| logFileName | URL | UUID | Y | ログファイル名 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| content | Body | String | ログファイルの内容(最大65533 bytes) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "content-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"content": "content-example"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスメンテナンスリストを表示する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| content | String | ログファイルの内容(最大65533 bytes) |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
+---
+
+### DBインスタンスメンテナンスリストを表示する
 
 #### 必要権限
 
@@ -2491,77 +2639,80 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | メンテナンスリストの件数 |
-| maintenances | Body | Array | メンテナンスリスト |
-| maintenances.maintenanceId | Body | UUID | メンテナンスID |
-| maintenances.dbInstanceId | Body | UUID | DBインスタンスID |
-| maintenances.category | Body | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| maintenances.description | Body | String | メンテナンスの説明 |
-| maintenances.type | Body | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| maintenances.payload | Body | Object | メンテナンスタイプに応じたPayload |
-| maintenances.required | Body | Boolean | メンテナンスが必須かどうか |
-| maintenances.deadlineYmdt | Body | DateTime | メンテナンスの強制適用日時 |
-| maintenances.status | Body | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
-| maintenances.addedYmdt | Body | DateTime | メンテナンススケジュール登録日時 |
-| maintenances.executionStartedYmdt | Body | DateTime | メンテナンス開始日時 |
-| maintenances.executionCompletedYmdt | Body | DateTime | メンテナンス終了日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "maintenances": [
-        {
-            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "category": "USER",
-            "description": "description-example",
-            "type": "UPDATE_DB_INSTANCE",
-            "payload": {
-            },
-            "required": false,
-            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
-            "status": "PENDING",
-            "executionType": "SCHEDULED",
-            "addedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"maintenances": [
+{
+"maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": {
+},
+"required": false,
+"deadlineYmdt": "2023-12-31T15:00:00+09:00",
+"status": "PENDING",
+"executionType": "SCHEDULED",
+"addedYmdt": "2023-12-31T15:00:00+09:00",
+"executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+"executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | メンテナンスリストの件数 |
+| maintenances | Array | メンテナンスリスト |
+| maintenances.maintenanceId | UUID | メンテナンスID |
+| maintenances.dbInstanceId | UUID | DBインスタンスID |
+| maintenances.category | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| maintenances.description | String | メンテナンスの説明 |
+| maintenances.type | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| maintenances.payload | Object | メンテナンスタイプに応じたPayload |
+| maintenances.required | Boolean | メンテナンスが必須かどうか |
+| maintenances.deadlineYmdt | DateTime | メンテナンスの強制適用日時 |
+| maintenances.status | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
+| maintenances.addedYmdt | DateTime | メンテナンススケジュール登録日時 |
+| maintenances.executionStartedYmdt | DateTime | メンテナンス開始日時 |
+| maintenances.executionCompletedYmdt | DateTime | メンテナンス終了日時 |
 
 ---
 
 ### DBインスタンスメンテナンスを即時実行する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
 
 #### 必要権限
 
@@ -2571,61 +2722,66 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| configId | Body | String | O | 設定ID |
-| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| description | Body | String | X | メンテナンスの説明 |
-| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| configId | String | Y | 設定ID |
+| category | Enum | Y | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | String | N | メンテナンスの説明 |
+| type | Enum | Y | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | String | Y | メンテナンスタイプに応じたPayload |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスメンテナンスを予約する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
 
 #### 必要権限
 
@@ -2635,30 +2791,40 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| configId | Body | String | O | 設定ID |
-| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| description | Body | String | X | メンテナンスの説明 |
-| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| configId | String | Y | 設定ID |
+| category | Enum | Y | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | String | N | メンテナンスの説明 |
+| type | Enum | Y | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | String | Y | メンテナンスタイプに応じたPayload |
 
 #### レスポンス
 
@@ -2668,10 +2834,6 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 ### DBインスタンスメンテナンスを削除する
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2680,23 +2842,28 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| maintenanceId | URL | UUID | O | メンテナンスID |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| maintenanceId | URL | UUID | Y | メンテナンスID |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
-### ネットワーク情報表示
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
+### ネットワーク情報表示
 
 #### 必要権限
 
@@ -2706,62 +2873,65 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | DBインスタンスを作成するアベイラビリティゾーン |
-| subnet | Body | Object | サブネットオブジェクト |
-| subnet.subnetId | Body | UUID | サブネットの識別子 |
-| subnet.subnetName | Body | String | サブネットを識別できる名前 |
-| subnet.subnetCidr | Body | String | サブネットのCIDR |
-| endPoints | Body | Array | 接続情報リスト |
-| endPoints.domain | Body | String | ドメイン |
-| endPoints.ipAddress | Body | String | IPアドレス |
-| endPoints.endPointType | Body | String | 接続情報タイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24"
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24"
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZone | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Object | サブネットオブジェクト |
+| subnet.subnetId | UUID | サブネットの識別子 |
+| subnet.subnetName | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | String | サブネットのCIDR |
+| endPoints | Array | 接続情報リスト |
+| endPoints.domain | String | ドメイン |
+| endPoints.ipAddress | String | IPアドレス |
+| endPoints.endPointType | String | 接続情報タイプ |
 
 ---
 
 ### ネットワーク情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 必要権限
 
@@ -2771,53 +2941,58 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 外部接続可否 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを昇格する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 必要権限
 
@@ -2827,42 +3002,45 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの再構築
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
 
 #### 必要権限
 
@@ -2872,41 +3050,45 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを複製する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
+---
+
+### DBインスタンスを複製する
 
 #### 必要権限
 
@@ -2914,122 +3096,127 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大の長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 3306、最大値: 43306 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否 |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | X | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | X | データストレージタイプ |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | X | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Boolean | N | 外部接続可否 |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | N | ストレージ情報オブジェクト |
+| storage.storageType | Enum | N | データストレージタイプ |
+| storage.storageSize | Number | N | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | N | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 必要権限
 
@@ -3039,59 +3226,64 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
-| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
-| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useOnlineFailover": false,
-    "executeBackup": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DB インスタンス復元情報照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 必要権限
 
@@ -3101,83 +3293,86 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 最古の復元可能時間 |
-| latestRestorableYmdt | Body | DateTime | 最新の復元可能時間 |
-| restorableBackups | Body | Array | 復元可能なバックアップリスト |
-| restorableBackups.backup | Body | Object | バックアップ情報オブジェクト |
-| restorableBackups.backup.backupId | Body | UUID | バックアップの識別子 |
-| restorableBackups.backup.backupName | Body | String | バックアップ名 |
-| restorableBackups.backup.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| restorableBackups.backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| restorableBackups.backup.dbVersion | Body | Enum | DBエンジンタイプ |
-| restorableBackups.backup.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | バックアップサイズ |
-| restorableBackups.backup.useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
-| restorableBackups.backup.failoverCount | Body | Number | フェイルオーバー回数 |
-| restorableBackups.backup.binLogFileName | Body | String | バイナリログファイル名 |
-| restorableBackups.backup.binLogPosition | Body | Object | バイナリログファイル位置 |
-| restorableBackups.backup.createdYmdt | Body | DateTime | バックアップ作成日時 |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | バックアップ更新日時 |
-| restorableBackups.restorableBinLogs | Body | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "550e8400-e29b-41d4-a716-446655440000",
-                "backupName": "backupName-example",
-                "backupStatus": "BACKING_UP",
-                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-                "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "MYSQL_V8036",
-                "backupType": "AUTO",
-                "backupSize": 1,
-                "useBackupLock": false,
-                "failoverCount": 1,
-                "binLogFileName": "binLogFileName-example",
-                "binLogPosition": {
-                },
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            },
-            "restorableBinLogs": []
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"backupType": "AUTO",
+"backupSize": 1,
+"useBackupLock": false,
+"failoverCount": 1,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+},
+"restorableBinLogs": []
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 最古の復元可能時間 |
+| latestRestorableYmdt | DateTime | 最新の復元可能時間 |
+| restorableBackups | Array | 復元可能なバックアップリスト |
+| restorableBackups.backup | Object | バックアップ情報オブジェクト |
+| restorableBackups.backup.backupId | UUID | バックアップの識別子 |
+| restorableBackups.backup.backupName | String | バックアップ名 |
+| restorableBackups.backup.backupStatus | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| restorableBackups.backup.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.backup.dbInstanceName | String | 原本DBインスタンスの名前 |
+| restorableBackups.backup.dbVersion | String | DBエンジンタイプ |
+| restorableBackups.backup.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | バックアップサイズ |
+| restorableBackups.backup.useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| restorableBackups.backup.failoverCount | Number | フェイルオーバー回数 |
+| restorableBackups.backup.binLogFileName | String | バイナリログファイル名 |
+| restorableBackups.backup.binLogPosition | Object | バイナリログファイル位置 |
+| restorableBackups.backup.createdYmdt | DateTime | バックアップ作成日時 |
+| restorableBackups.backup.updatedYmdt | DateTime | バックアップ更新日時 |
+| restorableBackups.restorableBinLogs | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
 
 ---
 
 ### 復元される最後のクエリ照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
 
 #### 必要権限
 
@@ -3187,43 +3382,47 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | クエリ実行日時 |
-| lastQuery | Body | String | 最後に実行したクエリ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-12-31T15:00:00+09:00",
-    "lastQuery": "lastQuery-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+"lastQuery": "lastQuery-example"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスの復元
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| executedYmdt | DateTime | クエリ実行日時 |
+| lastQuery | String | 最後に実行したクエリ |
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
+---
+
+### DBインスタンスの復元
 
 #### 必要権限
 
@@ -3231,169 +3430,174 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに対する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
-| dbPort | Body | Number | X | DBポート |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| storage | Body | Object | X | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
-| storage.storageType | Body | Enum | X | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| network | Body | Object | X | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
-| network.subnetId | Body | UUID | X | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
-| backup | Body | Object | X | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.restoreType | Body | Enum | O | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
-| restore.binLog.binLogFileName | Body | String | X | 復元に使用するバイナリログ名 |
-| restore.binLog.binLogPosition | Body | Object | X | 復元に使用するバイナリログ位置 |
-| useDefaultNotification | Body | Boolean | X | 基本アラームを使用するかどうか<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+}
+}
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
+| dbPort | Number | N | DBポート |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | N | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
+| storage.storageType | Enum | N | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
+| storage.storageSize | Number | N | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Object | N | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
+| network.subnetId | UUID | N | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
+| backup | Object | N | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.restoreType | Enum | Y | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
+| restore.binLog.binLogFileName | String | N | 復元に使用するバイナリログ名 |
+| restore.binLog.binLogPosition | Object | N | 復元に使用するバイナリログ位置 |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | UUID | N | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
 
 復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
 
 #### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
-| restore.binLog | Body | Object | X | バイナリログ情報オブジェクト |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+| restore.binLog | Object | N | バイナリログ情報オブジェクト |
 
 バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
 
 #### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "TIMESTAMP",
-        "binLog": {
-            "binLogFileName": "binLogFileName-example",
-            "binLogPosition": {
-            }
-        }
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
 
 #### 必要権限
 
@@ -3403,42 +3607,45 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 必要権限
 
@@ -3448,42 +3655,45 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ストレージ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3493,57 +3703,60 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageType | Body | String | データストレージタイプ |
-| storageSize | Body | Number | データストレージサイズ(GB) |
-| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
-| storageAutoscale | Body | Object | データストレージ自動拡張オブジェクト |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか |
-| storageAutoscale.threshold | Body | Number | 自動拡張条件(%) |
-| storageAutoscale.maxStorageSize | Body | Number | 自動拡張最大サイズ(GB) |
-| storageAutoscale.cooldownTime | Body | Number | 自動拡張クールダウン時間(分) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED",
-    "storageAutoscale": {
-        "useStorageAutoscale": false,
-        "threshold": 1,
-        "maxStorageSize": 1,
-        "cooldownTime": 1
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED",
+"storageAutoscale": {
+"useStorageAutoscale": false,
+"threshold": 1,
+"maxStorageSize": 1,
+"cooldownTime": 1
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageType | String | データストレージタイプ |
+| storageSize | Number | データストレージサイズ(GB) |
+| storageStatus | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
+| storageAutoscale | Object | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Boolean | ストレージ自動拡張を行うかどうか |
+| storageAutoscale.threshold | Number | 自動拡張条件(%) |
+| storageAutoscale.maxStorageSize | Number | 自動拡張最大サイズ(GB) |
+| storageAutoscale.cooldownTime | Number | 自動拡張クールダウン時間(分) |
 
 ---
 
 ### ストレージ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3551,79 +3764,85 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | ストレージ情報を修正する |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値: `2048` |
-| storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"storageSize": 1,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+| storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "storageSize": 1,
-    "storageAutoscale": {
-        "useStorageAutoscale": false
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## バックアップ
 
 ### バックアップ状態
 
-| 状態           | 説明           |
+| 状態 | 説明 |
 |--------------|--------------|
-| `BACKING_UP` | バックアップ中の場合     |
-| `COMPLETED`  | バックアップが完了している場合   |
-| `DELETING`   | バックアップが削除中の場合 |
-| `DELETED`    | バックアップが削除されている場合   |
-| `ERROR`      | エラーが発生した場合   |
+| `BACKING_UP` | バックアップ中の場合 |
+| `COMPLETED` | バックアップが完了している場合 |
+| `DELETING` | バックアップが削除中の場合 |
+| `DELETED` | バックアップが削除されている場合 |
+| `ERROR` | エラーが発生した場合 |
 
 ### バックアップリスト照会
-
-```http
-GET /v4.0/backups
-```
 
 #### 必要権限
 
@@ -3633,63 +3852,64 @@ GET /v4.0/backups
 
 #### リクエスト
 
+```http
+GET /v4.0/backups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全バックアップリスト数 |
-| backups | Body | Array | バックアップリスト |
-| backups.backupId | Body | UUID | バックアップの識別子 |
-| backups.backupName | Body | String | バックアップを識別できる名前 |
-| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
-| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backups.dbVersion | Body | Enum | DBエンジンタイプ |
-| backups.utilVersion | Body | String | ユーティリティバージョン |
-| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backups.createdYmdt | Body | DateTime | 作成日時 |
-| backups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "MYSQL_V8036",
-            "utilVersion": "utilVersion-example",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全バックアップリスト数 |
+| backups | Array | バックアップリスト |
+| backups.backupId | UUID | バックアップの識別子 |
+| backups.backupName | String | バックアップを識別できる名前 |
+| backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | String | DBエンジンタイプ |
+| backups.utilVersion | String | ユーティリティバージョン |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | DateTime | 作成日時 |
+| backups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップの作成
-
-```http
-POST /v4.0/backups
-```
 
 #### 必要権限
 
@@ -3699,58 +3919,58 @@ POST /v4.0/backups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| baseBackupId | Body | UUID | X | 原本バックアップの識別子 |
-| dbInstanceId | Body | UUID | X | DBインスタンスの識別子 |
-| backupMethodType | Body | Enum | O | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "backupName": "backupName",
-    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "backupMethodType": "FULL"
+"backupName": "backupName",
+"baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"backupMethodType": "FULL"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupName | String | Y | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| baseBackupId | UUID | N | 原本バックアップの識別子 |
+| dbInstanceId | UUID | N | DBインスタンスの識別子 |
+| backupMethodType | Enum | Y | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップの削除
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
 
 #### 必要権限
 
@@ -3760,42 +3980,45 @@ DELETE /v4.0/backups/{backupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップ詳細照会
-
-```http
-GET /v4.0/backups/{backupId}
-```
 
 #### 必要権限
 
@@ -3805,78 +4028,81 @@ GET /v4.0/backups/{backupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| backup | Body | Object | バックアップ詳細情報 |
-| backup.backupId | Body | UUID | バックアップの識別子 |
-| backup.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
-| backup.backupName | Body | String | バックアップを識別できる名前 |
-| backup.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
-| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| backup.dbVersion | Body | Enum | DBエンジンバージョン |
-| backup.utilVersion | Body | String | ユーティリティバージョン |
-| backup.backupType | Body | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backup.isReplicable | Body | Boolean | レプリケーション可否 |
-| backup.binLogFileName | Body | String | バイナリログファイル名 |
-| backup.binLogPosition | Body | Object | バイナリログ位置 |
-| backup.createdYmdt | Body | DateTime | 作成日時 |
-| backup.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "550e8400-e29b-41d4-a716-446655440000",
-        "regionCode": "KR1",
-        "backupName": "backupName-example",
-        "backupStatus": "BACKING_UP",
-        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "MYSQL_V8036",
-        "utilVersion": "utilVersion-example",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XBSTREAM",
-        "backupSize": 1,
-        "isReplicable": false,
-        "binLogFileName": "binLogFileName-example",
-        "binLogPosition": {
-        },
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"regionCode": "KR1",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupMethodType": "FULL",
+"backupFileType": "XBSTREAM",
+"backupSize": 1,
+"isReplicable": false,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backup | Object | バックアップ詳細情報 |
+| backup.backupId | UUID | バックアップの識別子 |
+| backup.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| backup.backupName | String | バックアップを識別できる名前 |
+| backup.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backup.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backup.dbInstanceName | String | 原本DBインスタンスの名前 |
+| backup.dbVersion | String | DBエンジンバージョン |
+| backup.utilVersion | String | ユーティリティバージョン |
+| backup.backupType | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | バックアップのサイズ(Byte) |
+| backup.isReplicable | Boolean | レプリケーション可否 |
+| backup.binLogFileName | String | バイナリログファイル名 |
+| backup.binLogPosition | Object | バイナリログ位置 |
+| backup.createdYmdt | DateTime | 作成日時 |
+| backup.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップのエクスポート
-
-```http
-POST /v4.0/backups/{backupId}/export
-```
 
 #### 必要権限
 
@@ -3886,61 +4112,66 @@ POST /v4.0/backups/{backupId}/export
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップを復元する
-
-```http
-POST /v4.0/backups/{backupId}/restore
-```
 
 #### 必要権限
 
@@ -3948,144 +4179,150 @@ POST /v4.0/backups/{backupId}/restore
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | バックアップの復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
-| dbPort | Body | Number | X | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| network | Body | Object | X | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| network.subnetId | Body | UUID | X | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
-| storage | Body | Object | X | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageType | Body | Enum | X | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | X | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
-| backup.backupSchedules | Body | Array | X | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbPort | Number | N | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Object | N | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| network.subnetId | UUID | N | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
+| storage | Object | N | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageType | Enum | N | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageSize | Number | N | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | N | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules | Array | N | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## DBセキュリティグループ
 
 ### DBセキュリティグループ進行状態
 
-| 状態              | 説明               |
-|-----------------|------------------|
-| `NONE`          | 進行中の作業がない        |
-| `CREATING_RULE` | ルールポリシーの作成中      |
-| `UPDATING_RULE` | ルールポリシーの修正中      |
-| `DELETING_RULE` | ルールポリシーの削除中      |
+| 状態 | 説明 |
+|-----------------|--------------|
+| `NONE` | 進行中の作業がない |
+| `CREATING_RULE` | ルールポリシーの作成中 |
+| `UPDATING_RULE` | ルールポリシーの修正中 |
+| `DELETING_RULE` | ルールポリシーの削除中 |
 
 ### DBセキュリティグループリストを表示
-
-```http
-GET /v4.0/db-security-groups
-```
 
 #### 必要権限
 
@@ -4095,55 +4332,56 @@ GET /v4.0/db-security-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | DBセキュリティグループリストの総数 |
-| dbSecurityGroups | Body | Array | DBセキュリティグループリスト |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
-| dbSecurityGroups.description | Body | String | DBセキュリティグループの追加情報 |
-| dbSecurityGroups.progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 作成日時 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | DBセキュリティグループリストの総数 |
+| dbSecurityGroups | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを作成する
-
-```http
-POST /v4.0/db-security-groups
-```
 
 #### 必要権限
 
@@ -4153,76 +4391,76 @@ POST /v4.0/db-security-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
-| rules | Body | Array | O | DBセキュリティグループルールリスト |
-| rules.direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| rules.etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| rules.port | Body | Object | O | ポートオブジェクト |
-| rules.port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| rules.port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| rules.port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | DBセキュリティグループルールの追加情報 |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 3306,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Array | Y | DBセキュリティグループルールリスト |
+| rules.direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | Y | ポートオブジェクト |
+| rules.port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | DBセキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
 
 ---
 
 ### DBセキュリティグループを削除する
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 必要権限
 
@@ -4232,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4246,10 +4492,6 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループの詳細を表示
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4258,80 +4500,83 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-| dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
-| description | Body | String | DBセキュリティグループの追加情報 |
-| progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
-| rules | Body | Array | DBセキュリティグループルールリスト |
-| rules.ruleId | Body | UUID | DBセキュリティグループルールの識別子 |
-| rules.description | Body | String | DBセキュリティグループルールの追加情報 |
-| rules.direction | Body | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| rules.etherType | Body | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| rules.port | Body | Object | ポートオブジェクト |
-| rules.port.portType | Body | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| rules.port.minPort | Body | Number | 最小ポート範囲 |
-| rules.port.maxPort | Body | Number | 最大ポート範囲 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 作成日時 |
-| rules.updatedYmdt | Body | DateTime | 修正日時 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
-        {
-            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description-example",
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| description | String | DBセキュリティグループの追加情報 |
+| progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| rules | Array | DBセキュリティグループルールリスト |
+| rules.ruleId | UUID | DBセキュリティグループルールの識別子 |
+| rules.description | String | DBセキュリティグループルールの追加情報 |
+| rules.direction | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | ポートオブジェクト |
+| rules.port.portType | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | 最小ポート範囲 |
+| rules.port.maxPort | Number | 最大ポート範囲 |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | 作成日時 |
+| rules.updatedYmdt | DateTime | 修正日時 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 必要権限
 
@@ -4341,24 +4586,34 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
@@ -4368,10 +4623,6 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループルールを削除する
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4380,43 +4631,46 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールを作成する
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
 
 #### 必要権限
 
@@ -4426,68 +4680,73 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| port | Body | Object | O | ポートオブジェクト |
-| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
 
 #### 必要権限
 
@@ -4497,70 +4756,76 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| port | Body | Object | O | ポートオブジェクト |
-| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## パラメータグループ
 
 ### パラメータグループリストを表示
-
-```http
-GET /v4.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4570,59 +4835,60 @@ GET /v4.0/parameter-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | パラメータグループの総数 |
-| parameterGroups | Body | Array | パラメータグループリスト |
-| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| parameterGroups.description | Body | String | パラメータグループの追加情報 |
-| parameterGroups.dbVersion | Body | Enum | DBエンジンタイプ |
-| parameterGroups.parameterGroupType | Body | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
-| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "parameterGroupType": "USER",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupType": "USER",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | パラメータグループの総数 |
+| parameterGroups | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | String | DBエンジンタイプ |
+| parameterGroups.parameterGroupType | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを作成する
-
-```http
-POST /v4.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4632,56 +4898,56 @@ POST /v4.0/parameter-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
+| dbVersion | String | Y | DBエンジンタイプ |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータグループを削除する
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4691,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4705,10 +4979,6 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループの詳細を表示
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4717,77 +4987,80 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| description | Body | String | パラメータグループの追加情報 |
-| dbVersion | Body | Enum | DBエンジンタイプ |
-| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameters | Body | Array | パラメータリスト |
-| parameters.parameterId | Body | UUID | パラメータの識別子 |
-| parameters.parameterFileGroup | Body | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | パラメータ名 |
-| parameters.fileParameterName | Body | String | パラメータファイル名 |
-| parameters.value | Body | String | 現在設定されている値 |
-| parameters.defaultValue | Body | String | デフォルト値 |
-| parameters.allowedValue | Body | String | 許可された値 |
-| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterFileGroup": "CLIENT",
-            "parameterName": "parameterName-example",
-            "fileParameterName": "fileParameterName-example",
-            "value": "value-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+"parameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+"applyType": "BOTH"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroupName | String | パラメータグループを識別できる名前 |
+| description | String | パラメータグループの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Array | パラメータリスト |
+| parameters.parameterId | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | パラメータ名 |
+| parameters.fileParameterName | String | パラメータファイル名 |
+| parameters.value | String | 現在設定されている値 |
+| parameters.defaultValue | String | デフォルト値 |
+| parameters.allowedValue | String | 許可された値 |
+| parameters.updateType | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4797,24 +5070,34 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
@@ -4824,10 +5107,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループをコピーする
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4836,55 +5115,60 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 必要権限
 
@@ -4894,29 +5178,39 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
-| modifiedParameters.parameterId | Body | UUID | O | パラメータの識別子 |
-| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "value": "value-example"
-        }
-    ]
+"modifiedParameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"value": "value-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 変更するパラメータリスト |
+| modifiedParameters.parameterId | UUID | Y | パラメータの識別子 |
+| modifiedParameters.value | String | Y | 変更するパラメータ値 |
 
 #### レスポンス
 
@@ -4926,10 +5220,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 ### パラメータグループをリセットする
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4938,24 +5228,29 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
-
-```http
-GET /v4.0/user-groups
-```
 
 #### 必要権限
 
@@ -4965,51 +5260,52 @@ GET /v4.0/user-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/user-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | ユーザーグループリストの総数 |
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroups.createdYmdt | Body | DateTime | 作成日時 |
-| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | ユーザーグループリストの総数 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | DateTime | 作成日時 |
+| userGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを作成する
-
-```http
-POST /v4.0/user-groups
-```
 
 #### 必要権限
 
@@ -5019,56 +5315,56 @@ POST /v4.0/user-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
-| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | Y | プロジェクトメンバーの識別子リスト |
+| selectAll | Boolean | N | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
 
 ---
 
 ### ユーザーグループを削除する
-
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -5078,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5092,10 +5396,6 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ### ユーザーグループの詳細を表示
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5104,57 +5404,60 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroupTypeCode | Body | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | プロジェクトメンバーリスト |
-| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"userGroupTypeCode": "ENTIRE",
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+| userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを修正する
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -5164,39 +5467,46 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
-| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | N | プロジェクトメンバーの識別子リスト |
+| selectAll | Boolean | N | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## 通知グループ
 
 ### 通知グループリストを表示
-
-```http
-GET /v4.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5206,55 +5516,56 @@ GET /v4.0/notification-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | 通知グループリスト |
-| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
-| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
-| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
-| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
-| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroups": [
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroups | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを作成する
-
-```http
-POST /v4.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5264,62 +5575,62 @@ POST /v4.0/notification-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
-| dbInstanceIds | Body | Array | O | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Array | Y | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
 
 ---
 
 ### 通知グループを削除する
-
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 必要権限
 
@@ -5329,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5343,10 +5662,6 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ### 通知グループの詳細を表示
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5355,72 +5670,75 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | メール通知の有無 |
-| notifySms | Body | Boolean | SMS通知の有無 |
-| isEnabled | Body | Boolean | 有効かどうか |
-| dbInstances | Body | Array | 監視対象DBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example"
+}
+],
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroupName | String | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | メール通知の有無 |
+| notifySms | Boolean | SMS通知の有無 |
+| isEnabled | Boolean | 有効かどうか |
+| dbInstances | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを修正する
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 必要権限
 
@@ -5430,45 +5748,52 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
-| dbInstanceIds | Body | Array | X | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Array | N | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## モニタリング
 
 ### 統計情報照会
-
-```http
-GET /v4.0/metric-statistics
-```
 
 #### 必要権限
 
@@ -5477,6 +5802,12 @@ GET /v4.0/metric-statistics
 | RDSforMariaDB:Metric.List | 統計情報照会 |
 
 #### リクエスト
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
@@ -5488,10 +5819,6 @@ GET /v4.0/metric-statistics
 
 ### Metricリスト表示
 
-```http
-GET /v4.0/metrics
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5500,37 +5827,42 @@ GET /v4.0/metrics
 
 #### リクエスト
 
+```http
+GET /v4.0/metrics
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metricリスト |
-| metrics.measureName | Body | String | 照会指標タイプ |
-| metrics.unit | Body | String | 測定値単位 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "measureName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"metrics": [
+{
+"measureName": "measureName-example",
+"unit": "unit-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| metrics | Array | Metricリスト |
+| metrics.measureName | String | 照会指標タイプ |
+| metrics.unit | String | 測定値単位 |
 
 ---
 
@@ -5540,20 +5872,16 @@ GET /v4.0/metrics
 
 イベントはカテゴリに分類することができ、下記の通りです。
 
-| イベントカテゴリー    | 説明      |
+| イベントカテゴリー | 説明 |
 |-------------|---------|
-| ALL         | 全体      |
-| BACKUP      | バックアップ      |
+| ALL | 全体 |
+| BACKUP | バックアップ |
 | DB_INSTANCE | DBインスタンス |
-| JOB         | 作業      |
-| TENANT      | テナント     |
-| MONITORING  | モニタリング    |
+| JOB | 作業 |
+| TENANT | テナント |
+| MONITORING | モニタリング |
 
 ### 購読可能なイベントコード一覧表示
-
-```http
-GET /v4.0/event-codes
-```
 
 #### 必要権限
 
@@ -5563,45 +5891,46 @@ GET /v4.0/event-codes
 
 #### リクエスト
 
+```http
+GET /v4.0/event-codes
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | イベントコードリスト |
-| eventCodes.eventCode | Body | Enum | イベントコード |
-| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventCodes": [
+{
+"eventCode": "ENUM_VALUE",
+"eventCategoryType": "ALL"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventCodes | Array | イベントコードリスト |
+| eventCodes.eventCode | Enum | イベントコード |
+| eventCodes.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### イベントリスト照会
-
-```http
-GET /v4.0/events
-```
 
 #### 必要権限
 
@@ -5611,65 +5940,67 @@ GET /v4.0/events
 
 #### リクエスト
 
+```http
+GET /v4.0/events
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全イベントリストの数 |
-| events | Body | Array | イベントリスト |
-| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | 発生したイベントのタイプ |
-| events.sourceId | Body | UUID | イベントソースの識別子 |
-| events.sourceName | Body | String | イベントソースを識別できる名前 |
-| events.messages | Body | Array | イベントメッセージリスト |
-| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | イベントメッセージ |
-| events.eventYmdt | Body | DateTime | イベント発生日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"events": [
+{
+"eventCategoryType": "ALL",
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+"messages": [
+{
+"langCode": "KO",
+"message": "message-example"
+}
+],
+"eventYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベントリストの数 |
+| events | Array | イベントリスト |
+| events.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 発生したイベントのタイプ |
+| events.sourceId | UUID | イベントソースの識別子 |
+| events.sourceName | String | イベントソースを識別できる名前 |
+| events.messages | Array | イベントメッセージリスト |
+| events.messages.langCode | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | イベントメッセージ |
+| events.eventYmdt | DateTime | イベント発生日時 |
+
 ---
+
 ## イベント購読
 
 ### イベント購読一覧照会
 
-```http
-GET /v4.0/event-subscriptions
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5677,74 +6008,75 @@ GET /v4.0/event-subscriptions
 
 #### リクエスト
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全イベント購読一覧数 |
-| eventSubscriptions | Body | Array | イベント購読一覧 |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | イベント購読を識別できる名前 |
-| eventSubscriptions.enabled | Body | Boolean | 有効かどうか |
-| eventSubscriptions.notifyEmail | Body | Boolean | メール送信の有無 |
-| eventSubscriptions.notifySms | Body | Boolean | SMS送信の有無 |
-| eventSubscriptions.eventCodes | Body | Array | 購読するイベントコード一覧 |
-| eventSubscriptions.sources | Body | Array | 購読するイベントソース一覧 |
-| eventSubscriptions.sources.sourceId | Body | UUID | イベントソースの識別子 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | イベント購読中のユーザーグループの識別子一覧 |
-| eventSubscriptions.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "eventSubscriptions": [
-        {
-            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL",
-            "eventSubscriptionName": "eventSubscriptionName-example",
-            "enabled": false,
-            "notifyEmail": false,
-            "notifySms": false,
-            "eventCodes": [],
-            "sources": [
-                {
-                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-                    "eventCategoryType": "ALL"
-                }
-            ],
-            "userGroupIds": [
-                "550e8400-e29b-41d4-a716-446655440000"
-            ],
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"eventSubscriptions": [
+{
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベント購読一覧数 |
+| eventSubscriptions | Array | イベント購読一覧 |
+| eventSubscriptions.eventSubscriptionId | UUID | イベント購読の識別子 |
+| eventSubscriptions.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | イベント購読を識別できる名前 |
+| eventSubscriptions.enabled | Boolean | 有効かどうか |
+| eventSubscriptions.notifyEmail | Boolean | メール送信の有無 |
+| eventSubscriptions.notifySms | Boolean | SMS送信の有無 |
+| eventSubscriptions.eventCodes | Array | 購読するイベントコード一覧 |
+| eventSubscriptions.sources | Array | 購読するイベントソース一覧 |
+| eventSubscriptions.sources.sourceId | UUID | イベントソースの識別子 |
+| eventSubscriptions.sources.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | イベント購読中のユーザーグループの識別子一覧 |
+| eventSubscriptions.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### イベント購読作成
 
-```http
-POST /v4.0/event-subscriptions
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5752,75 +6084,75 @@ POST /v4.0/event-subscriptions
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前 |
-| enabled | Body | Boolean | O | 有効かどうか |
-| notifyEmail | Body | Boolean | O | メール送信の有無 |
-| notifySms | Body | Boolean | O | SMS送信の有無 |
-| eventCodes | Body | Array | O | 購読するイベントコード一覧 |
-| sources | Body | Array | O | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | イベント購読するユーザーグループの識別子一覧 |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | イベント購読を識別できる名前 |
+| enabled | Boolean | Y | 有効かどうか |
+| notifyEmail | Boolean | Y | メール送信の有無 |
+| notifySms | Boolean | Y | SMS送信の有無 |
+| eventCodes | Array | Y | 購読するイベントコード一覧 |
+| sources | Array | Y | 購読するイベントソース一覧 |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | イベント購読するユーザーグループの識別子一覧 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | イベント購読の識別子 |
 
 ---
 
 ### イベント購読削除
 
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5828,25 +6160,29 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### イベント購読修正
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5854,47 +6190,57 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
-| enabled | Body | Boolean | X | 有効かどうか |
-| notifyEmail | Body | Boolean | X | メール送信の有無 |
-| notifySms | Body | Boolean | X | SMS送信の有無 |
-| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
-| sources | Body | Array | X | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | イベント購読を識別できる名前 |
+| enabled | Boolean | N | 有効かどうか |
+| notifyEmail | Boolean | N | メール送信の有無 |
+| notifySms | Boolean | N | SMS送信の有無 |
+| eventCodes | Array | N | 購読するイベントコード一覧 |
+| sources | Array | N | 購読するイベントソース一覧 |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | イベント購読するユーザーグループの識別子一覧 |
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
@@ -5902,11 +6248,7 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### アベイラビリティゾーン一覧照会
 
-```http
-GET /v4.0/availability-zones
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5914,39 +6256,44 @@ GET /v4.0/availability-zones
 
 #### リクエスト
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | アベイラビリティゾーン一覧 |
-| availabilityZones.availabilityZoneName | Body | String | アベイラビリティゾーン名 |
-| availabilityZones.zoneState | Body | Object | アベイラビリティゾーンの状態 |
-| availabilityZones.zoneState.available | Body | Boolean | アベイラビリティゾーンの使用可否 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "availabilityZoneName": "availabilityZoneName-example",
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZones": [
+{
+"availabilityZoneName": "availabilityZoneName-example",
+"zoneState": {
+"available": false
+}
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZones | Array | アベイラビリティゾーン一覧 |
+| availabilityZones.availabilityZoneName | String | アベイラビリティゾーン名 |
+| availabilityZones.zoneState | Object | アベイラビリティゾーンの状態 |
+| availabilityZones.zoneState.available | Boolean | アベイラビリティゾーンの使用可否 |
 
 ---

--- a/ja/api-guide-v4.0.md
+++ b/ja/api-guide-v4.0.md
@@ -1,86 +1,106 @@
-## Database > RDS for MariaDB > APIガイド
+## RDS for MariaDB API ガイド
+
+**Database > RDS for MariaDB > API v4.0 ガイド**
 
 ## RDS for MariaDB API共通情報
 
 ### APIエンドポイント
 
-| リージョン            | エンドポイント           |
-|------------------|-------------------|
+| リージョン | エンドポイント |
+|------|----------|
 | 韓国(パンギョ)リージョン | https://kr1-rds-mariadb.api.nhncloudservice.com |
 
-### 認証及び権限
+
+### 認証および権限
 
 RDS for MariaDBは、API呼び出し時の認証/認可のためにUser Access Keyトークンを使用します。User Access Keyトークンは、User Access Keyに基づいて発行されるBearerタイプの一時的なアクセストークンです。User Access Keyトークンの発行及び使用に関する詳細は、[User Access Keyトークン](/nhncloud/ja/public-api/user-access-key-token)を参照してください。
 発行されたトークンはAppkeyと一緒にリクエストHeaderに含める必要があります。
 
-| 名前                  | 種類     | 形式     | 必須 | 説明                                                        |
-|---------------------|--------|--------|----|-----------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public APIで発行されたBearerタイプトークン                             |
-
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDBサービスのAppkeyまたはプロジェクト統合Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public APIで発行されたBearerタイプトークン |
 
 また、プロジェクトメンバーのロールによって呼び出すことができるAPIが制限されます。 `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`で区分して権限を付与できます。
 
 * `RDS for MariaDB ADMIN`権限は全ての機能を使用可能です。
 * `RDS for MariaDB VIEWER`権限は情報を照会する機能のみ使用可能です。
-    * DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
-    * ただし、通知グループとユーザーグループに関連する機能は使用可能です。
+* DBインスタンスを作成、修正、削除したり、DBインスタンスを対象とするいかなる機能も使用できません。
+* ただし、通知グループとユーザーグループに関連する機能は使用可能です。
 
 APIリクエスト時、認証に失敗したり権限がない場合、次のようなエラーが発生します。
 
-| resultCode | resultMessage | 説明         |
-|------------|---------------|------------|
-| 80401      | Unauthorized  | 認証に失敗しました。 |
-| 80403      | Forbidden     | 権限がありません。  |
+| resultCode | resultMessage | 説明 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 認証に失敗しました。 |
+| 80403 | Forbidden | 権限がありません。 |
 
 ### レスポンス共通情報
 
 すべてのAPIリクエストに「200 OK」でレスポンスします。詳細なレスポンス結果はレスポンス本文のヘッダを参照します。
 
-#### レスポンス本文
+<details>
+  <summary><strong>成功レスポンス</strong></summary>
+
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+}
 }
 ```
 
-#### フィールド
-| 名前            | 形式      | 説明                                     |
-|---------------|---------|----------------------------------------|
-| resultCode    | Number  | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
-| resultMessage | String  | 結果メッセージ                                |
-| isSuccessful  | Boolean | 成否                                     |
+</details>
 
+<details>
+  <summary><strong>失敗レスポンス</strong></summary>
 
+```json
+{
+"header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| resultCode | Number | 結果コード<br/>- 成功: `0`<br/>- 失敗: `0`ではない値 |
+| resultMessage | String | 結果メッセージ |
+| isSuccessful | Boolean | 成否 |
 ### DBエンジンタイプ
 
 | DBエンジンタイプ | 作成可否 | OBSからの復元可否 | 認証プラグインサポート情報 |
-|-----------------|----------|------------------|-----------------|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
-
 ## プロジェクト情報
 
 ### プロジェクトメンバーリストを表示
-
-```http
-GET /v4.0/project/members
-```
 
 #### 必要権限
 
@@ -90,49 +110,50 @@ GET /v4.0/project/members
 
 #### リクエスト
 
+```http
+GET /v4.0/project/members
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| members | Body | Array | プロジェクトメンバーリスト |
-| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| members.memberName | Body | String | プロジェクトメンバーの名前 |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000",
-            "memberName": "memberName-example",
-            "emailAddress": "user@example.com",
-            "phoneNumber": "010-1234-5678"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000",
+"memberName": "memberName-example",
+"emailAddress": "user@example.com",
+"phoneNumber": "010-1234-5678"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | String | プロジェクトメンバーの名前 |
+| members.emailAddress | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | String | プロジェクトメンバーの電話番号 |
 
 ---
 
 ### リージョンリストを表示
-
-```http
-GET /v4.0/project/regions
-```
 
 #### 必要権限
 
@@ -142,46 +163,48 @@ GET /v4.0/project/regions
 
 #### リクエスト
 
+```http
+GET /v4.0/project/regions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| regions | Body | Array | リージョンリスト |
-| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
-| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "regionCode": "KR1",
-            "isEnabled": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"regions": [
+{
+"regionCode": "KR1",
+"isEnabled": false
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| regions | Array | リージョンリスト |
+| regions.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Boolean | リージョンが有効かどうか |
+
 ---
+
 ## DBインスタンスの仕様
 
 ### DBインスタンス仕様リストを表示
-
-```http
-GET /v4.0/db-flavors
-```
 
 #### 必要権限
 
@@ -191,51 +214,52 @@ GET /v4.0/db-flavors
 
 #### リクエスト
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DBインスタンス仕様リスト |
-| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
-| dbFlavors.ram | Body | Number | メモリ容量(MB) |
-| dbFlavors.vcpus | Body | Number | CPUコア数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbFlavorName": "dbFlavorName-example",
-            "ram": 1,
-            "vcpus": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbFlavors": [
+{
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbFlavorName": "dbFlavorName-example",
+"ram": 1,
+"vcpus": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbFlavors | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Number | CPUコア数 |
 
 ---
 
 ## ネットワーク
 
 ### サブネットリストを表示
-
-```http
-GET /v4.0/network/subnets
-```
 
 #### 必要権限
 
@@ -245,53 +269,54 @@ GET /v4.0/network/subnets
 
 #### リクエスト
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | サブネットリスト |
-| subnets.subnetId | Body | UUID | サブネットの識別子 |
-| subnets.subnetName | Body | String | サブネットを識別できる名前 |
-| subnets.subnetCidr | Body | String | サブネットのCIDR |
-| subnets.usingGateway | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-            "subnetName": "subnetName-example",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": false,
-            "availableIpCount": 1
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"subnets": [
+{
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24",
+"usingGateway": false,
+"availableIpCount": 1
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| subnets | Array | サブネットリスト |
+| subnets.subnetId | UUID | サブネットの識別子 |
+| subnets.subnetName | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | String | サブネットのCIDR |
+| subnets.usingGateway | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Number | 使用可能なIP数 |
 
 ---
 
 ## DBエンジン
 
 ### DBエンジンリストを表示
-
-```http
-GET /v4.0/db-versions
-```
 
 #### 必要権限
 
@@ -301,49 +326,50 @@ GET /v4.0/db-versions
 
 #### リクエスト
 
+```http
+GET /v4.0/db-versions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DBエンジンリスト |
-| dbVersions.dbVersion | Body | String | DBエンジンタイプ |
-| dbVersions.dbVersionName | Body | String | DBエンジン名 |
-| dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbVersions": [
-        {
-            "dbVersion": "MYSQL_V8036",
-            "dbVersionName": "dbVersionName-example",
-            "restorableFromObs": false
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbVersions": [
+{
+"dbVersion": "MYSQL_V8036",
+"dbVersionName": "dbVersionName-example",
+"restorableFromObs": false
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbVersions | Array | DBエンジンリスト |
+| dbVersions.dbVersion | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | String | DBエンジン名 |
+| dbVersions.restorableFromObs | Boolean | オブジェクトストレージから復元可能かどうか |
 
 ---
 
 ## データストレージ
 
 ### データストレージタイプリストを表示
-
-```http
-GET /v4.0/storage-types
-```
 
 #### 必要権限
 
@@ -353,33 +379,38 @@ GET /v4.0/storage-types
 
 #### リクエスト
 
+```http
+GET /v4.0/storage-types
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | データストレージタイプリスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageTypes": [
+"General SSD",
+"General HDD"
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageTypes | Array | データストレージタイプリスト |
 
 ---
 
@@ -387,26 +418,22 @@ GET /v4.0/storage-types
 
 ### 作業状態
 
-| 状態名              | 説明                 |
+| 状態名 | 説明 |
 |--------------------|----------------------|
-| `PREPARING`        | 作業が準備中の場合       |
-| `READY`            | 作業が準備完了している場合    |
-| `RUNNING`          | 作業が進行中の場合       |
-| `COMPLETED`        | 作業が完了している場合      |
-| `REGISTERED`       | 作業が登録されている場合     |
-| `WAIT_TO_REGISTER` | 作業登録待機中の場合     |
-| `INTERRUPTED`      | 作業進行中に割り込みが発生した場合 |
-| `CANCELED`         | 作業がキャンセルされた場合    |
-| `FAILED`           | 作業が失敗した場合         |
-| `ERROR`            | 作業進行中にエラーが発生した場合 |
-| `DELETED`          | 作業が削除された場合         |
-| `FAIL_TO_READY`    | 作業の準備に失敗した場合     |
+| `PREPARING` | 作業が準備中の場合 |
+| `READY` | 作業が準備完了している場合 |
+| `RUNNING` | 作業が進行中の場合 |
+| `COMPLETED` | 作業が完了している場合 |
+| `REGISTERED` | 作業が登録されている場合 |
+| `WAIT_TO_REGISTER` | 作業登録待機中の場合 |
+| `INTERRUPTED` | 作業進行中に割り込みが発生した場合 |
+| `CANCELED` | 作業がキャンセルされた場合 |
+| `FAILED` | 作業が失敗した場合 |
+| `ERROR` | 作業進行中にエラーが発生した場合 |
+| `DELETED` | 作業が削除された場合 |
+| `FAIL_TO_READY` | 作業の準備に失敗した場合 |
 
 ### 作業情報の詳細表示
-
-```http
-GET /v4.0/jobs/{jobId}
-```
 
 #### 必要権限
 
@@ -416,58 +443,62 @@ GET /v4.0/jobs/{jobId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 作業の識別子 |
-| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 関連リソースリスト |
-| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
-| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
-        {
-            "resourceType": "resourceType-example",
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000",
+"jobStatus": "DELETED",
+"resourceRelations": [
+{
+"resourceType": "resourceType-example",
+"resourceId": "resourceId-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+| jobStatus | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 関連リソースリスト |
+| resourceRelations.resourceType | String | 関連リソースタイプ |
+| resourceRelations.resourceId | String | 関連リソースの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
+
 ---
+
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
-
-```http
-GET /v4.0/db-instance-groups
-```
 
 #### 必要権限
 
@@ -477,49 +508,50 @@ GET /v4.0/db-instance-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DBインスタンスグループリスト |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroups": [
+{
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstanceGroups.createdYmdt | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスグループの詳細を表示
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 必要権限
 
@@ -529,51 +561,58 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
-| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"replicationType": "STANDALONE",
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| replicationType | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstances | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
@@ -581,54 +620,50 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                  | 説明                           |
+| 状態 | 説明 |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合 |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合 |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合 |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合 |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合 |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合 |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合 |
-| `SHUTDOWN`          | DBインスタンスが停止した場合 |
-| `DELETED`           | DBインスタンスが削除された場合 |
+| `AVAILABLE` | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE` | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL` | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE` | DBインスタンス作成に失敗した場合 |
+| `FAIL_TO_CONNECT` | DBインスタンス接続に失敗した場合 |
+| `REPLICATION_STOP` | DBインスタンスの複製が中断した場合 |
+| `FAILOVER` | DBインスタンスが高可用性フェイルオーバーした場合 |
+| `SHUTDOWN` | DBインスタンスが停止した場合 |
+| `DELETED` | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                         | 説明           |
+| 状態 | 説明 |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
-| `BACKING_UP`               | バックアップ中 |
-| `CANCELING`                | キャンセル中 |
-| `CREATING`                 | 作成中 |
-| `CREATING_SCHEMA`          | DBスキーマ作成中 |
-| `CREATING_USER`            | ユーザー作成中 |
-| `DELETING`                 | 削除中 |
-| `DELETING_SCHEMA`          | DBスキーマ削除中 |
-| `DELETING_USER`            | ユーザー削除中 |
-| `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中 |
-| `MIGRATING`                | マイグレーション中 |
-| `MODIFYING`                | 修正中 |
-| `PREPARING`                | 準備中 |
-| `PROMOTING`                | 昇格中 |
-| `REBUILDING`               | 再構築中 |
-| `REPAIRING`                | 復旧中 |
-| `REPLICATING`              | 複製中 |
-| `RESTARTING`               | 再起動中 |
-| `RESTARTING_FORCIBLY`      | 強制再起動中 |
-| `RESTORING`                | 復元中 |
-| `STARTING`                 | 起動中 |
-| `STOPPING`                 | 停止中 |
-| `SYNCING_SCHEMA`           | DBスキーマ同期中 |
-| `SYNCING_USER`             | ユーザー同期中 |
-| `UPDATING_USER`            | ユーザー修正中 |
+| `BACKING_UP` | バックアップ中 |
+| `CANCELING` | キャンセル中 |
+| `CREATING` | 作成中 |
+| `CREATING_SCHEMA` | DBスキーマ作成中 |
+| `CREATING_USER` | ユーザー作成中 |
+| `DELETING` | 削除中 |
+| `DELETING_SCHEMA` | DBスキーマ削除中 |
+| `DELETING_USER` | ユーザー削除中 |
+| `EXPORTING_BACKUP` | バックアップをエクスポート中 |
+| `FAILING_OVER` | フェイルオーバー中 |
+| `MIGRATING` | マイグレーション中 |
+| `MODIFYING` | 修正中 |
+| `PREPARING` | 準備中 |
+| `PROMOTING` | 昇格中 |
+| `REBUILDING` | 再構築中 |
+| `REPAIRING` | 復旧中 |
+| `REPLICATING` | 複製中 |
+| `RESTARTING` | 再起動中 |
+| `RESTARTING_FORCIBLY` | 強制再起動中 |
+| `RESTORING` | 復元中 |
+| `STARTING` | 起動中 |
+| `STOPPING` | 停止中 |
+| `SYNCING_SCHEMA` | DBスキーマ同期中 |
+| `SYNCING_USER` | ユーザー同期中 |
+| `UPDATING_USER` | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
-
-```http
-GET /v4.0/db-instances
-```
 
 #### 必要権限
 
@@ -638,62 +673,64 @@ GET /v4.0/db-instances
 
 #### リクエスト
 
+```http
+GET /v4.0/db-instances
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| dbInstances.description | Body | String | DBインスタンスの追加情報 |
-| dbInstances.dbVersion | Body | Enum | DBエンジンタイプ |
-| dbInstances.dbPort | Body | Number | DBポート |
-| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| dbInstances.progressStatus | Body | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
-| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "dbPort": 1,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "BEFORE_CREATE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを作成する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstances | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | String | DBエンジンタイプ |
+| dbInstances.dbPort | Number | DBポート |
+| dbInstances.dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | DateTime | 修正日時 |
 
-```http
-POST /v4.0/db-instances
-```
+---
+
+### DBインスタンスを作成する
 
 #### 必要権限
 
@@ -701,143 +738,143 @@ POST /v4.0/db-instances
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
-| dbPort | Body | Number | O | DBポート<br/>- 最小値: 3306、最大値: 43306 |
-| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
-| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | O | データストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | データストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+POST /v4.0/db-instances
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE",
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 1800,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbVersion | String | Y | DBエンジンタイプ |
+| dbPort | Number | Y | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | データストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE",
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 1800,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### オブジェクトストレージを利用したDBインスタンスの復元
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
 
 #### 必要権限
 
@@ -845,147 +882,148 @@ POST /v4.0/db-instances/restore-from-obs
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | O | DBポート |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| storage | Body | Object | O | データストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | O | ストレージタイプ |
-| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.subnetId | Body | UUID | O | サブネットの識別子 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| backup | Body | Object | O | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.tenantId | Body | String | O | バックアップが保存されたオブジェクトストレージのテナントID |
-| restore.username | Body | String | O | NHN Cloud会員またはIAMメンバーID |
-| restore.password | Body | String | O | バックアップが保存されたオブジェクトストレージのAPIパスワード |
-| restore.targetContainer | Body | String | O | バックアップが保存されたオブジェクトストレージのコンテナ |
-| restore.objectPath | Body | String | O | コンテナに保存されたバックアップのパス |
-| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
-| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"dbVersion": "MYSQL_V8036",
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | Y | DBインスタンス仕様の識別子 |
+| dbPort | Number | Y | DBポート |
+| dbVersion | String | Y | DBエンジンタイプ |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | Y | ストレージ情報オブジェクト |
+| storage.storageType | Enum | Y | ストレージタイプ |
+| storage.storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.subnetId | UUID | Y | サブネットの識別子 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Object | Y | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | Y | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | Y | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.tenantId | String | Y | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | String | Y | NHN Cloud会員またはIAMメンバーID |
+| restore.password | String | Y | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | String | Y | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | String | Y | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | UUID | Y | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "dbVersion": "MYSQL_V8036",
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "tenantId": "0123456789abcdef0123456789abcdef",
-        "username": "username-example",
-        "password": "password-example",
-        "targetContainer": "targetContainer-example",
-        "objectPath": "objectPath-example"
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを削除する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
+---
+
+### DBインスタンスを削除する
 
 #### 必要権限
 
@@ -995,53 +1033,58 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "deleteAutoBackup": false
+"deleteAutoBackup": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの詳細を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1051,86 +1094,89 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
-| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| description | Body | String | DBインスタンスの追加情報 |
-| dbVersion | Body | Enum | DBエンジンタイプ |
-| dbPort | Body | Number | DBポート |
-| dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
-| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
-| progressStatus | Body | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
-| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
-| useDeletionProtection | Body | Boolean | DBインスタンス削除保護の有無 |
-| useSlowQueryAnalysis | Body | Boolean | Slow query分析を行うかどうか |
-| supportAuthenticationPlugin | Body | Boolean | 認証プラグインサポートの有無 |
-| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用が必要かどうか |
-| needMigration | Body | Boolean | マイグレーションが必要かどうか |
-| supportDbVersionUpgrade | Body | Boolean | DBのバージョンアップグレードをサポートするかどうか |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceName": "dbInstanceName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "dbPort": 1,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "BEFORE_CREATE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "notificationGroupIds": [
-        "550e8400-e29b-41d4-a716-446655440000"
-    ],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": false,
-    "supportAuthenticationPlugin": false,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": false,
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"dbPort": 1,
+"dbInstanceType": "MASTER",
+"dbInstanceStatus": "BEFORE_CREATE",
+"progressStatus": "NONE",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"notificationGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": false,
+"supportAuthenticationPlugin": false,
+"needToApplyParameterGroup": false,
+"needMigration": false,
+"supportDbVersionUpgrade": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | String | DBインスタンスを識別できる名前 |
+| description | String | DBインスタンスの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| dbPort | Number | DBポート |
+| dbInstanceType | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Boolean | DBインスタンス削除保護の有無 |
+| useSlowQueryAnalysis | Boolean | Slow query分析を行うかどうか |
+| supportAuthenticationPlugin | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Boolean | DBのバージョンアップグレードをサポートするかどうか |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBインスタンスを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 必要権限
 
@@ -1140,79 +1186,84 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | X | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか |
-| useDummy | Body | Boolean | X | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
-| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>- デフォルト値: `false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>- デフォルト値: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "dbInstanceName",
-    "dbInstanceCandidateName": "dbInstanceCandidateName",
-    "description": "description-example",
-    "dbPort": 1,
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "MYSQL_V8036",
-    "useSlowQueryAnalysis": false,
-    "useDummy": false,
-    "dbSecurityGroupIds": [],
-    "executeBackup": false,
-    "useOnlineFailover": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"dbInstanceName": "dbInstanceName",
+"dbInstanceCandidateName": "dbInstanceCandidateName",
+"description": "description-example",
+"dbPort": 1,
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"useSlowQueryAnalysis": false,
+"useDummy": false,
+"dbSecurityGroupIds": [],
+"executeBackup": false,
+"useOnlineFailover": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| dbInstanceCandidateName | String | N | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbVersion | String | N | DBエンジンバージョンコード |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか |
+| useDummy | Boolean | N | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1222,59 +1273,62 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | バックアップ保管期間(日) |
-| ftwrlWaitTimeout | Body | Number | クエリ遅延待機時間(秒) |
-| backupRetryCount | Body | Number | バックアップ再試行回数 |
-| replicationRegion | Body | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules | Body | Array | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時刻 |
-| backupSchedules.backupWndDuration | Body | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1,
-    "backupRetryCount": 1,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backupPeriod": 1,
+"ftwrlWaitTimeout": 1,
+"backupRetryCount": 1,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backupPeriod | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Number | バックアップ再試行回数 |
+| replicationRegion | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### バックアップ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 必要権限
 
@@ -1284,71 +1338,77 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
-| backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "backupPeriod": 0,
-    "ftwrlWaitTimeout": 0,
-    "backupRetryCount": 0,
-    "replicationRegion": "KR1",
-    "useBackupLock": false,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "HALF_AN_HOUR"
-        }
-    ]
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 0,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ### バイナリログ一覧照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1356,53 +1416,56 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLogファイル一覧 |
-| binLogs.binLogFileName | Body | String | BinLogファイル名 |
-| binLogs.binLogFileSize | Body | Number | BinLogファイルサイズ(Byte) |
-| binLogs.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "binLogs": [
-        {
-            "binLogFileName": "binLogFileName-example",
-            "binLogFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"binLogs": [
+{
+"binLogFileName": "binLogFileName-example",
+"binLogFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| binLogs | Array | BinLogファイル一覧 |
+| binLogs.binLogFileName | String | BinLogファイル名 |
+| binLogs.binLogFileSize | Number | BinLogファイルサイズ(Byte) |
+| binLogs.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### バイナリログ削除
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1410,36 +1473,42 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "lastBinLogFileName": "mysql-bin.000010"
+"lastBinLogFileName": "mysql-bin.000010"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### 証明書ファイル一覧照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1447,55 +1516,58 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| certificates | Body | Array | 証明書ファイル一覧 |
-| certificates.fileName | Body | String | 証明書ファイル名 |
-| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | 証明書ファイルサイズ(Byte) |
-| certificates.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "certificates": [
-        {
-            "fileName": "fileName-example",
-            "certificateType": "CA_FILE",
-            "fileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"certificates": [
+{
+"fileName": "fileName-example",
+"certificateType": "CA_FILE",
+"fileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| certificates | Array | 証明書ファイル一覧 |
+| certificates.fileName | String | 証明書ファイル名 |
+| certificates.certificateType | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | 証明書ファイルサイズ(Byte) |
+| certificates.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### 証明書ファイルエクスポート
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1503,65 +1575,70 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| certificateTypes | Body | Array | O | アップロードする証明書タイプ一覧 |
-| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
-| username | Body | String | O | NHN CloudメンバーまたはIAMメンバーID |
-| password | Body | String | O | 証明書ファイルが保存されるObject StorageのAPIパスワード |
-| targetContainer | Body | String | O | 証明書ファイルが保存されるObject Storageのコンテナ |
-| objectPath | Body | String | O | コンテナに保存される証明書ファイルのパス |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "certificateTypes": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"certificateTypes": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | アップロードする証明書タイプ一覧 |
+| tenantId | String | Y | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | 証明書ファイルが保存されるObject StorageのAPIパスワード |
+| targetContainer | String | Y | 証明書ファイルが保存されるObject Storageのコンテナ |
+| objectPath | String | Y | コンテナに保存される証明書ファイルのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBスキーマリストを表示
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1569,55 +1646,58 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DBスキーマリスト |
-| dbSchemas.dbSchemaId | Body | UUID | DBスキーマの識別子 |
-| dbSchemas.dbSchemaName | Body | String | DBスキーマ名 |
-| dbSchemas.dbSchemaStatus | Body | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSchemaName": "dbSchemaName-example",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSchemas": [
+{
+"dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSchemaName": "dbSchemaName-example",
+"dbSchemaStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSchemas | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### DBスキーマを作成する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1625,55 +1705,60 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSchemaName": "dbSchemaName-example"
+"dbSchemaName": "dbSchemaName-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBスキーマを削除する
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -1681,43 +1766,46 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 
 #### リクエスト
 
-このAPIはリクエストボディを要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbSchemaId | URL | UUID | O | DBスキーマの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbSchemaId | URL | UUID | Y | DBスキーマの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 必要権限
 
@@ -1727,63 +1815,66 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DBユーザーリスト |
-| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
-| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
-| dbUsers.host | Body | String | DBユーザーアカウントのホスト名 |
-| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
-| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
-| dbUsers.authenticationPlugin | Body | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| dbUsers.tlsOption | Body | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbUserName": "dbUserName-example",
-            "host": "192.168.0.1",
-            "authorityType": "CUSTOM",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00",
-            "authenticationPlugin": "NATIVE",
-            "tlsOption": "NONE"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbUsers": [
+{
+"dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+"dbUserName": "dbUserName-example",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"dbUserStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbUsers | Array | DBユーザーリスト |
+| dbUsers.dbUserId | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | String | DBユーザーアカウント名 |
+| dbUsers.host | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| dbUsers.dbUserStatus | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 ---
 
 ### DBユーザーを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 必要権限
 
@@ -1793,63 +1884,68 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
-| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| host | Body | String | O | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
-| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbUserName": "dbUserName",
-    "dbPassword": "dbPassword",
-    "host": "192.168.0.1",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbUserName": "dbUserName",
+"dbPassword": "dbPassword",
+"host": "192.168.0.1",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | String | Y | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | String | Y | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Enum | Y | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -1859,43 +1955,46 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | DBユーザーの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBユーザーを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 必要権限
 
@@ -1905,60 +2004,65 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbUserId | URL | UUID | O | DBユーザーの識別子 |
-| dbPassword | Body | String | X | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
-| authorityType | Body | Enum | X | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
-| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
-| tlsOption | Body | Enum | X | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | Y | DBユーザーの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbPassword": "dbPassword",
-    "authorityType": "CUSTOM",
-    "authenticationPlugin": "NATIVE",
-    "tlsOption": "NONE"
+"dbPassword": "dbPassword",
+"authorityType": "CUSTOM",
+"authenticationPlugin": "NATIVE",
+"tlsOption": "NONE"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Enum | N | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Enum | N | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Enum | N | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 必要権限
 
@@ -1968,22 +2072,32 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useDeletionProtection": false
+"useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 削除保護の有無 |
 
 #### レスポンス
 
@@ -1993,10 +2107,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DBインスタンスを強制再起動する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2005,24 +2115,29 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ### 高可用性情報の照会
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2030,114 +2145,122 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | 高可用性の使用有無<br/>- デフォルト値: `false` |
-| haStatus | Body | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
-| pingInterval | Body | Number | Ping間隔(秒) |
-| pingType | Body | String | Pingタイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": false,
-    "haStatus": "CREATED",
-    "pingInterval": 1,
-    "pingType": "pingType-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"useHighAvailability": false,
+"haStatus": "CREATED",
+"pingInterval": 1,
+"pingType": "pingType-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| useHighAvailability | Boolean | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| haStatus | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Number | Ping間隔(秒) |
+| pingType | String | Pingタイプ |
 
 ---
 
 ### 高可用性を修正する
 
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useHighAvailability | Body | Boolean | O | 高可用性を使用するかどうか |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"useHighAvailability": false,
+"pingInterval": 1
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 高可用性を使用するかどうか |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長: `1`<br/>- 最大長: `100` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "useHighAvailability": false,
-    "pingInterval": 1
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を一時停止する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2145,44 +2268,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を復旧する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2190,44 +2316,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を再開する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2235,44 +2364,47 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### 高可用性を分離する
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -2280,41 +2412,45 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### ログファイルリスト表示
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
+---
+
+### ログファイルリスト表示
 
 #### 必要権限
 
@@ -2324,53 +2460,56 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | ログファイルリスト |
-| logFiles.logFileName | Body | String | ログファイル名 |
-| logFiles.logFileType | Body | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | ログファイルサイズ(Byte) |
-| logFiles.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "logFileName-example",
-            "logFileType": "ERROR",
-            "logFileSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"logFiles": [
+{
+"logFileName": "logFileName-example",
+"logFileType": "ERROR",
+"logFileSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| logFiles | Array | ログファイルリスト |
+| logFiles.logFileName | String | ログファイル名 |
+| logFiles.logFileType | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### ログファイルのエクスポート
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
 
 #### 必要権限
 
@@ -2380,63 +2519,68 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | ログファイル名リスト |
-| tenantId | Body | String | O | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | ログファイルが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるログファイルのパス |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "logFileNames": [],
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"logFileNames": [],
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | ログファイル名リスト |
+| tenantId | String | Y | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるログファイルのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ログファイルの内容照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
 
 #### 必要権限
 
@@ -2446,42 +2590,46 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| logFileName | URL | UUID | O | ログファイル名 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| logFileName | URL | UUID | Y | ログファイル名 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| content | Body | String | ログファイルの内容(最大65533 bytes) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "content-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"content": "content-example"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスメンテナンスリストを表示する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| content | String | ログファイルの内容(最大65533 bytes) |
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
+---
+
+### DBインスタンスメンテナンスリストを表示する
 
 #### 必要権限
 
@@ -2491,77 +2639,80 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | メンテナンスリストの件数 |
-| maintenances | Body | Array | メンテナンスリスト |
-| maintenances.maintenanceId | Body | UUID | メンテナンスID |
-| maintenances.dbInstanceId | Body | UUID | DBインスタンスID |
-| maintenances.category | Body | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| maintenances.description | Body | String | メンテナンスの説明 |
-| maintenances.type | Body | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| maintenances.payload | Body | Object | メンテナンスタイプに応じたPayload |
-| maintenances.required | Body | Boolean | メンテナンスが必須かどうか |
-| maintenances.deadlineYmdt | Body | DateTime | メンテナンスの強制適用日時 |
-| maintenances.status | Body | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
-| maintenances.addedYmdt | Body | DateTime | メンテナンススケジュール登録日時 |
-| maintenances.executionStartedYmdt | Body | DateTime | メンテナンス開始日時 |
-| maintenances.executionCompletedYmdt | Body | DateTime | メンテナンス終了日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "maintenances": [
-        {
-            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "category": "USER",
-            "description": "description-example",
-            "type": "UPDATE_DB_INSTANCE",
-            "payload": {
-            },
-            "required": false,
-            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
-            "status": "PENDING",
-            "executionType": "SCHEDULED",
-            "addedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
-            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"maintenances": [
+{
+"maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": {
+},
+"required": false,
+"deadlineYmdt": "2023-12-31T15:00:00+09:00",
+"status": "PENDING",
+"executionType": "SCHEDULED",
+"addedYmdt": "2023-12-31T15:00:00+09:00",
+"executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+"executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | メンテナンスリストの件数 |
+| maintenances | Array | メンテナンスリスト |
+| maintenances.maintenanceId | UUID | メンテナンスID |
+| maintenances.dbInstanceId | UUID | DBインスタンスID |
+| maintenances.category | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| maintenances.description | String | メンテナンスの説明 |
+| maintenances.type | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| maintenances.payload | Object | メンテナンスタイプに応じたPayload |
+| maintenances.required | Boolean | メンテナンスが必須かどうか |
+| maintenances.deadlineYmdt | DateTime | メンテナンスの強制適用日時 |
+| maintenances.status | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
+| maintenances.addedYmdt | DateTime | メンテナンススケジュール登録日時 |
+| maintenances.executionStartedYmdt | DateTime | メンテナンス開始日時 |
+| maintenances.executionCompletedYmdt | DateTime | メンテナンス終了日時 |
 
 ---
 
 ### DBインスタンスメンテナンスを即時実行する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
 
 #### 必要権限
 
@@ -2571,61 +2722,66 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| configId | Body | String | O | 設定ID |
-| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| description | Body | String | X | メンテナンスの説明 |
-| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| configId | String | Y | 設定ID |
+| category | Enum | Y | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | String | N | メンテナンスの説明 |
+| type | Enum | Y | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | String | Y | メンテナンスタイプに応じたPayload |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスメンテナンスを予約する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
 
 #### 必要権限
 
@@ -2635,30 +2791,40 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| configId | Body | String | O | 設定ID |
-| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
-| description | Body | String | X | メンテナンスの説明 |
-| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
-| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "configId": "configId-example",
-    "category": "USER",
-    "description": "description-example",
-    "type": "UPDATE_DB_INSTANCE",
-    "payload": "payload-example"
+"configId": "configId-example",
+"category": "USER",
+"description": "description-example",
+"type": "UPDATE_DB_INSTANCE",
+"payload": "payload-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| configId | String | Y | 設定ID |
+| category | Enum | Y | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | String | N | メンテナンスの説明 |
+| type | Enum | Y | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | String | Y | メンテナンスタイプに応じたPayload |
 
 #### レスポンス
 
@@ -2668,10 +2834,6 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 ### DBインスタンスメンテナンスを削除する
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -2680,23 +2842,28 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| maintenanceId | URL | UUID | O | メンテナンスID |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+| maintenanceId | URL | UUID | Y | メンテナンスID |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
-### ネットワーク情報表示
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
+### ネットワーク情報表示
 
 #### 必要権限
 
@@ -2706,62 +2873,65 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | DBインスタンスを作成するアベイラビリティゾーン |
-| subnet | Body | Object | サブネットオブジェクト |
-| subnet.subnetId | Body | UUID | サブネットの識別子 |
-| subnet.subnetName | Body | String | サブネットを識別できる名前 |
-| subnet.subnetCidr | Body | String | サブネットのCIDR |
-| endPoints | Body | Array | 接続情報リスト |
-| endPoints.domain | Body | String | ドメイン |
-| endPoints.ipAddress | Body | String | IPアドレス |
-| endPoints.endPointType | Body | String | 接続情報タイプ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "subnetName": "subnetName-example",
-        "subnetCidr": "192.168.0.0/24"
-    },
-    "endPoints": [
-        {
-            "domain": "domain-example",
-            "ipAddress": "192.168.0.1",
-            "endPointType": "https://example.com"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZone": "kr-pub-a",
+"subnet": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"subnetName": "subnetName-example",
+"subnetCidr": "192.168.0.0/24"
+},
+"endPoints": [
+{
+"domain": "domain-example",
+"ipAddress": "192.168.0.1",
+"endPointType": "https://example.com"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZone | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Object | サブネットオブジェクト |
+| subnet.subnetId | UUID | サブネットの識別子 |
+| subnet.subnetName | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | String | サブネットのCIDR |
+| endPoints | Array | 接続情報リスト |
+| endPoints.domain | String | ドメイン |
+| endPoints.ipAddress | String | IPアドレス |
+| endPoints.endPointType | String | 接続情報タイプ |
 
 ---
 
 ### ネットワーク情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 必要権限
 
@@ -2771,53 +2941,58 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "usePublicAccess": false
+"usePublicAccess": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 外部接続可否 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを昇格する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 必要権限
 
@@ -2827,42 +3002,45 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスの再構築
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
 
 #### 必要権限
 
@@ -2872,41 +3050,45 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスを複製する
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
+---
+
+### DBインスタンスを複製する
 
 #### 必要権限
 
@@ -2914,122 +3096,127 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大の長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
-| dbPort | Body | Number | X | DBポート<br/>- 最小値: 3306、最大値: 43306 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| network | Body | Object | O | ネットワーク情報オブジェクト |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否 |
-| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
-| storage | Body | Object | X | ストレージ情報オブジェクト |
-| storage.storageType | Body | Enum | X | データストレージタイプ |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | X | バックアップ情報オブジェクト |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子 |
+| dbPort | Number | N | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Object | Y | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Boolean | N | 外部接続可否 |
+| network.availabilityZone | Enum | Y | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Object | N | ストレージ情報オブジェクト |
+| storage.storageType | Enum | N | データストレージタイプ |
+| storage.storageSize | Number | N | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | N | バックアップ情報オブジェクト |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 必要権限
 
@@ -3039,59 +3226,64 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
-| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
-| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "useOnlineFailover": false,
-    "executeBackup": false,
-    "waitReplicationDelay": false,
-    "useReadOnly": false
+"useOnlineFailover": false,
+"executeBackup": false,
+"waitReplicationDelay": false,
+"useReadOnly": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Boolean | N | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Boolean | N | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Boolean | N | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DB インスタンス復元情報照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 必要権限
 
@@ -3101,83 +3293,86 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 最古の復元可能時間 |
-| latestRestorableYmdt | Body | DateTime | 最新の復元可能時間 |
-| restorableBackups | Body | Array | 復元可能なバックアップリスト |
-| restorableBackups.backup | Body | Object | バックアップ情報オブジェクト |
-| restorableBackups.backup.backupId | Body | UUID | バックアップの識別子 |
-| restorableBackups.backup.backupName | Body | String | バックアップ名 |
-| restorableBackups.backup.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| restorableBackups.backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| restorableBackups.backup.dbVersion | Body | Enum | DBエンジンタイプ |
-| restorableBackups.backup.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | バックアップサイズ |
-| restorableBackups.backup.useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
-| restorableBackups.backup.failoverCount | Body | Number | フェイルオーバー回数 |
-| restorableBackups.backup.binLogFileName | Body | String | バイナリログファイル名 |
-| restorableBackups.backup.binLogPosition | Body | Object | バイナリログファイル位置 |
-| restorableBackups.backup.createdYmdt | Body | DateTime | バックアップ作成日時 |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | バックアップ更新日時 |
-| restorableBackups.restorableBinLogs | Body | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
-    "restorableBackups": [
-        {
-            "backup": {
-                "backupId": "550e8400-e29b-41d4-a716-446655440000",
-                "backupName": "backupName-example",
-                "backupStatus": "BACKING_UP",
-                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-                "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "MYSQL_V8036",
-                "backupType": "AUTO",
-                "backupSize": 1,
-                "useBackupLock": false,
-                "failoverCount": 1,
-                "binLogFileName": "binLogFileName-example",
-                "binLogPosition": {
-                },
-                "createdYmdt": "2023-12-31T15:00:00+09:00",
-                "updatedYmdt": "2023-12-31T15:00:00+09:00"
-            },
-            "restorableBinLogs": []
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+"restorableBackups": [
+{
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"backupType": "AUTO",
+"backupSize": 1,
+"useBackupLock": false,
+"failoverCount": 1,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+},
+"restorableBinLogs": []
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 最古の復元可能時間 |
+| latestRestorableYmdt | DateTime | 最新の復元可能時間 |
+| restorableBackups | Array | 復元可能なバックアップリスト |
+| restorableBackups.backup | Object | バックアップ情報オブジェクト |
+| restorableBackups.backup.backupId | UUID | バックアップの識別子 |
+| restorableBackups.backup.backupName | String | バックアップ名 |
+| restorableBackups.backup.backupStatus | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| restorableBackups.backup.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.backup.dbInstanceName | String | 原本DBインスタンスの名前 |
+| restorableBackups.backup.dbVersion | String | DBエンジンタイプ |
+| restorableBackups.backup.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | バックアップサイズ |
+| restorableBackups.backup.useBackupLock | Boolean | テーブルロックを使用するかどうか |
+| restorableBackups.backup.failoverCount | Number | フェイルオーバー回数 |
+| restorableBackups.backup.binLogFileName | String | バイナリログファイル名 |
+| restorableBackups.backup.binLogPosition | Object | バイナリログファイル位置 |
+| restorableBackups.backup.createdYmdt | DateTime | バックアップ作成日時 |
+| restorableBackups.backup.updatedYmdt | DateTime | バックアップ更新日時 |
+| restorableBackups.restorableBinLogs | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
 
 ---
 
 ### 復元される最後のクエリ照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
 
 #### 必要権限
 
@@ -3187,43 +3382,47 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | クエリ実行日時 |
-| lastQuery | Body | String | 最後に実行したクエリ |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "executedYmdt": "2023-12-31T15:00:00+09:00",
-    "lastQuery": "lastQuery-example"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"executedYmdt": "2023-12-31T15:00:00+09:00",
+"lastQuery": "lastQuery-example"
 }
 ```
 
-</p>
 </details>
 
----
-### DBインスタンスの復元
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| executedYmdt | DateTime | クエリ実行日時 |
+| lastQuery | String | 最後に実行したクエリ |
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
+---
+
+### DBインスタンスの復元
 
 #### 必要権限
 
@@ -3231,169 +3430,174 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスに対する追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
-| dbPort | Body | Number | X | DBポート |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| storage | Body | Object | X | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
-| storage.storageType | Body | Enum | X | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| network | Body | Object | X | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
-| network.subnetId | Body | UUID | X | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
-| backup | Body | Object | X | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
-| restore | Body | Object | O | 復元情報オブジェクト |
-| restore.restoreType | Body | Enum | O | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
-| restore.binLog.binLogFileName | Body | String | X | 復元に使用するバイナリログ名 |
-| restore.binLog.binLogPosition | Body | Object | X | 復元に使用するバイナリログ位置 |
-| useDefaultNotification | Body | Boolean | X | 基本アラームを使用するかどうか<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"useHighAvailability": false,
+"pingInterval": 3,
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"backup": {
+"backupPeriod": 0,
+"ftwrlWaitTimeout": 1800,
+"backupRetryCount": 0,
+"replicationRegion": "KR1",
+"useBackupLock": true,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+},
+"restore": {
+"restoreType": "TIMESTAMP",
+"binLog": {
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+}
+}
+},
+"useDefaultNotification": false,
+"useSlowQueryAnalysis": true,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useDeletionProtection": false
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
+| dbPort | Number | N | DBポート |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Object | N | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
+| storage.storageType | Enum | N | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
+| storage.storageSize | Number | N | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Object | N | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
+| network.subnetId | UUID | N | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
+| backup | Object | N | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Array | N | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | N | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Object | Y | 復元情報オブジェクト |
+| restore.restoreType | Enum | Y | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
+| restore.binLog.binLogFileName | String | N | 復元に使用するバイナリログ名 |
+| restore.binLog.binLogPosition | Object | N | 復元に使用するバイナリログ位置 |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | UUID | N | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
 
 復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
 
 #### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
-| restore.binLog | Body | Object | X | バイナリログ情報オブジェクト |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
+| restore.binLog | Object | N | バイナリログ情報オブジェクト |
 
 バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
 
 #### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "ftwrlWaitTimeout": 1800,
-        "backupRetryCount": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": true,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    },
-    "restore": {
-        "restoreType": "TIMESTAMP",
-        "binLog": {
-            "binLogFileName": "binLogFileName-example",
-            "binLogPosition": {
-            }
-        }
-    },
-    "useDefaultNotification": false,
-    "useSlowQueryAnalysis": true,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useDeletionProtection": false
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 復元に使用するバックアップの識別子 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
 
 #### 必要権限
 
@@ -3403,42 +3607,45 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBインスタンスを停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 必要権限
 
@@ -3448,42 +3655,45 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### ストレージ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3493,57 +3703,60 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| storageType | Body | String | データストレージタイプ |
-| storageSize | Body | Number | データストレージサイズ(GB) |
-| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
-| storageAutoscale | Body | Object | データストレージ自動拡張オブジェクト |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか |
-| storageAutoscale.threshold | Body | Number | 自動拡張条件(%) |
-| storageAutoscale.maxStorageSize | Body | Number | 自動拡張最大サイズ(GB) |
-| storageAutoscale.cooldownTime | Body | Number | 自動拡張クールダウン時間(分) |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 1,
-    "storageStatus": "DELETED",
-    "storageAutoscale": {
-        "useStorageAutoscale": false,
-        "threshold": 1,
-        "maxStorageSize": 1,
-        "cooldownTime": 1
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"storageType": "General SSD",
+"storageSize": 1,
+"storageStatus": "DELETED",
+"storageAutoscale": {
+"useStorageAutoscale": false,
+"threshold": 1,
+"maxStorageSize": 1,
+"cooldownTime": 1
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| storageType | String | データストレージタイプ |
+| storageSize | Number | データストレージサイズ(GB) |
+| storageStatus | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
+| storageAutoscale | Object | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Boolean | ストレージ自動拡張を行うかどうか |
+| storageAutoscale.threshold | Number | 自動拡張条件(%) |
+| storageAutoscale.maxStorageSize | Number | 自動拡張最大サイズ(GB) |
+| storageAutoscale.cooldownTime | Number | 自動拡張クールダウン時間(分) |
 
 ---
 
 ### ストレージ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 必要権限
 
@@ -3551,79 +3764,85 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | ストレージ情報を修正する |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値: `2048` |
-| storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか |
+| dbInstanceId | URL | UUID | Y | DBインスタンスの識別子 |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"storageSize": 1,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+| storageAutoscale | Object | N | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "storageSize": 1,
-    "storageAutoscale": {
-        "useStorageAutoscale": false
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## バックアップ
 
 ### バックアップ状態
 
-| 状態           | 説明           |
+| 状態 | 説明 |
 |--------------|--------------|
-| `BACKING_UP` | バックアップ中の場合     |
-| `COMPLETED`  | バックアップが完了している場合   |
-| `DELETING`   | バックアップが削除中の場合 |
-| `DELETED`    | バックアップが削除されている場合   |
-| `ERROR`      | エラーが発生した場合   |
+| `BACKING_UP` | バックアップ中の場合 |
+| `COMPLETED` | バックアップが完了している場合 |
+| `DELETING` | バックアップが削除中の場合 |
+| `DELETED` | バックアップが削除されている場合 |
+| `ERROR` | エラーが発生した場合 |
 
 ### バックアップリスト照会
-
-```http
-GET /v4.0/backups
-```
 
 #### 必要権限
 
@@ -3633,63 +3852,64 @@ GET /v4.0/backups
 
 #### リクエスト
 
+```http
+GET /v4.0/backups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全バックアップリスト数 |
-| backups | Body | Array | バックアップリスト |
-| backups.backupId | Body | UUID | バックアップの識別子 |
-| backups.backupName | Body | String | バックアップを識別できる名前 |
-| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
-| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backups.dbVersion | Body | Enum | DBエンジンタイプ |
-| backups.utilVersion | Body | String | ユーティリティバージョン |
-| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backups.createdYmdt | Body | DateTime | 作成日時 |
-| backups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "backups": [
-        {
-            "backupId": "550e8400-e29b-41d4-a716-446655440000",
-            "backupName": "backupName-example",
-            "backupStatus": "BACKING_UP",
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbVersion": "MYSQL_V8036",
-            "utilVersion": "utilVersion-example",
-            "backupType": "AUTO",
-            "backupSize": 1,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"backups": [
+{
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupSize": 1,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全バックアップリスト数 |
+| backups | Array | バックアップリスト |
+| backups.backupId | UUID | バックアップの識別子 |
+| backups.backupName | String | バックアップを識別できる名前 |
+| backups.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backups.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | String | DBエンジンタイプ |
+| backups.utilVersion | String | ユーティリティバージョン |
+| backups.backupType | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | DateTime | 作成日時 |
+| backups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップの作成
-
-```http
-POST /v4.0/backups
-```
 
 #### 必要権限
 
@@ -3699,58 +3919,58 @@ POST /v4.0/backups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| baseBackupId | Body | UUID | X | 原本バックアップの識別子 |
-| dbInstanceId | Body | UUID | X | DBインスタンスの識別子 |
-| backupMethodType | Body | Enum | O | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "backupName": "backupName",
-    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-    "backupMethodType": "FULL"
+"backupName": "backupName",
+"baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"backupMethodType": "FULL"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| backupName | String | Y | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| baseBackupId | UUID | N | 原本バックアップの識別子 |
+| dbInstanceId | UUID | N | DBインスタンスの識別子 |
+| backupMethodType | Enum | Y | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップの削除
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
 
 #### 必要権限
 
@@ -3760,42 +3980,45 @@ DELETE /v4.0/backups/{backupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップ詳細照会
-
-```http
-GET /v4.0/backups/{backupId}
-```
 
 #### 必要権限
 
@@ -3805,78 +4028,81 @@ GET /v4.0/backups/{backupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| backup | Body | Object | バックアップ詳細情報 |
-| backup.backupId | Body | UUID | バックアップの識別子 |
-| backup.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
-| backup.backupName | Body | String | バックアップを識別できる名前 |
-| backup.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
-| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| backup.dbVersion | Body | Enum | DBエンジンバージョン |
-| backup.utilVersion | Body | String | ユーティリティバージョン |
-| backup.backupType | Body | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backup.isReplicable | Body | Boolean | レプリケーション可否 |
-| backup.binLogFileName | Body | String | バイナリログファイル名 |
-| backup.binLogPosition | Body | Object | バイナリログ位置 |
-| backup.createdYmdt | Body | DateTime | 作成日時 |
-| backup.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "550e8400-e29b-41d4-a716-446655440000",
-        "regionCode": "KR1",
-        "backupName": "backupName-example",
-        "backupStatus": "BACKING_UP",
-        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-        "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "MYSQL_V8036",
-        "utilVersion": "utilVersion-example",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XBSTREAM",
-        "backupSize": 1,
-        "isReplicable": false,
-        "binLogFileName": "binLogFileName-example",
-        "binLogPosition": {
-        },
-        "createdYmdt": "2023-12-31T15:00:00+09:00",
-        "updatedYmdt": "2023-12-31T15:00:00+09:00"
-    }
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"backup": {
+"backupId": "550e8400-e29b-41d4-a716-446655440000",
+"regionCode": "KR1",
+"backupName": "backupName-example",
+"backupStatus": "BACKING_UP",
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example",
+"dbVersion": "MYSQL_V8036",
+"utilVersion": "utilVersion-example",
+"backupType": "AUTO",
+"backupMethodType": "FULL",
+"backupFileType": "XBSTREAM",
+"backupSize": 1,
+"isReplicable": false,
+"binLogFileName": "binLogFileName-example",
+"binLogPosition": {
+},
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| backup | Object | バックアップ詳細情報 |
+| backup.backupId | UUID | バックアップの識別子 |
+| backup.regionCode | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| backup.backupName | String | バックアップを識別できる名前 |
+| backup.backupStatus | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backup.dbInstanceId | UUID | 原本DBインスタンスの識別子 |
+| backup.dbInstanceName | String | 原本DBインスタンスの名前 |
+| backup.dbVersion | String | DBエンジンバージョン |
+| backup.utilVersion | String | ユーティリティバージョン |
+| backup.backupType | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | バックアップのサイズ(Byte) |
+| backup.isReplicable | Boolean | レプリケーション可否 |
+| backup.binLogFileName | String | バイナリログファイル名 |
+| backup.binLogPosition | Object | バイナリログ位置 |
+| backup.createdYmdt | DateTime | 作成日時 |
+| backup.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### バックアップのエクスポート
-
-```http
-POST /v4.0/backups/{backupId}/export
-```
 
 #### 必要権限
 
@@ -3886,61 +4112,66 @@ POST /v4.0/backups/{backupId}/export
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
-| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
-| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
-| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "tenantId": "0123456789abcdef0123456789abcdef",
-    "username": "username-example",
-    "password": "password-example",
-    "targetContainer": "targetContainer-example",
-    "objectPath": "objectPath-example"
+"tenantId": "0123456789abcdef0123456789abcdef",
+"username": "username-example",
+"password": "password-example",
+"targetContainer": "targetContainer-example",
+"objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | String | Y | NHN CloudアカウントまたはIAMメンバーID |
+| password | String | Y | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | String | Y | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | String | Y | コンテナに保存されるバックアップのパス |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### バックアップを復元する
-
-```http
-POST /v4.0/backups/{backupId}/restore
-```
 
 #### 必要権限
 
@@ -3948,144 +4179,150 @@ POST /v4.0/backups/{backupId}/restore
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | バックアップの復元 |
 
-#### 共通リクエスト
+#### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
-| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
-| dbPort | Body | Number | X | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
-| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
-| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
-| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
-| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
-| network | Body | Object | X | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| network.subnetId | Body | UUID | X | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
-| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
-| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
-| storage | Body | Object | X | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageType | Body | Enum | X | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
-| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
-| backup | Body | Object | X | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
-| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
-| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
-| backup.backupSchedules | Body | Array | X | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| backupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
+
+```json
+{
+"dbInstanceName": "dbInstanceName",
+"description": "description-example",
+"dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+"dbPort": 1,
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupIds": [],
+"userGroupIds": [],
+"useHighAvailability": false,
+"pingInterval": 3,
+"useDefaultNotification": false,
+"useDeletionProtection": false,
+"useSlowQueryAnalysis": true,
+"network": {
+"subnetId": "550e8400-e29b-41d4-a716-446655440000",
+"usePublicAccess": false,
+"availabilityZone": "kr-pub-a"
+},
+"storage": {
+"storageType": "General SSD",
+"storageSize": 20,
+"storageAutoscale": {
+"useStorageAutoscale": false
+}
+},
+"backup": {
+"backupPeriod": 0,
+"backupRetryCount": 0,
+"ftwrlWaitTimeout": 0,
+"replicationRegion": "KR1",
+"useBackupLock": false,
+"backupSchedules": [
+{
+"backupWndBgnTime": "00:00:00",
+"backupWndDuration": "HALF_AN_HOUR"
+}
+]
+}
+}
+```
+
+</details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | String | N | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | UUID | N | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbPort | Number | N | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | UUID | N | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbSecurityGroupIds | Array | N | DBセキュリティグループの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
+| useHighAvailability | Boolean | N | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Number | N | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Boolean | N | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Boolean | N | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Object | N | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| network.subnetId | UUID | N | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
+| network.usePublicAccess | Boolean | N | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Enum | N | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
+| storage | Object | N | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageType | Enum | N | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageSize | Number | N | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
+| storage.storageAutoscale | Object | N | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Object | N | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
+| backup.backupPeriod | Number | N | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Number | N | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Number | N | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Enum | N | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Boolean | N | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules | Array | N | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
 
 #### 高可用性使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
 
 #### ストレージ自動拡張使用時
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "dbInstanceName",
-    "description": "description-example",
-    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbPort": 1,
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "userGroupIds": [],
-    "useHighAvailability": false,
-    "pingInterval": 3,
-    "useDefaultNotification": false,
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "network": {
-        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
-        "usePublicAccess": false,
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20,
-        "storageAutoscale": {
-            "useStorageAutoscale": false
-        }
-    },
-    "backup": {
-        "backupPeriod": 0,
-        "backupRetryCount": 0,
-        "ftwrlWaitTimeout": 0,
-        "replicationRegion": "KR1",
-        "useBackupLock": false,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "HALF_AN_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## DBセキュリティグループ
 
 ### DBセキュリティグループ進行状態
 
-| 状態              | 説明               |
-|-----------------|------------------|
-| `NONE`          | 進行中の作業がない        |
-| `CREATING_RULE` | ルールポリシーの作成中      |
-| `UPDATING_RULE` | ルールポリシーの修正中      |
-| `DELETING_RULE` | ルールポリシーの削除中      |
+| 状態 | 説明 |
+|-----------------|--------------|
+| `NONE` | 進行中の作業がない |
+| `CREATING_RULE` | ルールポリシーの作成中 |
+| `UPDATING_RULE` | ルールポリシーの修正中 |
+| `DELETING_RULE` | ルールポリシーの削除中 |
 
 ### DBセキュリティグループリストを表示
-
-```http
-GET /v4.0/db-security-groups
-```
 
 #### 必要権限
 
@@ -4095,55 +4332,56 @@ GET /v4.0/db-security-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | DBセキュリティグループリストの総数 |
-| dbSecurityGroups | Body | Array | DBセキュリティグループリスト |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
-| dbSecurityGroups.description | Body | String | DBセキュリティグループの追加情報 |
-| dbSecurityGroups.progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 作成日時 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbSecurityGroupName": "dbSecurityGroupName-example",
-            "description": "description-example",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"dbSecurityGroups": [
+{
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | DBセキュリティグループリストの総数 |
+| dbSecurityGroups | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを作成する
-
-```http
-POST /v4.0/db-security-groups
-```
 
 #### 必要権限
 
@@ -4153,76 +4391,76 @@ POST /v4.0/db-security-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
-| rules | Body | Array | O | DBセキュリティグループルールリスト |
-| rules.direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| rules.etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| rules.port | Body | Object | O | ポートオブジェクト |
-| rules.port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| rules.port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| rules.port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | DBセキュリティグループルールの追加情報 |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 3306,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "description": "description-example"
-        }
-    ]
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example",
+"rules": [
+{
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Array | Y | DBセキュリティグループルールリスト |
+| rules.direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | Y | ポートオブジェクト |
+| rules.port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | DBセキュリティグループルールの追加情報 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
 
 ---
 
 ### DBセキュリティグループを削除する
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 必要権限
 
@@ -4232,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4246,10 +4492,6 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループの詳細を表示
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4258,80 +4500,83 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-| dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
-| description | Body | String | DBセキュリティグループの追加情報 |
-| progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
-| rules | Body | Array | DBセキュリティグループルールリスト |
-| rules.ruleId | Body | UUID | DBセキュリティグループルールの識別子 |
-| rules.description | Body | String | DBセキュリティグループルールの追加情報 |
-| rules.direction | Body | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| rules.etherType | Body | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| rules.port | Body | Object | ポートオブジェクト |
-| rules.port.portType | Body | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| rules.port.minPort | Body | Number | 最小ポート範囲 |
-| rules.port.maxPort | Body | Number | 最大ポート範囲 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 作成日時 |
-| rules.updatedYmdt | Body | DateTime | 修正日時 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
-        {
-            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
-            "description": "description-example",
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "ALL",
-                "minPort": 1,
-                "maxPort": 1
-            },
-            "cidr": "192.168.0.0/24",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"dbSecurityGroupName": "dbSecurityGroupName-example",
+"description": "description-example",
+"progressStatus": "NONE",
+"rules": [
+{
+"ruleId": "550e8400-e29b-41d4-a716-446655440000",
+"description": "description-example",
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 1,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroupName | String | DBセキュリティグループを識別できる名前 |
+| description | String | DBセキュリティグループの追加情報 |
+| progressStatus | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| rules | Array | DBセキュリティグループルールリスト |
+| rules.ruleId | UUID | DBセキュリティグループルールの識別子 |
+| rules.description | String | DBセキュリティグループルールの追加情報 |
+| rules.direction | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Object | ポートオブジェクト |
+| rules.port.portType | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Number | 最小ポート範囲 |
+| rules.port.maxPort | Number | 最大ポート範囲 |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | 作成日時 |
+| rules.updatedYmdt | DateTime | 修正日時 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### DBセキュリティグループを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 必要権限
 
@@ -4341,24 +4586,34 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
+"dbSecurityGroupName": "dbSecurityGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
@@ -4368,10 +4623,6 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DBセキュリティグループルールを削除する
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4380,43 +4631,46 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールを作成する
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
 
 #### 必要権限
 
@@ -4426,68 +4680,73 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| port | Body | Object | O | ポートオブジェクト |
-| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
 
 ---
 
 ### DBセキュリティグループルールを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
 
 #### 必要権限
 
@@ -4497,70 +4756,76 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
-| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
-| port | Body | Object | O | ポートオブジェクト |
-| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
-| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
-| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "192.168.0.0/24",
-    "description": "description-example"
+"direction": "INGRESS",
+"etherType": "IPV4",
+"port": {
+"portType": "ALL",
+"minPort": 3306,
+"maxPort": 1
+},
+"cidr": "192.168.0.0/24",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Enum | Y | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Object | Y | ポートオブジェクト |
+| port.portType | Enum | Y | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Number | N | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Number | N | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| jobId | UUID | リクエストした作業の識別子 |
+
 ---
+
 ## パラメータグループ
 
 ### パラメータグループリストを表示
-
-```http
-GET /v4.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4570,59 +4835,60 @@ GET /v4.0/parameter-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | パラメータグループの総数 |
-| parameterGroups | Body | Array | パラメータグループリスト |
-| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| parameterGroups.description | Body | String | パラメータグループの追加情報 |
-| parameterGroups.dbVersion | Body | Enum | DBエンジンタイプ |
-| parameterGroups.parameterGroupType | Body | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
-| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterGroupName": "parameterGroupName-example",
-            "description": "description-example",
-            "dbVersion": "MYSQL_V8036",
-            "parameterGroupType": "USER",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"parameterGroups": [
+{
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupType": "USER",
+"parameterGroupStatus": "STABLE",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | パラメータグループの総数 |
+| parameterGroups | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | String | DBエンジンタイプ |
+| parameterGroups.parameterGroupType | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを作成する
-
-```http
-POST /v4.0/parameter-groups
-```
 
 #### 必要権限
 
@@ -4632,56 +4898,56 @@ POST /v4.0/parameter-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
-| dbVersion | Body | Enum | O | DBエンジンタイプ |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
+| dbVersion | String | Y | DBエンジンタイプ |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータグループを削除する
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4691,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -4705,10 +4979,6 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループの詳細を表示
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4717,77 +4987,80 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
-| description | Body | String | パラメータグループの追加情報 |
-| dbVersion | Body | Enum | DBエンジンタイプ |
-| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
-| parameters | Body | Array | パラメータリスト |
-| parameters.parameterId | Body | UUID | パラメータの識別子 |
-| parameters.parameterFileGroup | Body | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | パラメータ名 |
-| parameters.fileParameterName | Body | String | パラメータファイル名 |
-| parameters.value | Body | String | 現在設定されている値 |
-| parameters.defaultValue | Body | String | デフォルト値 |
-| parameters.allowedValue | Body | String | 許可された値 |
-| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "MYSQL_V8036",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "parameterFileGroup": "CLIENT",
-            "parameterName": "parameterName-example",
-            "fileParameterName": "fileParameterName-example",
-            "value": "value-example",
-            "defaultValue": "defaultValue-example",
-            "allowedValue": "allowedValue-example",
-            "updateType": "VARIABLE",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterGroupName": "parameterGroupName-example",
+"description": "description-example",
+"dbVersion": "MYSQL_V8036",
+"parameterGroupStatus": "STABLE",
+"parameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"parameterFileGroup": "CLIENT",
+"parameterName": "parameterName-example",
+"fileParameterName": "fileParameterName-example",
+"value": "value-example",
+"defaultValue": "defaultValue-example",
+"allowedValue": "allowedValue-example",
+"updateType": "VARIABLE",
+"applyType": "BOTH"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
+| parameterGroupName | String | パラメータグループを識別できる名前 |
+| description | String | パラメータグループの追加情報 |
+| dbVersion | String | DBエンジンタイプ |
+| parameterGroupStatus | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Array | パラメータリスト |
+| parameters.parameterId | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | パラメータ名 |
+| parameters.fileParameterName | String | パラメータファイル名 |
+| parameters.value | String | 現在設定されている値 |
+| parameters.defaultValue | String | デフォルト値 |
+| parameters.allowedValue | String | 許可された値 |
+| parameters.updateType | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### パラメータグループを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 必要権限
 
@@ -4797,24 +5070,34 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
@@ -4824,10 +5107,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 ### パラメータグループをコピーする
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4836,55 +5115,60 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
-| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
+"parameterGroupName": "parameterGroupName",
+"description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | String | N | パラメータグループの追加情報<br/>- 最大長: `100` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| parameterGroupId | UUID | パラメータグループの識別子 |
 
 ---
 
 ### パラメータを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 必要権限
 
@@ -4894,29 +5178,39 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
-| modifiedParameters.parameterId | Body | UUID | O | パラメータの識別子 |
-| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "modifiedParameters": [
-        {
-            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
-            "value": "value-example"
-        }
-    ]
+"modifiedParameters": [
+{
+"parameterId": "550e8400-e29b-41d4-a716-446655440000",
+"value": "value-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 変更するパラメータリスト |
+| modifiedParameters.parameterId | UUID | Y | パラメータの識別子 |
+| modifiedParameters.value | String | Y | 変更するパラメータ値 |
 
 #### レスポンス
 
@@ -4926,10 +5220,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 ### パラメータグループをリセットする
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -4938,24 +5228,29 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
-
-```http
-GET /v4.0/user-groups
-```
 
 #### 必要権限
 
@@ -4965,51 +5260,52 @@ GET /v4.0/user-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/user-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | ユーザーグループリストの総数 |
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroups.createdYmdt | Body | DateTime | 作成日時 |
-| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example",
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | ユーザーグループリストの総数 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | DateTime | 作成日時 |
+| userGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを作成する
-
-```http
-POST /v4.0/user-groups
-```
 
 #### 必要権限
 
@@ -5019,56 +5315,56 @@ POST /v4.0/user-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
-| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | Y | プロジェクトメンバーの識別子リスト |
+| selectAll | Boolean | N | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
 
 ---
 
 ### ユーザーグループを削除する
-
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -5078,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5092,10 +5396,6 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ### ユーザーグループの詳細を表示
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5104,57 +5404,60 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| userGroupTypeCode | Body | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | プロジェクトメンバーリスト |
-| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "userGroupName": "userGroupName-example",
-    "userGroupTypeCode": "ENTIRE",
-    "members": [
-        {
-            "memberId": "550e8400-e29b-41d4-a716-446655440000"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example",
+"userGroupTypeCode": "ENTIRE",
+"members": [
+{
+"memberId": "550e8400-e29b-41d4-a716-446655440000"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| userGroupId | UUID | ユーザーグループの識別子 |
+| userGroupName | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | プロジェクトメンバーリスト |
+| members.memberId | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### ユーザーグループを修正する
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
 
 #### 必要権限
 
@@ -5164,39 +5467,46 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
-| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
-| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "userGroupName": "userGroupName-example",
-    "memberIds": [],
-    "selectAll": false
+"userGroupName": "userGroupName-example",
+"memberIds": [],
+"selectAll": false
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | ユーザーグループを識別できる名前 |
+| memberIds | Array | N | プロジェクトメンバーの識別子リスト |
+| selectAll | Boolean | N | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## 通知グループ
 
 ### 通知グループリストを表示
-
-```http
-GET /v4.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5206,55 +5516,56 @@ GET /v4.0/notification-groups
 
 #### リクエスト
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | 通知グループリスト |
-| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
-| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
-| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
-| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
-| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroups": [
-        {
-            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "notificationGroupName": "notificationGroupName-example",
-            "notifyEmail": false,
-            "notifySms": false,
-            "isEnabled": false,
-            "createdYmdt": "2023-12-31T15:00:00+09:00",
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroups": [
+{
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroups | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを作成する
-
-```http
-POST /v4.0/notification-groups
-```
 
 #### 必要権限
 
@@ -5264,62 +5575,62 @@ POST /v4.0/notification-groups
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
-| dbInstanceIds | Body | Array | O | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName",
-    "notifyEmail": true,
-    "notifySms": true,
-    "isEnabled": true,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName",
+"notifyEmail": true,
+"notifySms": true,
+"isEnabled": true,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Array | Y | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | Y | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
 
 ---
 
 ### 通知グループを削除する
-
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 必要権限
 
@@ -5329,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
@@ -5343,10 +5662,6 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ### 通知グループの詳細を表示
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5355,72 +5670,75 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-| notificationGroupName | Body | String | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | メール通知の有無 |
-| notifySms | Body | Boolean | SMS通知の有無 |
-| isEnabled | Body | Boolean | 有効かどうか |
-| dbInstances | Body | Array | 監視対象DBインスタンスリスト |
-| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
-| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
-| userGroups | Body | Array | ユーザーグループリスト |
-| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
-| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
-| createdYmdt | Body | DateTime | 作成日時 |
-| updatedYmdt | Body | DateTime | 修正日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstances": [
-        {
-            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
-            "dbInstanceName": "dbInstanceName-example"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
-            "userGroupName": "userGroupName-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstances": [
+{
+"dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+"dbInstanceName": "dbInstanceName-example"
+}
+],
+"userGroups": [
+{
+"userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+"userGroupName": "userGroupName-example"
+}
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00",
+"updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 通知グループの識別子 |
+| notificationGroupName | String | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | メール通知の有無 |
+| notifySms | Boolean | SMS通知の有無 |
+| isEnabled | Boolean | 有効かどうか |
+| dbInstances | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | String | DBインスタンスを識別できる名前 |
+| userGroups | Array | ユーザーグループリスト |
+| userGroups.userGroupId | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | String | ユーザーグループを識別できる名前 |
+| createdYmdt | DateTime | 作成日時 |
+| updatedYmdt | DateTime | 修正日時 |
 
 ---
 
 ### 通知グループを修正する
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 必要権限
 
@@ -5430,45 +5748,52 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
-| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
-| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
-| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
-| dbInstanceIds | Body | Array | X | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "notificationGroupName": "notificationGroupName-example",
-    "notifyEmail": false,
-    "notifySms": false,
-    "isEnabled": false,
-    "dbInstanceIds": [],
-    "userGroupIds": []
+"notificationGroupName": "notificationGroupName-example",
+"notifyEmail": false,
+"notifySms": false,
+"isEnabled": false,
+"dbInstanceIds": [],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 通知グループを識別できる名前 |
+| notifyEmail | Boolean | N | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Boolean | N | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Boolean | N | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Array | N | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Array | N | ユーザーグループの識別子リスト |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
 
 ---
+
 ## モニタリング
 
 ### 統計情報照会
-
-```http
-GET /v4.0/metric-statistics
-```
 
 #### 必要権限
 
@@ -5477,6 +5802,12 @@ GET /v4.0/metric-statistics
 | RDSforMariaDB:Metric.List | 統計情報照会 |
 
 #### リクエスト
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### リクエスト本文
 
 このAPIはリクエスト本文を要求しません。
 
@@ -5488,10 +5819,6 @@ GET /v4.0/metric-statistics
 
 ### Metricリスト表示
 
-```http
-GET /v4.0/metrics
-```
-
 #### 必要権限
 
 | 権限名 | 説明 |
@@ -5500,37 +5827,42 @@ GET /v4.0/metrics
 
 #### リクエスト
 
+```http
+GET /v4.0/metrics
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metricリスト |
-| metrics.measureName | Body | String | 照会指標タイプ |
-| metrics.unit | Body | String | 測定値単位 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "measureName": "measureName-example",
-            "unit": "unit-example"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"metrics": [
+{
+"measureName": "measureName-example",
+"unit": "unit-example"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| metrics | Array | Metricリスト |
+| metrics.measureName | String | 照会指標タイプ |
+| metrics.unit | String | 測定値単位 |
 
 ---
 
@@ -5540,20 +5872,16 @@ GET /v4.0/metrics
 
 イベントはカテゴリに分類することができ、下記の通りです。
 
-| イベントカテゴリー    | 説明      |
+| イベントカテゴリー | 説明 |
 |-------------|---------|
-| ALL         | 全体      |
-| BACKUP      | バックアップ      |
+| ALL | 全体 |
+| BACKUP | バックアップ |
 | DB_INSTANCE | DBインスタンス |
-| JOB         | 作業      |
-| TENANT      | テナント     |
-| MONITORING  | モニタリング    |
+| JOB | 作業 |
+| TENANT | テナント |
+| MONITORING | モニタリング |
 
 ### 購読可能なイベントコード一覧表示
-
-```http
-GET /v4.0/event-codes
-```
 
 #### 必要権限
 
@@ -5563,45 +5891,46 @@ GET /v4.0/event-codes
 
 #### リクエスト
 
+```http
+GET /v4.0/event-codes
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | イベントコードリスト |
-| eventCodes.eventCode | Body | Enum | イベントコード |
-| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventCodes": [
-        {
-            "eventCode": "ENUM_VALUE",
-            "eventCategoryType": "ALL"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventCodes": [
+{
+"eventCode": "ENUM_VALUE",
+"eventCategoryType": "ALL"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventCodes | Array | イベントコードリスト |
+| eventCodes.eventCode | Enum | イベントコード |
+| eventCodes.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### イベントリスト照会
-
-```http
-GET /v4.0/events
-```
 
 #### 必要権限
 
@@ -5611,65 +5940,67 @@ GET /v4.0/events
 
 #### リクエスト
 
+```http
+GET /v4.0/events
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全イベントリストの数 |
-| events | Body | Array | イベントリスト |
-| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | 発生したイベントのタイプ |
-| events.sourceId | Body | UUID | イベントソースの識別子 |
-| events.sourceName | Body | String | イベントソースを識別できる名前 |
-| events.messages | Body | Array | イベントメッセージリスト |
-| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | イベントメッセージ |
-| events.eventYmdt | Body | DateTime | イベント発生日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "events": [
-        {
-            "eventCategoryType": "ALL",
-            "eventCode": "ENUM_VALUE",
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "sourceName": "sourceName-example",
-            "messages": [
-                {
-                    "langCode": "KO",
-                    "message": "message-example"
-                }
-            ],
-            "eventYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"events": [
+{
+"eventCategoryType": "ALL",
+"eventCode": "ENUM_VALUE",
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"sourceName": "sourceName-example",
+"messages": [
+{
+"langCode": "KO",
+"message": "message-example"
+}
+],
+"eventYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
 
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベントリストの数 |
+| events | Array | イベントリスト |
+| events.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 発生したイベントのタイプ |
+| events.sourceId | UUID | イベントソースの識別子 |
+| events.sourceName | String | イベントソースを識別できる名前 |
+| events.messages | Array | イベントメッセージリスト |
+| events.messages.langCode | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | イベントメッセージ |
+| events.eventYmdt | DateTime | イベント発生日時 |
+
 ---
+
 ## イベント購読
 
 ### イベント購読一覧照会
 
-```http
-GET /v4.0/event-subscriptions
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5677,74 +6008,75 @@ GET /v4.0/event-subscriptions
 
 #### リクエスト
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 全イベント購読一覧数 |
-| eventSubscriptions | Body | Array | イベント購読一覧 |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | イベント購読を識別できる名前 |
-| eventSubscriptions.enabled | Body | Boolean | 有効かどうか |
-| eventSubscriptions.notifyEmail | Body | Boolean | メール送信の有無 |
-| eventSubscriptions.notifySms | Body | Boolean | SMS送信の有無 |
-| eventSubscriptions.eventCodes | Body | Array | 購読するイベントコード一覧 |
-| eventSubscriptions.sources | Body | Array | 購読するイベントソース一覧 |
-| eventSubscriptions.sources.sourceId | Body | UUID | イベントソースの識別子 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | イベント購読中のユーザーグループの識別子一覧 |
-| eventSubscriptions.createdYmdt | Body | DateTime | 作成日時 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "eventSubscriptions": [
-        {
-            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL",
-            "eventSubscriptionName": "eventSubscriptionName-example",
-            "enabled": false,
-            "notifyEmail": false,
-            "notifySms": false,
-            "eventCodes": [],
-            "sources": [
-                {
-                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-                    "eventCategoryType": "ALL"
-                }
-            ],
-            "userGroupIds": [
-                "550e8400-e29b-41d4-a716-446655440000"
-            ],
-            "createdYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"totalCounts": 1,
+"eventSubscriptions": [
+{
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": [
+"550e8400-e29b-41d4-a716-446655440000"
+],
+"createdYmdt": "2023-12-31T15:00:00+09:00"
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| totalCounts | Number | 全イベント購読一覧数 |
+| eventSubscriptions | Array | イベント購読一覧 |
+| eventSubscriptions.eventSubscriptionId | UUID | イベント購読の識別子 |
+| eventSubscriptions.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | イベント購読を識別できる名前 |
+| eventSubscriptions.enabled | Boolean | 有効かどうか |
+| eventSubscriptions.notifyEmail | Boolean | メール送信の有無 |
+| eventSubscriptions.notifySms | Boolean | SMS送信の有無 |
+| eventSubscriptions.eventCodes | Array | 購読するイベントコード一覧 |
+| eventSubscriptions.sources | Array | 購読するイベントソース一覧 |
+| eventSubscriptions.sources.sourceId | UUID | イベントソースの識別子 |
+| eventSubscriptions.sources.eventCategoryType | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | イベント購読中のユーザーグループの識別子一覧 |
+| eventSubscriptions.createdYmdt | DateTime | 作成日時 |
 
 ---
 
 ### イベント購読作成
 
-```http
-POST /v4.0/event-subscriptions
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5752,75 +6084,75 @@ POST /v4.0/event-subscriptions
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前 |
-| enabled | Body | Boolean | O | 有効かどうか |
-| notifyEmail | Body | Boolean | O | メール送信の有無 |
-| notifySms | Body | Boolean | O | SMS送信の有無 |
-| eventCodes | Body | Array | O | 購読するイベントコード一覧 |
-| sources | Body | Array | O | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | イベント購読するユーザーグループの識別子一覧 |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | イベント購読を識別できる名前 |
+| enabled | Boolean | Y | 有効かどうか |
+| notifyEmail | Boolean | Y | メール送信の有無 |
+| notifySms | Boolean | Y | SMS送信の有無 |
+| eventCodes | Array | Y | 購読するイベントコード一覧 |
+| sources | Array | Y | 購読するイベントソース一覧 |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | イベント購読するユーザーグループの識別子一覧 |
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | イベント購読の識別子 |
 
 ---
 
 ### イベント購読削除
 
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5828,25 +6160,29 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
 ### イベント購読修正
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5854,47 +6190,57 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
-| enabled | Body | Boolean | X | 有効かどうか |
-| notifyEmail | Body | Boolean | X | メール送信の有無 |
-| notifySms | Body | Boolean | X | SMS送信の有無 |
-| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
-| sources | Body | Array | X | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>例</summary>
-<p>
+#### リクエストパラメータ
+
+| 名前 | 区分 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### リクエスト本文
+
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "eventCategoryType": "ALL",
-    "eventSubscriptionName": "eventSubscriptionName-example",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": false,
-    "eventCodes": [],
-    "sources": [
-        {
-            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
-            "eventCategoryType": "ALL"
-        }
-    ],
-    "userGroupIds": []
+"eventCategoryType": "ALL",
+"eventSubscriptionName": "eventSubscriptionName-example",
+"enabled": false,
+"notifyEmail": false,
+"notifySms": false,
+"eventCodes": [],
+"sources": [
+{
+"sourceId": "550e8400-e29b-41d4-a716-446655440000",
+"eventCategoryType": "ALL"
+}
+],
+"userGroupIds": []
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 必須 | 説明 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | イベント購読を識別できる名前 |
+| enabled | Boolean | N | 有効かどうか |
+| notifyEmail | Boolean | N | メール送信の有無 |
+| notifySms | Boolean | N | SMS送信の有無 |
+| eventCodes | Array | N | 購読するイベントコード一覧 |
+| sources | Array | N | 購読するイベントソース一覧 |
+| sources.sourceId | UUID | Y | イベントソースの識別子 |
+| sources.eventCategoryType | Enum | Y | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | イベント購読するユーザーグループの識別子一覧 |
 
 #### レスポンス
 
-このAPIはレスポンスボディを返しません。
+このAPIはレスポンス本文を返しません。
 
 ---
 
@@ -5902,11 +6248,7 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### アベイラビリティゾーン一覧照会
 
-```http
-GET /v4.0/availability-zones
-```
-
-#### 必要な権限
+#### 必要権限
 
 | 権限名 | 説明 |
 |-----|-----|
@@ -5914,39 +6256,44 @@ GET /v4.0/availability-zones
 
 #### リクエスト
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### リクエスト本文
+
 このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
-| 名前 | 種類 | 形式 | 説明 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | アベイラビリティゾーン一覧 |
-| availabilityZones.availabilityZoneName | Body | String | アベイラビリティゾーン名 |
-| availabilityZones.zoneState | Body | Object | アベイラビリティゾーンの状態 |
-| availabilityZones.zoneState.available | Body | Boolean | アベイラビリティゾーンの使用可否 |
-
-<details><summary>例</summary>
-<p>
+<details>
+  <summary><strong>例コード</strong></summary>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "availabilityZoneName": "availabilityZoneName-example",
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
+"header": {
+"resultCode": 0,
+"resultMessage": "SUCCESS",
+"isSuccessful": true
+},
+"availabilityZones": [
+{
+"availabilityZoneName": "availabilityZoneName-example",
+"zoneState": {
+"available": false
+}
+}
+]
 }
 ```
 
-</p>
 </details>
+
+| 名前 | タイプ | 説明 |
+|-----|-----|-----|
+| availabilityZones | Array | アベイラビリティゾーン一覧 |
+| availabilityZones.availabilityZoneName | String | アベイラビリティゾーン名 |
+| availabilityZones.zoneState | Object | アベイラビリティゾーンの状態 |
+| availabilityZones.zoneState.available | Boolean | アベイラビリティゾーンの使用可否 |
 
 ---

--- a/ja/api-guide-v4.0.md
+++ b/ja/api-guide-v4.0.md
@@ -73,7 +73,60 @@ APIリクエスト時、認証に失敗したり権限がない場合、次の�
 * ENUMタイプのdbVersionフィールドに対して該当値を使用できます。
 * バージョンによって作成または復元が不可能な場合があります。
 
+
 ## プロジェクト情報
+
+### プロジェクトメンバーリストを表示
+
+```http
+GET /v4.0/project/members
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | プロジェクトメンバーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| members.memberName | Body | String | プロジェクトメンバーの名前 |
+| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
+| members.phoneNumber | Body | String | プロジェクトメンバーの電話番号 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
 
 ### リージョンリストを表示
 
@@ -83,9 +136,9 @@ GET /v4.0/project/regions
 
 #### 必要権限
 
-| 権限名                                     | 説明         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | プロジェクト情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | リージョンリストを表示 |
 
 #### リクエスト
 
@@ -93,11 +146,11 @@ GET /v4.0/project/regions
 
 #### レスポンス
 
-| 名前               | 種類 | 形式    | 説明                                                                       |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | リージョンリスト                                                                    |
-| regions.regionCode | Body | Enum    | リージョンコード<br/>- `KR1`:韓国(パンギョ)リージョン |
-| regions.isEnabled  | Body | Boolean | リージョンが有効かどうか                                                                          |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| regions | Body | Array | リージョンリスト |
+| regions.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| regions.isEnabled | Body | Boolean | リージョンが有効かどうか |
 
 <details><summary>例</summary>
 <p>
@@ -112,58 +165,7 @@ GET /v4.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### プロジェクトメンバーリストを表示
-
-```http
-GET /v4.0/project/members
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明       |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | プロジェクト情報照会 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-#### レスポンス
-
-| 名前                 | 種類 | 形式   | 説明            |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | プロジェクトメンバーリスト    |
-| members.memberId     | Body | UUID   | プロジェクトメンバーの識別子  |
-| members.memberName   | Body | String | プロジェクトメンバーの名前   |
-| members.emailAddress | Body | String | プロジェクトメンバーのメールアドレス |
-| members.phoneNumber  | Body | String | プロジェクトメンバーの電話番号 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "ホン・ギルドン",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "isEnabled": false
         }
     ]
 }
@@ -173,7 +175,6 @@ GET /v4.0/project/members
 </details>
 
 ---
-
 ## DBインスタンスの仕様
 
 ### DBインスタンス仕様リストを表示
@@ -184,8 +185,8 @@ GET /v4.0/db-flavors
 
 #### 必要権限
 
-| 権限名                                     | 説明             |
-|-------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbFlavor.List | DBインスタンス仕様リスト表示 |
 
 #### リクエスト
@@ -194,13 +195,13 @@ GET /v4.0/db-flavors
 
 #### レスポンス
 
-| 名前                   | 種類 | 形式   | 説明            |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DBインスタンス仕様リスト |
-| dbFlavors.dbFlavorId   | Body | UUID   | DBインスタンス仕様の識別子 |
-| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名   |
-| dbFlavors.ram          | Body | Number | メモリ容量(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPUコア数      |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DBインスタンス仕様リスト |
+| dbFlavors.dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| dbFlavors.dbFlavorName | Body | String | DBインスタンス仕様名 |
+| dbFlavors.ram | Body | Number | メモリ容量(MB) |
+| dbFlavors.vcpus | Body | Number | CPUコア数 |
 
 <details><summary>例</summary>
 <p>
@@ -214,9 +215,9 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -238,8 +239,8 @@ GET /v4.0/network/subnets
 
 #### 必要権限
 
-| 権限名                                    | 説明      |
-|------------------------------------------|-----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Network.List | サブネットリスト表示 |
 
 #### リクエスト
@@ -248,14 +249,14 @@ GET /v4.0/network/subnets
 
 #### レスポンス
 
-| 名前                     | 種類 | 形式    | 説明             |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | サブネットリスト         |
-| subnets.subnetId         | Body | UUID    | サブネットの識別子       |
-| subnets.subnetName       | Body | String  | サブネットを識別できる名前  |
-| subnets.subnetCidr       | Body | String  | サブネットのCIDR        |
-| subnets.usingGateway     | Body | Boolean | ゲートウェイを使用するかどうか |
-| subnets.availableIpCount | Body | Number  | 使用可能なIP数       |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | サブネットリスト |
+| subnets.subnetId | Body | UUID | サブネットの識別子 |
+| subnets.subnetName | Body | String | サブネットを識別できる名前 |
+| subnets.subnetCidr | Body | String | サブネットのCIDR |
+| subnets.usingGateway | Body | Boolean | ゲートウェイを使用するかどうか |
+| subnets.availableIpCount | Body | Number | 使用可能なIP数 |
 
 <details><summary>例</summary>
 <p>
@@ -269,11 +270,11 @@ GET /v4.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
@@ -294,8 +295,8 @@ GET /v4.0/db-versions
 
 #### 必要権限
 
-| 権限名                                      | 説明        |
-|--------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbVersion.List | DBエンジンリスト表示 |
 
 #### リクエスト
@@ -304,11 +305,11 @@ GET /v4.0/db-versions
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式    | 説明                  |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DBエンジンリスト            |
-| dbVersions.dbVersion         | Body | String  | DBエンジンタイプ            |
-| dbVersions.dbVersionName     | Body | String  | DBエンジン名            |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DBエンジンリスト |
+| dbVersions.dbVersion | Body | String | DBエンジンタイプ |
+| dbVersions.dbVersionName | Body | String | DBエンジン名 |
 | dbVersions.restorableFromObs | Body | Boolean | オブジェクトストレージから復元可能かどうか |
 
 <details><summary>例</summary>
@@ -323,9 +324,9 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
@@ -346,8 +347,8 @@ GET /v4.0/storage-types
 
 #### 必要権限
 
-| 権限名                                    | 説明              |
-|------------------------------------------|-------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Storage.List | データストレージタイプリスト表示 |
 
 #### リクエスト
@@ -356,8 +357,8 @@ GET /v4.0/storage-types
 
 #### レスポンス
 
-| 名前         | 種類 | 形式  | 説明           |
-|--------------|------|-------|----------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | storageTypes | Body | Array | データストレージタイプリスト |
 
 <details><summary>例</summary>
@@ -409,29 +410,29 @@ GET /v4.0/jobs/{jobId}
 
 #### 必要権限
 
-| 権限名                               | 説明        |
-|-------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Job.Get | 作業情報詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前  | 種類 | 形式 | 必須 | 説明    |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 作業の識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                           | 種類 | 形式     | 説明                              |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 作業の識別子                         |
-| jobStatus                      | Body | Enum     | 作業の現在状態                       |
-| resourceRelations              | Body | Array    | 関連リソースリスト                       |
-| resourceRelations.resourceType | Body | Enum     | 関連リソースタイプ                       |
-| resourceRelations.resourceId   | Body | UUID     | 関連リソースの識別子                      |
-| createdYmdt                    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 作業の識別子 |
+| jobStatus | Body | Enum | 作業の現在状態<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 関連リソースリスト |
+| resourceRelations.resourceType | Body | String | 関連リソースタイプ |
+| resourceRelations.resourceId | Body | String | 関連リソースの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -443,16 +444,16 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -460,7 +461,6 @@ GET /v4.0/jobs/{jobId}
 </details>
 
 ---
-
 ## DBインスタンスグループ
 
 ### DBインスタンスグループリストを表示
@@ -471,8 +471,8 @@ GET /v4.0/db-instance-groups
 
 #### 必要権限
 
-| 権限名                                            | 説明             |
-|--------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.List | DBインスタンスグループリスト表示 |
 
 #### リクエスト
@@ -481,13 +481,13 @@ GET /v4.0/db-instance-groups
 
 #### レスポンス
 
-| 名前                               | 種類 | 形式     | 説明                                                                     |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DBインスタンスグループリスト                                                          |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                        |
-| dbInstanceGroups.replicationType   | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DBインスタンスグループリスト |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceGroups.replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -501,10 +501,10 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -523,30 +523,30 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 必要権限
 
-| 権限名                                           | 説明             |
-|-------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstanceGroup.Get | DBインスタンスグループ詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明            |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DBインスタンスグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式     | 説明                                                                                                                                  |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| replicationType              | Body | Enum     | DBインスタンスグループの複製形態<br/>- `STANDALONE`:単一<br/>- `HIGH_AVAILABILITY`:高可用性                                                                 |
-| dbInstances                  | Body | Array    | DBインスタンスグループに属するDBインスタンスリスト                                                                                                           |
-| dbInstances.dbInstanceId     | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstances.dbInstanceType   | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| createdYmdt                  | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| replicationType | Body | Enum | DBインスタンスグループの複製形態<br/>- STANDALONE: `高可用性を使用しない`<br/>- HIGH_AVAILABILITY: `高可用性を使用` |
+| dbInstances | Body | Array | DBインスタンスグループに属するDBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -558,17 +558,17 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -581,48 +581,48 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DBインスタンス状態
 
-| 状態                | 説明                         |
+| 状態                  | 説明                           |
 |---------------------|------------------------------|
-| `AVAILABLE`         | DBインスタンスが使用可能な場合         |
-| `BEFORE_CREATE`     | DBインスタンスが作成前の場合               |
-| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合          |
-| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合         |
-| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合         |
-| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合            |
-| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合     |
-| `SHUTDOWN`          | DBインスタンスが停止した場合               |
-| `DELETED`           | DBインスタンスが削除された場合            |
+| `AVAILABLE`         | DBインスタンスが使用可能な場合 |
+| `BEFORE_CREATE`     | DBインスタンスが作成前の場合 |
+| `STORAGE_FULL`      | DBインスタンスの容量が不足している場合 |
+| `FAIL_TO_CREATE`    | DBインスタンス作成に失敗した場合 |
+| `FAIL_TO_CONNECT`   | DBインスタンス接続に失敗した場合 |
+| `REPLICATION_STOP`  | DBインスタンスの複製が中断した場合 |
+| `FAILOVER`          | DBインスタンスが高可用性フェイルオーバーした場合 |
+| `SHUTDOWN`          | DBインスタンスが停止した場合 |
+| `DELETED`           | DBインスタンスが削除された場合 |
 
 ### DBインスタンス進行状態
 
-| 状態                       | 説明         |
+| 状態                         | 説明           |
 |----------------------------|--------------|
 | `APPLYING_PARAMETER_GROUP` | パラメータグループ適用中 |
-| `BACKING_UP`               | バックアップ中       |
-| `CANCELING`                | キャンセル中       |
-| `CREATING`                 | 作成中       |
-| `CREATING_SCHEMA`          | DBスキーマ作成中	 |
-| `CREATING_USER`            | ユーザー作成中	    |
-| `DELETING`                 | 削除中       |
+| `BACKING_UP`               | バックアップ中 |
+| `CANCELING`                | キャンセル中 |
+| `CREATING`                 | 作成中 |
+| `CREATING_SCHEMA`          | DBスキーマ作成中 |
+| `CREATING_USER`            | ユーザー作成中 |
+| `DELETING`                 | 削除中 |
 | `DELETING_SCHEMA`          | DBスキーマ削除中 |
-| `DELETING_USER`            | ユーザー削除中   |
+| `DELETING_USER`            | ユーザー削除中 |
 | `EXPORTING_BACKUP`         | バックアップをエクスポート中 |
-| `FAILING_OVER`             | フェイルオーバー中    |
-| `MIGRATING`                | マイグレーション中   |
-| `MODIFYING`                | 修正中       |
-| `PREPARING`                | 準備中       |
-| `PROMOTING`                | 昇格中       |
-| `REBUILDING`               | 再構築中      |
-| `REPAIRING`                | 復旧中       |
-| `REPLICATING`              | 複製中       |
-| `RESTARTING`               | 再起動中          |
-| `RESTARTING_FORCIBLY`      | 強制再起動中        |
-| `RESTORING`                | 復元中       |
-| `STARTING`                 | 起動中       |
-| `STOPPING`                 | 停止中       |
+| `FAILING_OVER`             | フェイルオーバー中 |
+| `MIGRATING`                | マイグレーション中 |
+| `MODIFYING`                | 修正中 |
+| `PREPARING`                | 準備中 |
+| `PROMOTING`                | 昇格中 |
+| `REBUILDING`               | 再構築中 |
+| `REPAIRING`                | 復旧中 |
+| `REPLICATING`              | 複製中 |
+| `RESTARTING`               | 再起動中 |
+| `RESTARTING_FORCIBLY`      | 強制再起動中 |
+| `RESTORING`                | 復元中 |
+| `STARTING`                 | 起動中 |
+| `STOPPING`                 | 停止中 |
 | `SYNCING_SCHEMA`           | DBスキーマ同期中 |
-| `SYNCING_USER`             | ユーザー同期中	   |
-| `UPDATING_USER`            | ユーザー修正中	    |
+| `SYNCING_USER`             | ユーザー同期中 |
+| `UPDATING_USER`            | ユーザー修正中 |
 
 ### DBインスタンスリストを表示
 
@@ -632,8 +632,8 @@ GET /v4.0/db-instances
 
 #### 必要権限
 
-| 権限名                                       | 説明          |
-|---------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.List | DBインスタンスリスト表示 |
 
 #### リクエスト
@@ -642,20 +642,20 @@ GET /v4.0/db-instances
 
 #### レスポンス
 
-| 名前                          | 種類 | 形式     | 説明                                                                                                                                  |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DBインスタンスリスト                                                                                                                          |
-| dbInstances.dbInstanceId      | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| dbInstances.dbInstanceName    | Body | String   | DBインスタンスを識別できる名前                                                                                                                       |
-| dbInstances.description       | Body | String   | DBインスタンスの追加情報                                                                                                                          |
-| dbInstances.dbVersion         | Body | Enum     | DBエンジンタイプ                                                                                                                            |
-| dbInstances.dbPort            | Body | Number   | DBポート                                                                                                                               |
-| dbInstances.dbInstanceType    | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| dbInstances.progressStatus    | Body | Enum     | DBインスタンスの現在進行状態                                                                                                                   |
-| dbInstances.createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| dbInstances.description | Body | String | DBインスタンスの追加情報 |
+| dbInstances.dbVersion | Body | Enum | DBエンジンタイプ |
+| dbInstances.dbPort | Body | Number | DBポート |
+| dbInstances.dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstances.dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| dbInstances.progressStatus | Body | Enum | DBインスタンスの現在進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | 作成日時 |
+| dbInstances.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -669,19 +669,366 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを作成する
+
+```http
+POST /v4.0/db-instances
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| dbPort | Body | Number | O | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | O | データストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | データストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### オブジェクトストレージを利用したDBインスタンスの復元
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに関する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | O | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | O | DBポート |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Body | Object | O | データストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | O | ストレージタイプ |
+| storage.storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.subnetId | Body | UUID | O | サブネットの識別子 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| backup | Body | Object | O | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | O | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.tenantId | Body | String | O | バックアップが保存されたオブジェクトストレージのテナントID |
+| restore.username | Body | String | O | NHN Cloud会員またはIAMメンバーID |
+| restore.password | Body | String | O | バックアップが保存されたオブジェクトストレージのAPIパスワード |
+| restore.targetContainer | Body | String | O | バックアップが保存されたオブジェクトストレージのコンテナ |
+| restore.objectPath | Body | String | O | コンテナに保存されたバックアップのパス |
+| useDefaultNotification | Body | Boolean | X | 基本通知の使用有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析の有無<br/>- デフォルト値: `true` |
+| parameterGroupId | Body | UUID | O | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | DBインスタンスの削除 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "deleteAutoBackup": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -698,43 +1045,43 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                        | 種類 | 形式     | 説明                                                                                                                                  |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DBインスタンスの識別子                                                                                                                        |
-| dbInstanceGroupId           | Body | UUID     | DBインスタンスグループの識別子                                                                                                                     |
-| dbInstanceName              | Body | String   | DBインスタンスを識別できる名前                                                                                                                       |
-| description                 | Body | String   | DBインスタンスの追加情報                                                                                                                          |
-| dbVersion                   | Body | Enum     | DBエンジンタイプ                                                                                                                            |
-| dbPort                      | Body | Number   | DBポート                                                                                                                               |
-| dbInstanceType              | Body | Enum     | DBインスタンスの役割タイプ<br/>- `MASTER`:マスター<br/>- `FAILED_MASTER`:フェイルオーバーしたマスター<br/>- `CANDIDATE_MASTER`:予備マスター<br/>- `READ_ONLY_SLAVE`:リードレプリカ |
-| dbInstanceStatus            | Body | Enum     | DBインスタンスの現在状態                                                                                                                      |
-| progressStatus              | Body | Enum     | DBインスタンスの現在作業進行状態                                                                                                                |
-| dbFlavorId                  | Body | UUID     | DBインスタンス仕様の識別子                                                                                                                     |
-| parameterGroupId            | Body | UUID     | DBインスタンスに適用されたパラメータグループの識別子                                                                                                           |
-| dbSecurityGroupIds          | Body | Array    | DBインスタンスに適用されたDBセキュリティグループの識別子リスト                                                                                                       |
-| notificationGroupIds        | Body | Array    | DBインスタンスに適用された通知グループの識別子リスト                                                                                                          |
-| useDeletionProtection       | Body | Boolean  | DBインスタンス削除保護の有無                                                                                                                     |
-| useSlowQueryAnalysis        | Body | Boolean  | Slow query分析を行うかどうか                                                                                                                     |
-| supportAuthenticationPlugin | Body | Boolean  | 認証プラグインサポートの有無                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 最新パラメータグループの適用が必要かどうか                                                                                                                  |
-| needMigration               | Body | Boolean  | マイグレーションが必要かどうか                                                                                                                        |
-| supportDbVersionUpgrade     | Body | Boolean  | DBのバージョンアップグレードをサポートするかどうか                                                                                                             |
-| createdYmdt                 | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstanceGroupId | Body | UUID | DBインスタンスグループの識別子 |
+| dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| description | Body | String | DBインスタンスの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| dbPort | Body | Number | DBポート |
+| dbInstanceType | Body | Enum | DBインスタンスの役割タイプ<br/>- MASTER: `マスター`<br/>- FAILED_MASTER: `障害マスター`<br/>- CANDIDATE_MASTER: `予備マスター`<br/>- READ_ONLY_SLAVE: `リードレプリカ` |
+| dbInstanceStatus | Body | Enum | DBインスタンスの現在状態<br/>- BEFORE_CREATE: `作成前(グレー)`<br/>- AVAILABLE: `使用可能(グリーン)`<br/>- STORAGE_FULL: `容量不足(レッド)`<br/>- FAIL_TO_CREATE: `作成失敗(レッド)`<br/>- FAIL_TO_CONNECT: `接続失敗(レッド)`<br/>- REPLICATION_STOP: `複製中断(レッド)`<br/>- REPLICATION_DELAY: `複製遅延(イエロー)`<br/>- FAILOVER: `フェイルオーバー完了(レッド)`<br/>- SHUTDOWN: `停止済み(グレー)`<br/>- DELETED: `削除済み(グレー)` |
+| progressStatus | Body | Enum | DBインスタンスの現在作業進行状態<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | UUID | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | DBインスタンスに適用されたパラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | DBインスタンスに適用されたDBセキュリティグループの識別子リスト |
+| notificationGroupIds | Body | Array | DBインスタンスに適用された通知グループの識別子リスト |
+| useDeletionProtection | Body | Boolean | DBインスタンス削除保護の有無 |
+| useSlowQueryAnalysis | Body | Boolean | Slow query分析を行うかどうか |
+| supportAuthenticationPlugin | Body | Boolean | 認証プラグインサポートの有無 |
+| needToApplyParameterGroup | Body | Boolean | 最新パラメータグループの適用が必要かどうか |
+| needMigration | Body | Boolean | マイグレーションが必要かどうか |
+| supportDbVersionUpgrade | Body | Boolean | DBのバージョンアップグレードをサポートするかどうか |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -746,135 +1093,36 @@ GET /v4.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
     "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
+    "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
     "needToApplyParameterGroup": false,
     "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
-
----
-
-### DBインスタンスを作成する
-
-```http
-POST /v4.0/db-instances
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | DBインスタンスの作成 |
-
-#### リクエスト
-
-| 名前                                           | 種類   | 形式      | 必須 | 説明                                                                  |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる マスター名                                                |
-| dbInstanceCandidateName                      | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                             |
-| description                                  | Body | String  | X  | DBインスタンスに関する追加情報                                                    |
-| dbFlavorId                                   | Body | UUID    | O  | DBインスタンス仕様の識別子                                                      |
-| dbVersion                                    | Body | Enum    | O  | DBエンジンタイプ                                                           |
-| dbPort                                       | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                          |
-| dbUserName                                   | Body | String  | O  | DBユーザーアカウント名                                                        |
-| dbPassword                                   | Body | String  | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                 |
-| parameterGroupId                             | Body | UUID    | O  | パラメータグループの識別子                                                       |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                 |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                     |
-| useHighAvailability                          | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                 |
-| pingInterval                                 | Body | Number  | X  | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`        |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知の使用有無<br/>- デフォルト値: `false`                                     |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                       |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | スロークエリ分析の有無<br/>- デフォルト値: `true`                                    |
-| authenticationPlugin                         | Body | Enum    | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519`                                                                                                                                                                                   |
-| network                                      | Body | Object  | O  | ネットワーク情報オブジェクト                                                                                                                                                                                                                 |
-| network.subnetId                             | Body | UUID    | O  | サブネットの識別子                                                                                                                                                                                                                      |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                                                                                                   |
-| network.availabilityZone                     | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                                                                                                                                                                   |
-| storage                                      | Body | Object  | O  | データストレージ情報オブジェクト                                                                                                                                                                                                               |    
-| storage.storageType                          | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                                                                                                                                                                             |
-| storage.storageSize                          | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                                                                                                                                                                              |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                                                                                                                                                             |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージ自動拡張を行うかどうか                                                                                                                                                                                                               |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                                                                                                                                                                                      |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                                                                                                                                                                                |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                                                                                                                                                                              |
-| backup                                       | Body | Object  | O  | バックアップ情報オブジェクト                                                                                                                                                                                                                 |
-| backup.backupPeriod                          | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                  |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                            |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                   |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                          |
-| backup.backupSchedules                       | Body | Array   | O  | 予定された自動バックアップリスト                                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
-    },
-    "backup": {
-        "backupPeriod": 1,
-        "backupSchedules": [
-            {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
-            }
-        ]
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
 
 ---
 
@@ -886,38 +1134,49 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 必要権限
 
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
 
 #### リクエスト
 
-| 名前                     | 種類  | 形式     | 必須 | 説明                                         |
-|-------------------------|------|---------|----|---------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DBインスタンスの識別子                               |
-| dbInstanceName          | Body | String  | X  | DBインスタンスを識別できる マスター名                   |
-| dbInstanceCandidateName | Body | String  | X  | DBインスタンスを識別できる 予備マスター名 |
-| description             | Body | String  | X  | DBインスタンスに関する追加情報                          |
-| dbPort                  | Body | Number  | X  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Slow query分析を行うかどうか |
-| dbFlavorId         | Body | UUID    | X  | DBインスタンス仕様の識別子                                                         |
-| parameterGroupId   | Body | UUID    | X  | パラメータグループの識別子                                                            |
-| dbSecurityGroupIds | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                        |
-| executeBackup      | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| useOnlineFailover  | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | X | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| dbInstanceCandidateName | Body | String | X | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbVersion | Body | Enum | X | DBエンジンバージョンコード |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか |
+| useDummy | Body | Boolean | X | 単一DBインスタンスのDBバージョンアップグレード時にダミーを使用するかどうか<br/>- デフォルト値: `false` |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消の待機有無<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 読み取り専用への変更有無<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
 }
 ```
 
@@ -926,426 +1185,9 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | DBインスタンスの削除 |
-
-#### リクエスト
-
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| deleteAutoBackup | Body | Boolean | X | 自動バックアップの削除有無<br/>- デフォルト値：`false` |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | DBインスタンスの再起動 |
-
-#### リクエスト
-
-| 名前              | 種類 | 形式    | 必須 | 説明                                                                            |
-|-------------------|------|---------|----|-------------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                                  |
-| useOnlineFailover | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| executeBackup     | Body | Boolean | X  | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false`                                       |
-| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-| useReadOnly | Body | Boolean | X | 読み取り専用への変更を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値：`false` |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-### DBインスタンスを強制再起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明             |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | DBインスタンスの強制再起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式    | 必須 | 説明                                                                      |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DBインスタンスを起動する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明         |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | DBインスタンスの起動 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 必要権限
-
-| 権限名                                       | 説明         |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | DBインスタンスの停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを複製する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明         |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
-
-#### リクエスト
-
-| 名前                                         | 種類 | 形式    | 必須 | 説明                                                                      |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる名前                                                 |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                       |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値:原本DBインスタンス値                                 |
-| dbPort                                       | Body | Number  | X  | DBポート<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `3306`<br/>- 最大値: `43306`        |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値:原本DBインスタンス値                                    |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト<br/>- デフォルト値:原本DBインスタンス値                                |
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                          |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                            |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                               |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                        |
-| network                                      | Body | Object  | O  | ネットワーク情報オブジェクト                                                              |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値:原本DBインスタンス値                                     |
-| network.availabilityZone                     | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                  |
-| storage                                      | Body | Object  | X  | データストレージ情報オブジェクト                                                          |    
-| storage.storageType                          | Body | Enum    | X  | データストレージタイプ<br/>- デフォルト値:原本DBインスタンス値<br/>- 例: `General SSD`                        |
-| storage.storageSize                          | Body | Number  | X  | データストレージサイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `20`<br/>- 最大値: `2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                       |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージ自動拡張を行うかどうか   <br/>- デフォルト値:原本DBインスタンス値                                                          |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `50`<br/>- 最大値: `95`                               |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最大値: `4096`                                         |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `10`<br/>- 最大値: `1440`                         |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                                |
-| backup.backupPeriod                          | Body | Number  | X  | バックアップ保管期間(日)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値:原本DBインスタンス値<br/>- 最小値: `0`<br/>- 最大値: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | バックアップ開始時刻<br/>- 例: `00:00:00`<br/>- デフォルト値:原本DBインスタンス値                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間<br/>- デフォルト値:原本DBインスタンス値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスを昇格する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明         |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | DBインスタンスの昇格 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBインスタンスの再構築
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | DBインスタンスの再構築 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 復元情報照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                    | 種類 | 形式     | 説明                                                                                                                                                                         |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 最古の復元可能時間                                                                                                                                                                               |
-| latestRestorableYmdt                    | Body | DateTime | 最新の復元可能時間                                                                                                                                                                               |
-| restorableBackups                       | Body | Array    | 復元可能なバックアップリスト                                                                                                                                                               |
-| restorableBackups.backup                | Body | Object   | バックアップ情報オブジェクト                                                                                                                                                                   |
-| restorableBackups.backup.backupId       | Body | UUID     | バックアップの識別子                                                                                                                                                                    |
-| restorableBackups.backup.backupName     | Body | String   | バックアップ名                                                                                                                                                                      |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | テーブルロックを使用するかどうか                                                                                                                                                               |
-| restorableBackups.backup.backupSize     | Body | Number   | バックアップサイズ                                                                                                                                                                      |
-| restorableBackups.backup.backupType     | Body | Enum     | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | バックアップ状態<br/>- `BACKING_UP`:バックアップ中の場合<br/>- `COMPLETED`:バックアップが完了している場合<br/>- `DELETING`:バックアップが削除中の場合<br/>- `DELETED`:バックアップが削除されている場合<br/>- `ERROR`:エラーが発生した場合 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 原本DBインスタンスの識別子                                                                                                                                                            |
-| restorableBackups.backup.dbInstanceName | Body | String   | 原本DBインスタンスの名前                                                                                                                                                             |
-| restorableBackups.backup.dbVersion      | Body | String   | DBエンジンタイプ                                                                                                                                                                   |
-| restorableBackups.backup.failoverCount  | Body | Number   | フェイルオーバー回数                                                                                                                                                                   |
-| restorableBackups.backup.binLogFileName | Body | String   | バイナリログファイル名                                                                                                                                                              |
-| restorableBackups.backup.binLogPosition | Body | Number   | バイナリログファイル位置                                                                                                                                                              |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | バックアップ作成日時                                                                                                                                                                   |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | バックアップ更新日時                                                                                                                                                                   |
-| restorableBackups.restorableBinLogs     | Body | Array    | 該当バックアップを利用して復元可能なバイナリログ名リスト                                                                                                                                                            |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 復元される最後のクエリ照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### 共通リクエスト
-
-| 名前         | 種類  | 形式 | 必須 | 説明                                                                                                                        |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DBインスタンスの識別子                                                                                                              |
-| restoreType  | Query | Enum | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ |
-
-#### restoreTypeが`TIMESTAMP`の場合
-
-| 名前        | 種類  | 形式     | 必須 | 説明                                      |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreTypeが`BINLOG`の場合
-
-| 名前           | 種類  | 形式   | 必須 | 説明               |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 復元に使用するバックアップの識別子  |
-| binLogFileName | Query | String | O  | 復元に使用するバイナリログ名 |
-| binLogPosition | Query | Number | O  | 復元に使用するバイナリログ位置 |
-
-#### レスポンス
-
-| 名前         | 種類 | 形式     | 説明                                 |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | クエリ実行日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 最後に実行したクエリ                         |
 
 <details><summary>例</summary>
 <p>
@@ -1357,701 +1199,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
----
-
-### 復元
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明         |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
-
-#### 共通リクエスト
-
-| 名前                                                | 種類 | 形式    | 必須 | 説明                                                                                                                                                                    |
-|-----------------------------------------------------|------|---------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                          |
-| restore                                             | Body | Object  | O  | 復元情報オブジェクト                                                                                                                                                              |
-| restore.restoreType                                 | Body | Enum    | O  | 復元タイプの種類<br/>- `TIMESTAMP`:復元可能な時間内の時間を利用した時点復元タイプ<br/>- `BINLOG`:復元可能なバイナリログ位置を利用した時点復元タイプ<br/>- `BACKUP`:既存に作成したバックアップを利用したスナップショット復元タイプ                                                                                                                                                                                                                                                                                                            |
-| dbInstanceName                                      | Body | String  | O  | DBインスタンスを識別できる マスター名                                                                                                                                               |
-| dbInstanceCandidateName                             | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                                                                                                                             |
-| description                                         | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                                                                                                    |
-| dbFlavorId                                          | Body | UUID    | X  | DBインスタンス仕様の識別子                                                                                                                                                       |
-| dbPort | Body | Number | X | DBポート<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`3306`<br/>- 最大値：`43306` |
-| parameterGroupId | Body | UUID | X | パラメータグループの識別子<br/>- デフォルト値：原本DBインスタンスの値 |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                                                                                                      |
-| userGroupIds                                        | Body | Array   | X  | ユーザーグループの識別子リスト                                                                                                                                                        |
-| useHighAvailability                                 | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600`                                                                                  |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                      |
-| useDefaultNotification                              | Body | Boolean | X  | 基本アラームを使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護の有無<br>デフォルト値: `false`                                                                                                                                                |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                                                                                                                      |
-| network                                             | Body | Object  | X  | ネットワーク情報オブジェクト                                                                                                                                                            |
-| network.subnetId                                    | Body | UUID    | X  | サブネットの識別子<br/>- デフォルト値: 原本DBインスタンスの値                                                                                                                                                              |
-| network.usePublicAccess                             | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                                                                                                           |
-| network.availabilityZone                            | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`<br/>- デフォルト値: ランダム選択                                                                                                                 |
-| storage                                             | Body | Object  | X  | ストレージ情報オブジェクト                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| storage.storageType | Body | Enum | X | データストレージタイプ<br/>- デフォルト値：原本DBインスタンスの値<br/>- 例：`General SSD` |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`20`<br/>- 最大値：`2048` |
-| storage.storageAutoscale                            | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                                                                                                     |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張の使用有無 |
-| storage.storageAutoscale.threshold | Body | Number | X | 自動拡張条件(%)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`50`<br/>- 最大値：`95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | X | 自動拡張最大サイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最大値：`4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | X | 自動拡張クールダウン時間(分)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`10`<br/>- 最大値：`1440` |
-| backup                                              | Body | Object  | X  | バックアップ情報オブジェクト                                                                                                                                                              |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`0`<br/>- 最大値：`730` |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                   |
-| backup.backupRetryCount                             | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                              |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`<span style="color:#313338">: 30分</span><br/>- `ONE_HOUR`<span style="color:#313338">: 1時間</span><br/>- `ONE_HOUR_AND_HALF`<span style="color:#313338">: 1時間30分</span><br/>- `TWO_HOURS`<span style="color:#313338">: 2時間</span><br/>- `TWO_HOURS_AND_HALF`<span style="color:#313338">: 2時間30分</span><br/>- `THREE_HOURS`<span style="color:#313338">: 3時間</span> |
-
-#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
-
-| 名前                | 種類 | 形式     | 必須 | 説明                                                                                           |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
-
-| 名前                          | 種類 | 形式   | 必須 | 説明               |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 復元に使用するバックアップの識別子  |
-| restore.binLog                | Body | Object | O  | バイナリログ情報オブジェクト    |
-| restore.binLog.binLogFileName | Body | String | O  | 復元に使用するバイナリログの名前 |
-| restore.binLog.binLogPosition | Body | Number | O  | 復元に使用するバイナリログの位置 |
-
-* バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
-
-| 名前             | 種類 | 形式 | 必須                         | 説明            |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreTypeが`BACKUP`の場合) | 復元に使用するバックアップの識別子 |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-
----
-
-### オブジェクトストレージから復元
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### 必要権限
-
-| 権限名                                                 | 説明                    |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | DBインスタンスオブジェクトストレージから復元 |
-
-#### リクエスト
-
-| 名前                                                | 種類 | 形式    | 必須 | 説明                                                                                   |
-|-----------------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O  | 復元情報オブジェクト                                                                             |
-| restore.tenantId                                    | Body | String  | O  | バックアップが保存されたオブジェクトストレージのテナントID                                                              |
-| restore.username                                    | Body | String  | O  | NHN Cloud会員またはIAMメンバーID                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| restore.password                                    | Body | String  | O  | バックアップが保存されたオブジェクトストレージのAPIパスワード                                                          |
-| restore.targetContainer                             | Body | String  | O  | バックアップが保存されたオブジェクトストレージのコンテナ                                                              |
-| restore.objectPath                                  | Body | String  | O  | コンテナに保存されたバックアップのパス                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| dbVersion                                           | Body | Enum    | O  | DBエンジンタイプ                                                                             |
-| dbInstanceName                                      | Body | String  | O  | DBインスタンスを識別できる マスター名                                                              |
-| dbInstanceCandidateName                             | Body | String  | O  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                                            |
-| description                                         | Body | String  | X  | DBインスタンスに対する追加情報                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| dbFlavorId                                          | Body | UUID    | O  | DBインスタンス仕様の識別子                                                                      |
-| dbPort                                              | Body | Number  | O  | DBポート<br/>- 最小値: `3306`<br/>- 最大値: `43306`                            |
-| parameterGroupId | Body | UUID    | O  | パラメータグループの識別子                                                                         |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                                     |
-| userGroupIds                                        | Body | Array   | X  | ユーザーグループの識別子リスト                                                                       |
-| useHighAvailability                                 | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| pingInterval                                        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`       |
-| useDefaultNotification                              | Body | Boolean | X  | 基本アラームを使用するかどうか<br/>- デフォルト値: `false`                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| useDeletionProtection                               | Body | Boolean | X  | 削除保護の有無<br>デフォルト値: `false`                                                               |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                                     |
-| network                                             | Body | Object  | O  | ネットワーク情報オブジェクト                                                                           |
-| network.subnetId                                    | Body | UUID    | O  | サブネットの識別子                                                                             |
-| network.usePublicAccess                             | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                          |
-| network.availabilityZone                            | Body | Enum    | O  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`                                |
-| storage                                             | Body | Object  | O  | データストレージ情報オブジェクト                                                                       |
-| storage.storageType                                 | Body | Enum    | O  | データストレージタイプ<br/>- 例: `General SSD`                                     |
-| storage.storageSize                                 | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値: `20`<br/>- 最大値: `2048`                     |
-| storage.storageAutoscale                            | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                                    |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | ストレージ自動拡張を行うかどうか                                                                         |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                                            |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                                      |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                                      |
-| backup                                              | Body | Object  | O  | バックアップ情報オブジェクト                                                                             |
-| backup.backupPeriod                                 | Body | Number  | O  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                           |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                             | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`             |
-| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 予定された自動バックアップリスト                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`<span style="color:#313338">: 30分</span><br/>- `ONE_HOUR`<span style="color:#313338">: 1時間</span><br/>- `ONE_HOUR_AND_HALF`<span style="color:#313338">: 1時間30分</span><br/>- `TWO_HOURS`<span style="color:#313338">: 2時間</span><br/>- `TWO_HOURS_AND_HALF`<span style="color:#313338">: 2時間30分</span><br/>- `THREE_HOURS`<span style="color:#313338">: 3時間</span> |
-
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
-
----
-
-
-### DBインスタンス削除保護設定を変更する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明         |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DBインスタンスの識別子 |
-| useDeletionProtection | Body | Boolean | O  | 削除保護の有無    |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 高可用性の状態
-
-| 状態                               | 説明                               |
-|----------------------------------|---------------------------------|
-| `CREATED`                        | 高可用性が作成された場合                    |
-| `STABLE`                         | 高可用性が正常な場合                    |
-| `PAUSING`                        | 高可用性が一時停止中の場合               |
-| `PAUSED`                         | 高可用性が一時停止された場合                 |
-| `PAUSED_DUE_TO_TASK`             | タスクにより高可用性が一時停止された場合         |
-| `DISABLE_MASTER_IN_REPLICATION`  | マスターの異常なレプリケーションの検知により高可用性が中断された場合     |
-| `DISABLE_MHA_PROCESS`            | 高可用性プロセスが中断された場合               |
-| `DISABLE_REPLICATION_STOP`       | レプリケーションの中断により高可用性が中断された場合         |
-| `DISABLE_REPLICATION_DELAY`      | レプリケーションの遅延により高可用性が中断された場合         |
-| `MASTER_FAILURE_DETECTION`       | マスターの障害が検知された場合                 |
-| `FAILOVER_STARTED`               | フェイルオーバーが開始された場合                   |
-| `FAILOVER_FAILED`                | フェイルオーバーが失敗した場合                   |
-| `FAILOVER_COMPLETED`             | フェイルオーバーが完了した場合                   |
-| `DELETED`                        | 高可用性が削除された場合                   |
-
----
-
-### 高可用性情報の照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要な権限
-
-| 権限名                                              | 説明         |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンスの詳細照会 |
-
-#### リクエスト
-
-このAPIはリクエストボディを必要としません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                  | 種類   | 形式      | 説明                                                                                                                  |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | 高可用性の使用有無                                                                                                          |
-| haStatus            | Body | Enum    | 高可用性の状態                                                                                                          |
-| pingInterval        | Body | Number  | Ping間隔(秒)                                                                                                           |
-| pingType            | Body | Enum    | Pingタイプ<br/>- `INSERT`<br/>- `SELECT`                                                                                |                                                                                              |
-
-<details><summary>例</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
----
-
-### 高可用性を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明      |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
-
-#### リクエスト
-
-| 名前                | 種類 | 形式    | 必須 | 説明                                                 |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DBインスタンスの識別子                                       |
-| useHighAvailability | Body | Boolean | O  | 高可用性を使用するかどうか                                       |
-| pingInterval        | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType            | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- `INSERT`<br/>- `SELECT`         |
-| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できるスタンバイマスター名 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を再開する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明         |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | 高可用性の再開 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を一時停止する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明         |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | 高可用性の一時停止 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を復旧する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明      |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | 高可用性の復旧 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### 高可用性を分離する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明      |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | 高可用性の分離 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ストレージ情報を表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                                 | 種類 | 形式    | 説明                                                                                 |
-|--------------------------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | データストレージタイプ                                                                        |
-| storageSize                          | Body | Number  | データストレージサイズ(GB)                                                                      |
-| storageStatus                        | Body | Enum    | データストレージの現在状態<br/>- `DETACHED`:取り付けられていない<br/>- `ATTACHED`:取り付けられている<br/>- `DELETED`:削除済み |
-| storageAutoscale                     | Body | Object  | データストレージ自動拡張オブジェクト                                                                  |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか                                                                       |
-| storageAutoscale.threshold           | Body | Number  | 自動拡張条件(%)                                                                          |
-| storageAutoscale.maxStorageSize      | Body | Number  | 自動拡張最大サイズ(GB)                                                                      |
-| storageAutoscale.cooldownTime        | Body | Number  | 自動拡張クールダウン時間(分)                                                                      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### ストレージ情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                                 | 種類 | 形式    | 必須 | 説明                                                                      |
-|--------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O  | DBインスタンスの識別子                                                            |
-| storageSize                          | Body | Number  | O  | データストレージサイズ(GB)<br/>- 最小値:現在値<br/>- 最大値: `2048`                          |
-| useOnlineFailover                    | Body | Boolean | X  | フェイルオーバーを利用した再起動を行うかどうか<br/>高可用性を使用中のDBインスタンスでのみ使用可能です。<br/>- デフォルト値: `false` |
-| storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                       |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X  | ストレージの自動拡張を行うかどうか                                                            |
-| storageAutoscale.threshold           | Body | Number  | X  | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95`                               |
-| storageAutoscale.maxStorageSize      | Body | Number  | X  | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096`                                         |
-| storageAutoscale.cooldownTime        | Body | Number  | X  | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440`                         |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
 
 ---
 
@@ -2063,30 +1216,30 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 必要権限
 
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | バックアップ情報を表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
-| 名前                              | 種類 | 形式    | 説明           |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | バックアップ保管期間(日)    |
-| ftwrlWaitTimeout                  | Body | Number  | クエリ遅延待機時間(秒) |
-| backupRetryCount                  | Body | Number  | バックアップ再試行回数    |
-| replicationRegion                 | Body | Enum    | バックアップ複製リージョン     |
-| useBackupLock                     | Body | Boolean | テーブルロックを使用するかどうか |
-| backupSchedules                   | Body | Array   | 予定された自動バックアップリスト |
-| backupSchedules.backupWndBgnTime  | Body | String  | バックアップ開始時刻     |
-| backupSchedules.backupWndDuration | Body | Enum    | バックアップDuration    |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | バックアップ保管期間(日) |
+| ftwrlWaitTimeout | Body | Number | クエリ遅延待機時間(秒) |
+| backupRetryCount | Body | Number | バックアップ再試行回数 |
+| replicationRegion | Body | Enum | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
+| backupSchedules | Body | Array | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Body | Enum | バックアップDuration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>例</summary>
 <p>
@@ -2099,14 +1252,14 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2114,7 +1267,6 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 </p>
 </details>
-
 
 ---
 
@@ -2126,520 +1278,51 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 必要権限
 
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前                                  | 種類 | 形式    | 必須 | 説明                                                                                                                                                                                                                        |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DBインスタンスの識別子                                                                                                                                                                                                              |
-| backupPeriod                          | Body | Number  | X  | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか                                                                                                                                                                                                              |
-| backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト                                                                                                                                                                                                                 |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupPeriod": 5,
-    "useBackupLock": true,
-    "backupSchedules": [
-        {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ネットワーク情報表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                                      | 説明          |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DBインスタンス詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                   | 種類 | 形式   | 説明                                                                                                                                    |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DBインスタンスを作成するアベイラビリティゾーン                                                                                                                   |
-| subnet                 | Body | Object | サブネットオブジェクト                                                                                                                                |
-| subnet.subnetId        | Body | UUID   | サブネットの識別子                                                                                                                              |
-| subnet.subnetName      | Body | UUID   | サブネットの識別できる名前                                                                                                                 |
-| subnet.subnetCidr      | Body | UUID   | サブネットのCIDR                                                                                                                               |
-| endPoints              | Body | Array  | 接続情報リスト                                                                                                                              |
-| endPoints.domain       | Body | String | ドメイン                                                                                                                                   |
-| endPoints.ipAddress    | Body | String | IPアドレス                                                                                                                                 |
-| endPoints.endPointType | Body | Enum   | 接続情報タイプ<br>-`EXTERNAL`:外部接続ドメイン<br>-`INTERNAL`:内部接続ドメイン<br>-`PUBLIC`: (Deprecated)外部接続ドメイン<br>-`PRIVATE`: (Deprecated)内部接続ドメイン |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ネットワーク情報を修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 必要権限
-
-| 権限名                                         | 説明         |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DBインスタンスを修正する |
-
-#### リクエスト
-
-| 名前            | 種類 | 形式    | 必須 | 説明         |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DBインスタンスの識別子 |
-| usePublicAccess | Body | Boolean | O  | 外部接続可否 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明                |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | DBインスタンス内のユーザーリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                           | 種類   | 形式       | 説明                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DBユーザーリスト                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DBユーザーの識別子                                                                                                                  |
-| dbUsers.dbUserName           | Body | String   | DBユーザーアカウント名                                                                                                                |
-| dbUsers.host                 | Body | String   | DBユーザーアカウントのホスト名                                                                                                            |
-| dbUsers.authorityType        | Body | Enum     | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/>                      |
-| dbUsers.dbUserStatus         | Body | Enum     | DBユーザーの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `UPDATING`:修正中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み         |
-| dbUsers.authenticationPlugin | Body | Enum     | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-| dbUsers.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBユーザーを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | DBインスタンス内のユーザーを作成 |
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserName           | Body | String | O  | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32`                                                          |
-| dbPassword           | Body | String | O  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| host                 | Body | String | O  | DBユーザーアカウントのホスト名<br/>- 例: `1.1.1.%`                                                                    |
-| authorityType        | Body | Enum   | O  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- デフォルト値: `NATIVE`(未対応の場合は`ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを修正する
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | DBインスタンス内のユーザーを修正 |
-
-#### リクエスト
-
-| 名前                   | 種類   | 形式     | 必須 | 説明                                                                                                     |
-|----------------------|------|--------|----|--------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DBインスタンスの識別子                                                                                           |
-| dbUserId             | URL  | UUID   | O  | DBユーザーの識別子                                                                                             |
-| dbPassword           | Body | String | X  | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256`                                                    |
-| authorityType        | Body | Enum   | X  | DBユーザー権限タイプ<br/>- `READ`: SELECTクエリ実行可能な権限<br/>- `CRUD`: DMLクエリ実行可能な権限<br/>- `DDL`: DDLクエリ実行可能な権限<br/> |
-| authenticationPlugin | Body | Enum   | X  | 認証プラグイン<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBユーザーを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明               |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | DBインスタンス内のユーザーを削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbUserId     | URL | UUID | O  | DBユーザーの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBスキーマリストを表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明                |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | DBインスタンス内のスキーマリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前           | 種類  | 形式   | 必須 | 説明           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-
-#### レスポンス
-
-| 名前                       | 種類   | 形式       | 説明                                                                                             |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DBスキーマリスト                                                                                      |
-| dbSchemas.dbSchemaId     | Body | UUID     | DBスキーマの識別子                                                                                     |
-| dbSchemas.dbSchemaName   | Body | String   | DBスキーマ名                                                                                        |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DBスキーマの現在状態<br/>- `STABLE`:作成済み<br/>- `CREATING`:作成中<br/>- `DELETING`:削除中<br/>- `DELETED`:削除済み |
-| dbSchemas.createdYmdt    | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                               |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBスキーマを作成する
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明               |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | DBインスタンス内のスキーマを作成 |
-
-#### リクエスト
-
-| 名前         | 種類 | 形式   | 必須 | 説明         |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DBインスタンスの識別子 |
-| dbSchemaName | Body | String | O  | DBスキーマ名  |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### DBスキーマを削除する
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 必要権限
-
-| 権限名                                               | 説明               |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | DBインスタンス内のスキーマを削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DBインスタンスの識別子 |
-| dbSchemaId   | URL | UUID | O  | DBスキーマの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### ログファイルリスト表示
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明                  |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | DBインスタンス内のログファイルリストを表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前         | 種類  | 形式  | 必須 | 説明                                                                                                                                                                                            |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DBインスタンスの識別子                                                                                                                                                                                  |
-| logFileTypes | Query | Array | X  | ログファイルタイプ種類一覧<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### レスポンス
-
-| 名前                 | 種類 | 形式     | 説明                                                                                                                                                                                         |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | ログファイルリスト                                                                                                                                                                                   |
-| logFiles.logFileName | Body | String   | ログファイル名                                                                                                                                                                                   |
-| logFiles.logFileType | Body | Enum     | ログファイルタイプ種類<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | ログファイルサイズ(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ログファイルの内容照会
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### 必要な権限
-
 | 権限名 | 説明 |
-|-----------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.Get | DBインスタンス内のログファイル内容照会 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | バックアップ情報を修正する |
 
 #### リクエスト
-
-このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| logFileName | URL | String | O | ログファイル名 |
-| logFileType | Query | Enum | O | ログファイルタイプの種類<br/>- `ERROR`：error.log<br/>- `BINLOG`：mysql-bin<br/>- `GENERAL`：general.log<br/>- `SLOW_QUERY`：slow_query.log<br/>- `AUDIT`：server_audit.log<br/>- `BACKUP`：xtra_full.log |
+| backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
+| backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
+| backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
+    "backupSchedules": [
+        {
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|---------|------|--------|--------------------------|
-| content | Body | String | ログファイルの内容(最大65533 Bytes) |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -2651,7 +1334,7 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "content": "..."
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2659,57 +1342,7 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 </details>
 
 ---
-
-### ログファイルのエクスポート
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明                 |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | DBインスタンス内のログファイルをエクスポート |
-
-#### リクエスト
-
-| 名前            | 種類 | 形式   | 必須 | 説明                           |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DBインスタンスの識別子                 |
-| logFileNames    | Body | Array  | O  | ログファイル名リスト<br/>- 最小サイズ: `1`      |
-| tenantId        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN CloudアカウントまたはIAMアカウントID      |
-| password        | Body | String | O  | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | ログファイルが保存されるオブジェクトストレージのコンテナ   |
-| objectPath      | Body | String | O  | コンテナに保存されるログファイルのパス          |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
-
----
-
-### BinLog一覧照会
+### バイナリログ一覧照会
 
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
@@ -2718,26 +1351,25 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 #### 必要な権限
 
 | 権限名 | 説明 |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | BinLog一覧照会 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | バイナリログ一覧照会 |
 
 #### リクエスト
 
 このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| deletable | Query | Boolean | X | 削除可能なBinLogのみ照会するかどうか<br/>- `true`：最後のBinLogを除く<br/>- `false`：全体<br/>- デフォルト値：`false` |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|------------------------|------|----------|-----------------------------------|
+|-----|-----|-----|-----|
 | binLogs | Body | Array | BinLogファイル一覧 |
 | binLogs.binLogFileName | Body | String | BinLogファイル名 |
 | binLogs.binLogFileSize | Body | Number | BinLogファイルサイズ(Byte) |
-| binLogs.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| binLogs.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
 <p>
@@ -2751,9 +1383,9 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2764,7 +1396,7 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 ---
 
-### BinLog削除
+### バイナリログ削除
 
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
@@ -2773,14 +1405,14 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | BinLog削除 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | バイナリログ削除 |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------------|------|--------|----|---------------------------------------|
-| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 | lastBinLogFileName | Body | String | O | 削除する最後のBinLogファイル名(該当ファイルの直前まで削除されます) |
 
 <details><summary>例</summary>
@@ -2799,22 +1431,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 このAPIはレスポンスボディを返しません。
 
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
 ### 証明書ファイル一覧照会
@@ -2826,7 +1442,7 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 #### 必要な権限
 
 | 権限名 | 説明 |
-|--------------------------------------------------------|---------------|
+|-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.List | 証明書ファイル一覧照会 |
 
 #### リクエスト
@@ -2834,18 +1450,18 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 このAPIはリクエストボディを要求しません。
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|-----|------|----|---------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
+|-----|-----|-----|-----|
 | certificates | Body | Array | 証明書ファイル一覧 |
 | certificates.fileName | Body | String | 証明書ファイル名 |
-| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- `CA_FILE`：CA証明書<br/>- `CERT_FILE`：証明書<br/>- `KEY_FILE`：秘密鍵 |
+| certificates.certificateType | Body | Enum | 証明書タイプ<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
 | certificates.fileSize | Body | Number | 証明書ファイルサイズ(Byte) |
-| certificates.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| certificates.createdYmdt | Body | DateTime | 作成日時 |
 
 <details><summary>例</summary>
 <p>
@@ -2859,10 +1475,10 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
-            "fileName": "ca.pem",
+            "fileName": "fileName-example",
             "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "fileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2882,16 +1498,16 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|-------------|
+|-----|-----|
 | RDSforMariaDB:DbInstanceCertificate.Export | 証明書ファイルエクスポート |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
+|-----|-----|-----|-----|-----|
 | dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
-| certificateTypes | Body | Array | O | アップロードする証明書タイプ<br/>- `CA_FILE`：CA証明書<br/>- `CERT_FILE`：証明書<br/>- `KEY_FILE`：秘密鍵 |
-| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID |
+| certificateTypes | Body | Array | O | アップロードする証明書タイプ一覧 |
+| tenantId | Body | String | O | 証明書ファイルが保存されるObject StorageのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
 | username | Body | String | O | NHN CloudメンバーまたはIAMメンバーID |
 | password | Body | String | O | 証明書ファイルが保存されるObject StorageのAPIパスワード |
 | targetContainer | Body | String | O | 証明書ファイルが保存されるObject Storageのコンテナ |
@@ -2902,12 +1518,12 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 ```json
 {
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
+    "certificateTypes": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -2917,64 +1533,8 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストされたジョブの識別子 |
-
----
-
-## バックアップ
-
-### バックアップ状態
-
-| 状態         | 説明         |
-|--------------|--------------|
-| `BACKING_UP` | バックアップ中の場合   |
-| `COMPLETED`  | バックアップが完了している場合 |
-| `DELETING`   | バックアップが削除中の場合 |
-| `DELETED`    | バックアップが削除されている場合 |
-| `ERROR`      | エラーが発生した場合 |
-
-### バックアップ詳細照会
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### 必要な権限
-
-| 権限名 | 説明 |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | バックアップ詳細照会 |
-
-#### リクエスト
-
-このAPIはリクエストボディを要求しません。
-
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O | バックアップの識別子 |
-
-#### レスポンス
-
-| 名前 | 種類 | 形式 | 説明 |
-|-------------------------|------|----------|-----------------|
-| backup | Body | Object | バックアップ詳細情報 |
-| backup.backupId | Body | UUID | バックアップの識別子 |
-| backup.regionCode | Body | Enum | リージョンコード |
-| backup.backupName | Body | String | バックアップを識別できる名前 |
-| backup.backupStatus | Body | Enum | バックアップの現在のステータス |
-| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
-| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
-| backup.dbVersion | Body | Enum | DBエンジンバージョン |
-| backup.backupType | Body | Enum | バックアップタイプ |
-| backup.backupMethodType | Body | Enum | バックアップ方式 |
-| backup.backupFileType | Body | Enum | バックアップファイルタイプ |
-| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
-| backup.isReplicable | Body | Boolean | レプリケーション可否 |
-| backup.binLogFileName | Body | String | バイナリログファイル名 |
-| backup.binLogPosition | Body | Number | バイナリログ位置 |
-| backup.createdYmdt | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -2986,23 +1546,1990 @@ GET /v4.0/backups/{backupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマリストを表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | DBスキーマリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエストボディを要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DBスキーマリスト |
+| dbSchemas.dbSchemaId | Body | UUID | DBスキーマの識別子 |
+| dbSchemas.dbSchemaName | Body | String | DBスキーマ名 |
+| dbSchemas.dbSchemaStatus | Body | Enum | DBスキーマの現在状態<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | 作成日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマを作成する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | DBスキーマを作成する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbSchemaName | Body | String | O | DBスキーマ名<br/>- 最大長さ: `64`<br/>- 英字で始まり、英字/数字/_のみ使用可、1〜64文字、MySQLの予約語は不可 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBスキーマを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | DBスキーマを削除する |
+
+#### リクエスト
+
+このAPIはリクエストボディを要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbSchemaId | URL | UUID | O | DBスキーマの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーリストを表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | DBユーザーリストを表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DBユーザーリスト |
+| dbUsers.dbUserId | Body | UUID | DBユーザーの識別子 |
+| dbUsers.dbUserName | Body | String | DBユーザーアカウント名 |
+| dbUsers.host | Body | String | DBユーザーアカウントのホスト名 |
+| dbUsers.authorityType | Body | Enum | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| dbUsers.dbUserStatus | Body | Enum | DBユーザーの現在状態<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | 作成日時 |
+| dbUsers.updatedYmdt | Body | DateTime | 修正日時 |
+| dbUsers.authenticationPlugin | Body | Enum | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| dbUsers.tlsOption | Body | Enum | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを作成する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | DBユーザーを作成する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserName | Body | String | O | DBユーザーアカウント名<br/>- 最小長さ: `1`<br/>- 最大長さ: `32` |
+| dbPassword | Body | String | O | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| host | Body | String | O | DBユーザーアカウントのホスト名<br/>- 最大長さ: `45` |
+| authorityType | Body | Enum | O | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | 証明書オプション<br/>- デフォルト値: `NONE`<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | DBユーザーを削除する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBユーザーを修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | DBユーザーを修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbUserId | URL | UUID | O | DBユーザーの識別子 |
+| dbPassword | Body | String | X | DBユーザーアカウントのパスワード<br/>- 最小長さ: `4`<br/>- 最大長さ: `256` |
+| authorityType | Body | Enum | X | DBユーザー権限タイプ<br/>- CUSTOM: `ユーザー定義権限`<br/>- READ: `読み取り権限`<br/>- CRUD: `CRUD権限`<br/>- DDL: `DDL権限`<br/>- ALL: `全権限` |
+| authenticationPlugin | Body | Enum | X | 認証プラグイン<br/>- NATIVE: `mysql_native_password認証`<br/>- ED25519: `ed25519認証(MariaDB専用)` |
+| tlsOption | Body | Enum | X | 証明書オプション<br/>- NONE: `TLS未使用`<br/>- SSL: `SSL認証`<br/>- X509: `X509証明書認証` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンス削除保護設定を変更する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DBインスタンス削除保護設定を変更する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useDeletionProtection | Body | Boolean | O | 削除保護の有無 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスを強制再起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | DBインスタンスを強制再起動する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### 高可用性情報の照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 高可用性情報の照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | 高可用性の使用有無<br/>- デフォルト値: `false` |
+| haStatus | Body | Enum | 高可用性の状態<br/>- CREATED: `作成済み`<br/>- STABLE: `正常`<br/>- PAUSING: `一時停止中`<br/>- DISABLE: `停止`<br/>- DISABLE_MASTER_IN_REPLICATION: `マスターの異常なレプリケーション検知による高可用性(HA)の中断`<br/>- DISABLE_MHA_PROCESS: `高可用性(HA)プロセスの中断`<br/>- DISABLE_REPLICATION_STOP: `レプリケーション中断による高可用性(HA)の中断`<br/>- DISABLE_REPLICATION_DELAY: `レプリケーション遅延による高可用性(HA)の中断`<br/>- FAILOVER_STARTED: `フェイルオーバー開始`<br/>- FAILOVER_FAILED: `フェイルオーバー失敗`<br/>- FAILOVER_COMPLETED: `フェイルオーバー完了`<br/>- DELETED: `削除済み`<br/>- PAUSED: `一時停止`<br/>- PAUSED_DUE_TO_TASK: `タスクによる一時停止`<br/>- MASTER_FAILURE_DETECTION: `マスター障害検知` |
+| pingInterval | Body | Number | Ping間隔(秒) |
+| pingType | Body | String | Pingタイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | 高可用性の修正 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useHighAvailability | Body | Boolean | O | 高可用性を使用するかどうか |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長: `1`<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を一時停止する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | 高可用性の一時停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を復旧する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | 高可用性の復旧 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を再開する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | 高可用性の再開 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 高可用性を分離する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | 高可用性の分離 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### ログファイルリスト表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | ログファイルリスト表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | ログファイルリスト |
+| logFiles.logFileName | Body | String | ログファイル名 |
+| logFiles.logFileType | Body | Enum | ログファイルタイプ種類<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | ログファイルサイズ(Byte) |
+| logFiles.createdYmdt | Body | DateTime | 作成日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### ログファイルのエクスポート
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | ログファイルのエクスポート |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | ログファイル名リスト |
+| tenantId | Body | String | O | ログファイルが保存されるオブジェクトストレージのテナントID<br/>- 最小長: `32`<br/>- 最大長: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | ログファイルが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | ログファイルが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるログファイルのパス |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### ログファイルの内容照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | ログファイルの内容照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| logFileName | URL | UUID | O | ログファイル名 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| content | Body | String | ログファイルの内容(最大65533 bytes) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスメンテナンスリストを表示する
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | DBインスタンスメンテナンスリストを表示する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | メンテナンスリストの件数 |
+| maintenances | Body | Array | メンテナンスリスト |
+| maintenances.maintenanceId | Body | UUID | メンテナンスID |
+| maintenances.dbInstanceId | Body | UUID | DBインスタンスID |
+| maintenances.category | Body | Enum | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| maintenances.description | Body | String | メンテナンスの説明 |
+| maintenances.type | Body | Enum | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| maintenances.payload | Body | Object | メンテナンスタイプに応じたPayload |
+| maintenances.required | Body | Boolean | メンテナンスが必須かどうか |
+| maintenances.deadlineYmdt | Body | DateTime | メンテナンスの強制適用日時 |
+| maintenances.status | Body | Enum | メンテナンスのステータス<br/>- PENDING: `待機`<br/>- READY: `準備`<br/>- RUNNING: `実行中`<br/>- COMPLETED: `完了`<br/>- FAILED: `失敗`<br/>- EXCLUDED: `除外`<br/>- DELETED: `削除`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | メンテナンスの実行タイプ<br/>- SCHEDULED: `予約実行(メンテナンス期間中の自動実行)`<br/>- MANUAL: `手動実行(即時実行)`<br/>- FORCED: `強制実行(デッドライン超過後の自動実行)` |
+| maintenances.addedYmdt | Body | DateTime | メンテナンススケジュール登録日時 |
+| maintenances.executionStartedYmdt | Body | DateTime | メンテナンス開始日時 |
+| maintenances.executionCompletedYmdt | Body | DateTime | メンテナンス終了日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンスを即時実行する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | DBインスタンスメンテナンスを即時実行する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| configId | Body | String | O | 設定ID |
+| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | Body | String | X | メンテナンスの説明 |
+| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスメンテナンスを予約する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | DBインスタンスメンテナンスを予約する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| configId | Body | String | O | 設定ID |
+| category | Body | Enum | O | メンテナンスカテゴリ<br/>- USER: `ユーザーメンテナンスカテゴリ`<br/>- PROVIDER: `Providerメンテナンスカテゴリ`<br/>- AUTO: `自動メンテナンスカテゴリ` |
+| description | Body | String | X | メンテナンスの説明 |
+| type | Body | Enum | O | メンテナンスタイプ<br/>- UPDATE_DB_INSTANCE: `DBインスタンスの修正(スペック変更、ポート変更、パラメータグループ変更)`<br/>- UPGRADE_ENGINE_VERSION: `エンジンバージョンアップグレード`<br/>- APPLY_CHANGE_PARAMETER: `パラメータグループのパラメータ変更`<br/>- UPGRADE_OS: `OSバージョンアップグレード`<br/>- PATCH_SECURITY: `セキュリティアップデート`<br/>- MIGRATION: `ハイパーバイザーメンテナンスのためのマイグレーション`<br/>- CLEANUP_STORAGE: `ストレージの整理` |
+| payload | Body | String | O | メンテナンスタイプに応じたPayload |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBインスタンスメンテナンスを削除する
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | DBインスタンスメンテナンスを削除する |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| maintenanceId | URL | UUID | O | メンテナンスID |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+### ネットワーク情報表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | ネットワーク情報表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | DBインスタンスを作成するアベイラビリティゾーン |
+| subnet | Body | Object | サブネットオブジェクト |
+| subnet.subnetId | Body | UUID | サブネットの識別子 |
+| subnet.subnetName | Body | String | サブネットを識別できる名前 |
+| subnet.subnetCidr | Body | String | サブネットのCIDR |
+| endPoints | Body | Array | 接続情報リスト |
+| endPoints.domain | Body | String | ドメイン |
+| endPoints.ipAddress | Body | String | IPアドレス |
+| endPoints.endPointType | Body | String | 接続情報タイプ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### ネットワーク情報を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | ネットワーク情報を修正する |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| usePublicAccess | Body | Boolean | O | 外部接続可否 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを昇格する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | DBインスタンスの昇格 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスの再構築
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | DBインスタンスの再構築 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスを複製する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | DBインスタンスの複製 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できる名前<br/>- 最小の長さ: `1`<br/>- 最大の長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大の長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子 |
+| dbPort | Body | Number | X | DBポート<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Body | Object | O | ネットワーク情報オブジェクト |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否 |
+| network.availabilityZone | Body | Enum | O | DBインスタンスを作成するアベイラビリティゾーン |
+| storage | Body | Object | X | ストレージ情報オブジェクト |
+| storage.storageType | Body | Enum | X | データストレージタイプ |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | X | バックアップ情報オブジェクト |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか |
+| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
     "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを再起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | DBインスタンスの再起動 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| useOnlineFailover | Body | Boolean | X | フェイルオーバーを利用した再起動を行うかどうか<br/>- デフォルト値: `false` |
+| executeBackup | Body | Boolean | X | 現時点でバックアップを行うかどうか<br/>- デフォルト値: `false` |
+| waitReplicationDelay | Body | Boolean | X | レプリケーション遅延解消待機を行うかどうか<br/>- デフォルト値: `false` |
+| useReadOnly | Body | Boolean | X | 書き込み負荷のブロック<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB インスタンス復元情報照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB インスタンス復元情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 最古の復元可能時間 |
+| latestRestorableYmdt | Body | DateTime | 最新の復元可能時間 |
+| restorableBackups | Body | Array | 復元可能なバックアップリスト |
+| restorableBackups.backup | Body | Object | バックアップ情報オブジェクト |
+| restorableBackups.backup.backupId | Body | UUID | バックアップの識別子 |
+| restorableBackups.backup.backupName | Body | String | バックアップ名 |
+| restorableBackups.backup.backupStatus | Body | Enum | バックアップ状態<br/>- BACKING_UP: `バックアップ中(スピナー)`<br/>- VERIFYING: `検証中(スピナー)`<br/>- COMPLETED: `使用可能(緑アイコン)`<br/>- DELETING: `削除中(スピナー)`<br/>- DELETED: `削除済み(グレーアイコン)`<br/>- ERROR: `エラー(赤アイコン)` |
+| restorableBackups.backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| restorableBackups.backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
+| restorableBackups.backup.dbVersion | Body | Enum | DBエンジンタイプ |
+| restorableBackups.backup.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | バックアップサイズ |
+| restorableBackups.backup.useBackupLock | Body | Boolean | テーブルロックを使用するかどうか |
+| restorableBackups.backup.failoverCount | Body | Number | フェイルオーバー回数 |
+| restorableBackups.backup.binLogFileName | Body | String | バイナリログファイル名 |
+| restorableBackups.backup.binLogPosition | Body | Object | バイナリログファイル位置 |
+| restorableBackups.backup.createdYmdt | Body | DateTime | バックアップ作成日時 |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | バックアップ更新日時 |
+| restorableBackups.restorableBinLogs | Body | Array | 該当バックアップを利用して復元可能なバイナリログ名リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "backup": {
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "MYSQL_V8036",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
+            "restorableBinLogs": []
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 復元される最後のクエリ照会
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 復元される最後のクエリ照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | クエリ実行日時 |
+| lastQuery | Body | String | 最後に実行したクエリ |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+### DBインスタンスの復元
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | DBインスタンスの復元 |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスに対する追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未入力時は原本インスタンスの仕様が適用されます。 |
+| dbPort | Body | Number | X | DBポート |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| storage | Body | Object | X | ストレージ情報オブジェクト。未入力時は原本インスタンスのストレージ設定が適用されます。 |
+| storage.storageType | Body | Enum | X | ストレージタイプ。未入力時は原本インスタンスのストレージタイプが適用されます。 |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未入力時は原本インスタンスのストレージサイズが適用されます。<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| network | Body | Object | X | ネットワーク情報オブジェクト。未入力時は原本インスタンスのネットワーク設定が適用されます。 |
+| network.subnetId | Body | UUID | X | サブネットの識別子。未入力時は原本インスタンスの値を使用します。 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未入力時はランダムに選択されます。 |
+| backup | Body | Object | X | バックアップ情報オブジェクト。未入力時は原本インスタンスのバックアップ設定が適用されます。 |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未入力時は原本インスタンスのバックアップ保管期間が適用されます。<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか<br/>- デフォルト値: `true` |
+| backup.backupSchedules | Body | Array | X | 予定された自動バックアップリスト。未入力時は原本インスタンスのバックアップスケジュールが適用されます。 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+| restore | Body | Object | O | 復元情報オブジェクト |
+| restore.restoreType | Body | Enum | O | 復元タイプの種類<br/>- TIMESTAMP: `復元可能な時間内の時間を利用した時点復元タイプ`<br/>- BINLOG: `復元可能なバイナリログ位置を利用した時点復元タイプ`<br/>- BACKUP: `既存に作成したバックアップを利用したスナップショット復元タイプ` |
+| restore.binLog.binLogFileName | Body | String | X | 復元に使用するバイナリログ名 |
+| restore.binLog.binLogPosition | Body | Object | X | 復元に使用するバイナリログ位置 |
+| useDefaultNotification | Body | Boolean | X | 基本アラームを使用するかどうか<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未入力時は原本インスタンスのパラメータグループが適用されます。 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト。未入力時は原本インスタンスのセキュリティグループが適用されます。 |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+#### Timestampを利用した時点復元時、リクエスト(restoreTypeが`TIMESTAMP`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DBインスタンス復元日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+復元情報照会で照会した最新の復元可能な時間以前に対してのみ復元が可能です。
+
+#### バイナリログを利用した時点復元時、リクエスト(restoreTypeが`BINLOG`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+| restore.binLog | Body | Object | X | バイナリログ情報オブジェクト |
+
+バイナリログを利用した時点復元時、基準バックアップのバイナリログファイルおよび位置を基準に、その後に記録されたログに対して復元が可能です。
+
+#### バックアップを利用した復元時、リクエスト(restoreTypeが`BACKUP`の場合)
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 復元に使用するバックアップの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを起動する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | DBインスタンスの起動 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBインスタンスを停止する
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | DBインスタンスの停止 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### ストレージ情報を表示
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | ストレージ情報を表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| storageType | Body | String | データストレージタイプ |
+| storageSize | Body | Number | データストレージサイズ(GB) |
+| storageStatus | Body | Enum | データストレージの現在状態<br/>- DELETED: `削除済み`<br/>- PENDING_DELETION: `削除猶予中`<br/>- DELETION_RESERVED: `削除予約済み(スナップショット整理待ち)`<br/>- DETACHED: `取り外し済み`<br/>- ATTACHED: `割り当て済み` |
+| storageAutoscale | Body | Object | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | ストレージ自動拡張を行うかどうか |
+| storageAutoscale.threshold | Body | Number | 自動拡張条件(%) |
+| storageAutoscale.maxStorageSize | Body | Number | 自動拡張最大サイズ(GB) |
+| storageAutoscale.cooldownTime | Body | Number | 自動拡張クールダウン時間(分) |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
     }
 }
 ```
@@ -3012,6 +3539,86 @@ GET /v4.0/backups/{backupId}
 
 ---
 
+### ストレージ情報を修正する
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | ストレージ情報を修正する |
+
+#### 共通リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DBインスタンスの識別子 |
+| storageSize | Body | Number | O | データストレージサイズ(GB)<br/>- 最大値: `2048` |
+| storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+## バックアップ
+
+### バックアップ状態
+
+| 状態           | 説明           |
+|--------------|--------------|
+| `BACKING_UP` | バックアップ中の場合     |
+| `COMPLETED`  | バックアップが完了している場合   |
+| `DELETING`   | バックアップが削除中の場合 |
+| `DELETED`    | バックアップが削除されている場合   |
+| `ERROR`      | エラーが発生した場合   |
+
 ### バックアップリスト照会
 
 ```http
@@ -3020,37 +3627,30 @@ GET /v4.0/backups
 
 #### 必要権限
 
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.List | バックアップリスト照会 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前         | 種類  | 形式   | 必須 | 説明                                                     |
-|-------------------|-------|----------|----|------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| backupType   | Query | Enum   | X  | バックアップタイプ<br/>- `AUTO`:自動<br/>- `MANUAL`:手動<br/>- デフォルト値:全体 |
-| dbInstanceId | Query | UUID   | X  | 原本DBインスタンスの識別子                                        |
-| dbVersion    | Query | Enum   | X  | DBエンジンタイプ                                               |
-
 #### レスポンス
 
-| 名前                 | 種類 | 形式     | 説明                              |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 全バックアップリスト数                     |
-| backups              | Body | Array    | バックアップリスト                           |
-| backups.backupId     | Body | UUID     | バックアップの識別子                         |
-| backups.backupName   | Body | String   | バックアップを識別できる名前                  |
-| backups.backupStatus | Body | Enum     | バックアップの現在状態                       |
-| backups.dbInstanceId | Body | UUID     | 原本DBインスタンスの識別子                 |
-| backups.dbVersion    | Body | Enum     | DBエンジンタイプ                        |
-| backups.backupType   | Body | Enum     | バックアップタイプ                           |
-| backups.backupSize   | Body | Number   | バックアップのサイズ(Byte)                      |
-| createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全バックアップリスト数 |
+| backups | Body | Array | バックアップリスト |
+| backups.backupId | Body | UUID | バックアップの識別子 |
+| backups.backupName | Body | String | バックアップを識別できる名前 |
+| backups.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backups.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backups.dbVersion | Body | Enum | DBエンジンタイプ |
+| backups.utilVersion | Body | String | ユーティリティバージョン |
+| backups.backupType | Body | Enum | バックアップタイプ<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | バックアップのサイズ(Byte) |
+| backups.createdYmdt | Body | DateTime | 作成日時 |
+| backups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3065,15 +3665,16 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3092,89 +3693,182 @@ POST /v4.0/backups
 
 #### 必要権限
 
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Create | バックアップの作成 |
 
-#### 共通リクエスト
-
-| 名前             | 種類 | 形式   | 必須 | 説明                                                                                         |
-|------------------|------|--------|----|--------------------------------------------------------------------------------------------|
-| backupName       | Body | String | O  | バックアップを識別できる名前                                                                             |
-| backupMethodType | Body | Enum | O | バックアップ方式タイプ種類<br/>- `FULL`：全体バックアップ<br/>- `INCREMENTAL`：増分バックアップ<br/>- `SNAPSHOT`：スナップショットバックアップ |
-
-#### 全体バックアップ(backupMethodTypeが`FULL`の場合)
-
-| 名前         | 種類 | 形式 | 必須 | 説明         |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DBインスタンスの識別子 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
-#### 増分バックアップ(backupMethodTypeが`INCREMENTAL`の場合)
-
-| 名前         | 種類 | 形式 | 必須 | 説明       |
-|--------------|------|------|----|------------|
-| baseBackupId | Body | UUID | O  | 基準バックアップの識別子 |
-
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-
-#### スナップショットバックアップ(backupMethodTypeが`SNAPSHOT`の場合)
+#### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O | DBインスタンスの識別子 |
-
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | バックアップを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| baseBackupId | Body | UUID | X | 原本バックアップの識別子 |
+| dbInstanceId | Body | UUID | X | DBインスタンスの識別子 |
+| backupMethodType | Body | Enum | O | バックアップ方式タイプ<br/>- FULL: `全体バックアップ`<br/>- INCREMENTAL: `増分バックアップ`<br/>- SNAPSHOT: `スナップショットバックアップ` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップの削除
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | バックアップの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### バックアップ詳細照会
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | バックアップ詳細照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| backup | Body | Object | バックアップ詳細情報 |
+| backup.backupId | Body | UUID | バックアップの識別子 |
+| backup.regionCode | Body | Enum | リージョンコード<br/>- KR1: `韓国(パンギョ)` |
+| backup.backupName | Body | String | バックアップを識別できる名前 |
+| backup.backupStatus | Body | Enum | バックアップの現在状態<br/>- BACKING_UP: `バックアップ中 (スピナー)`<br/>- VERIFYING: `検証中 (スピナー)`<br/>- COMPLETED: `使用可能 (緑色アイコン)`<br/>- DELETING: `削除中 (スピナー)`<br/>- DELETED: `削除済み (グレーアイコン)`<br/>- ERROR: `エラー (赤色アイコン)` |
+| backup.dbInstanceId | Body | UUID | 原本DBインスタンスの識別子 |
+| backup.dbInstanceName | Body | String | 原本DBインスタンスの名前 |
+| backup.dbVersion | Body | Enum | DBエンジンバージョン |
+| backup.utilVersion | Body | String | ユーティリティバージョン |
+| backup.backupType | Body | Enum | バックアップタイプ(AUTO、MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | バックアップ方式(FULL、SNAPSHOT、INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | バックアップファイルタイプ<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | バックアップのサイズ(Byte) |
+| backup.isReplicable | Body | Boolean | レプリケーション可否 |
+| backup.binLogFileName | Body | String | バイナリログファイル名 |
+| backup.binLogPosition | Body | Object | バイナリログ位置 |
+| backup.createdYmdt | Body | DateTime | 作成日時 |
+| backup.updatedYmdt | Body | DateTime | 修正日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "MYSQL_V8036",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3186,31 +3880,31 @@ POST /v4.0/backups/{backupId}/export
 
 #### 必要権限
 
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Export | バックアップエクスポート |
 
 #### リクエスト
 
-| 名前            | 種類 | 形式   | 必須 | 説明                        |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | バックアップの識別子                   |
-| tenantId        | Body | String | O  | バックアップが保存されるオブジェクトストレージのテナントID   |
-| username        | Body | String | O  | NHN Cloud会員またはIAMメンバーID          |
-| password        | Body | String | O  | バックアップが保存されるオブジェクトストレージのAPIパスワード |
-| targetContainer | Body | String | O  | バックアップが保存されるオブジェクトストレージのコンテナ   |
-| objectPath      | Body | String | O  | コンテナに保存されるバックアップのパス          |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | バックアップが保存されるオブジェクトストレージのテナントID<br/>- 最小長さ: `32`<br/>- 最大長さ: `32` |
+| username | Body | String | O | NHN CloudアカウントまたはIAMメンバーID |
+| password | Body | String | O | バックアップが保存されるオブジェクトストレージのAPIパスワード |
+| targetContainer | Body | String | O | バックアップが保存されるオブジェクトストレージのコンテナ |
+| objectPath | Body | String | O | コンテナに保存されるバックアップのパス |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3219,12 +3913,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
-> [注意]
-> 手動バックアップの場合、バックアップが行われたDBインスタンスが存在しない場合、バックアップをオブジェクトストレージにエクスポートすることができません。
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3236,70 +3944,95 @@ POST /v4.0/backups/{backupId}/restore
 
 #### 必要権限
 
-| 権限名                                      | 説明    |
-|--------------------------------------------|---------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:Backup.Restore | バックアップの復元 |
 
-#### リクエスト
+#### 共通リクエスト
 
-| 名前                                         | 種類 | 形式    | 必須 | 説明                                                                |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O  | バックアップの識別子                                                           |
-| dbInstanceName                               | Body | String  | O  | DBインスタンスを識別できる マスター名                                           |
-| dbInstanceCandidateName                      | Body | String  | X  | DBインスタンスを識別できる 予備マスター名(高可用性を使用する場合の必須値)                         |
-| description                                  | Body | String  | X  | DBインスタンスの追加情報                                                 |
-| dbFlavorId                                   | Body | UUID    | X  | DBインスタンス仕様の識別子<br/>- デフォルト値：原本DBインスタンスの値                                                   |
-| dbPort | Body | Integer | X | DBポート<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`3306`<br/>- 最大値：`43306` |
-| parameterGroupId                             | Body | UUID    | X  | パラメータグループの識別子<br/>- デフォルト値：原本DBインスタンスの値                                                      |
-| dbSecurityGroupIds                           | Body | Array   | X  | DBセキュリティグループの識別子リスト                                                  ||network|Body|Object|O|ネットワーク情報オブジェクト|
-| userGroupIds                                 | Body | Array   | X  | ユーザーグループの識別子リスト                                                    |
-| useHighAvailability                          | Body | Boolean | X  | 高可用性を使用するかどうか<br/>- デフォルト値: `false`                                       |
-| pingInterval                                 | Body | Number  | X  | 高可用性使用時Ping間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
-| pingType                                             | Body | Enum    | X  | 高可用性使用時のPingタイプ<br/>- デフォルト値: `INSERT`<br/>- `INSERT`<br/>- `SELECT`      |
-| useDefaultNotification                       | Body | Boolean | X  | 基本通知を使用するかどうか<br/>- デフォルト値: `false`                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 削除保護の有無<br/>- デフォルト値: `false`                                         | 
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query分析を行うかどうか<br/>- デフォルト値: `true`                                  |
-| network                                      | Body | Object  | X  | ネットワーク情報オブジェクト                                                        |
-| network.subnetId | Body | UUID | X | サブネットの識別子<br/>- デフォルト値：原本DBインスタンスの値 |
-| network.usePublicAccess                      | Body | Boolean | X  | 外部接続可否<br/>- デフォルト値: `false`                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DBインスタンスを作成するアベイラビリティゾーン<br/>- 例: `kr-pub-a`<br/>- デフォルト値：ランダム選択                            |
-| storage                                      | Body | Object  | X  | データストレージ情報オブジェクト                                                    |    
-| storage.storageType | Body | Enum | X | データストレージタイプ<br/>- デフォルト値：原本DBインスタンスの値<br/>- 例：`General SSD` |
-| storage.storageSize | Body | Number | X | データストレージサイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`20`<br/>- 最大値：`2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | データストレージ自動拡張オブジェクト                                                 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値：原本DBインスタンスの値 |
-| storage.storageAutoscale.threshold | Body | Number | X | 自動拡張条件(%)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`50`<br/>- 最大値：`95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | X | 自動拡張最大サイズ(GB)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最大値：`4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | X | 自動拡張クールダウン時間(分)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`10`<br/>- 最大値：`1440` |
-| backup                                       | Body | Object  | X  | バックアップ情報オブジェクト                                                          |
-| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)<br/>- デフォルト値：原本DBインスタンスの値<br/>- 最小値：`0`<br/>- 最大値：`730` |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | クエリ遅延待機時間(秒)<br/>- デフォルト値: `1800`<br/>- 最小値: `0`<br/>- 最大値: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | バックアップ再試行回数<br/>- デフォルト値: `0`<br/>- 最小値: `0`<br/>- 最大値: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | テーブルロックを使用するかどうか<br/>- デフォルト値: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 予定された自動バックアップリスト<br/>- デフォルト値：原本DBインスタンスの値                                                                                                                                                                                                                 |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | バックアップ開始時刻<br/>- 例: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | バックアップDuration<br/>バックアップ開始時刻からDuration内に自動バックアップが実行されます。<br/>- `HALF_AN_HOUR`: 30分<br/>- `ONE_HOUR`: 1時間<br/>- `ONE_HOUR_AND_HALF`: 1時間30分<br/>- `TWO_HOURS`: 2時間<br/>- `TWO_HOURS_AND_HALF`: 2時間30分<br/>- `THREE_HOURS`: 3時間 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | DBインスタンスを識別できるマスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| description | Body | String | X | DBインスタンスの追加情報<br/>- 最大長さ: `100` |
+| dbFlavorId | Body | UUID | X | DBインスタンス仕様の識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbPort | Body | Number | X | DBポート。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: 3306、最大値: 43306 |
+| parameterGroupId | Body | UUID | X | パラメータグループの識別子。未指定の場合、原本インスタンスの値を使用 |
+| dbSecurityGroupIds | Body | Array | X | DBセキュリティグループの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+| useHighAvailability | Body | Boolean | X | 高可用性を使用するかどうか<br/>- デフォルト値: `false` |
+| pingInterval | Body | Number | X | 高可用性使用時のPing間隔(秒)<br/>- デフォルト値: `3`<br/>- 最小値: `1`<br/>- 最大値: `600` |
+| useDefaultNotification | Body | Boolean | X | 基本通知を使用するかどうか<br/>- デフォルト値: `false` |
+| useDeletionProtection | Body | Boolean | X | 削除保護の有無<br/>- デフォルト値: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query分析を行うかどうか<br/>- デフォルト値: `true` |
+| network | Body | Object | X | ネットワーク情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| network.subnetId | Body | UUID | X | サブネットの識別子。未指定の場合、原本インスタンスの値を使用 |
+| network.usePublicAccess | Body | Boolean | X | 外部接続可否<br/>- デフォルト値: `false` |
+| network.availabilityZone | Body | Enum | X | DBインスタンスを作成するアベイラビリティゾーン。未指定の場合、ランダム選択 |
+| storage | Body | Object | X | ストレージ情報オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageType | Body | Enum | X | ストレージタイプ。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageSize | Body | Number | X | データストレージサイズ(GB)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `20` |
+| storage.storageAutoscale | Body | Object | X | データストレージ自動拡張オブジェクト。未指定の場合、原本インスタンスの値を使用 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | ストレージ自動拡張を行うかどうか<br/>- デフォルト値: `false` |
+| backup | Body | Object | X | バックアップ情報オブジェクト。未指定の場合、原本インスタンスのバックアップ設定を使用 |
+| backup.backupPeriod | Body | Number | X | バックアップ保管期間(日)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `730` |
+| backup.backupRetryCount | Body | Number | X | バックアップ再試行回数。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | クエリ遅延待機時間(秒)。未指定の場合、原本インスタンスの値を使用<br/>- 最小値: `0`<br/>- 最大値: `21600` |
+| backup.replicationRegion | Body | Enum | X | バックアップ複製リージョン<br/>- KR1: `韓国(パンギョ)` |
+| backup.useBackupLock | Body | Boolean | X | テーブルロックを使用するかどうか。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules | Body | Array | X | バックアップスケジュールリスト。未指定の場合、原本インスタンスの値を使用 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | バックアップ開始時刻 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | バックアップDuration<br/>- HALF_AN_HOUR: `30分`<br/>- ONE_HOUR: `1時間`<br/>- ONE_HOUR_AND_HALF: `1時間30分`<br/>- TWO_HOURS: `2時間`<br/>- TWO_HOURS_AND_HALF: `2時間30分`<br/>- THREE_HOURS: `3時間` |
+
+#### 高可用性使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DBインスタンスを識別できる予備マスター名<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+
+#### ストレージ自動拡張使用時
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 自動拡張条件(%)<br/>- 最小値: `50`<br/>- 最大値: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 自動拡張最大サイズ(GB)<br/>- 最大値: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 自動拡張クールダウン時間(分)<br/>- 最小値: `10`<br/>- 最大値: `1440` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
         "storageType": "General SSD",
-        "storageSize": 20
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -3315,50 +4048,38 @@ POST /v4.0/backups/{backupId}/restore
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
----
+<details><summary>例</summary>
+<p>
 
-### バックアップを削除する
-
-```http
-DELETE /v4.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 必要権限
-
-| 権限名                                     | 説明    |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | バックアップの削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前     | 種類 | 形式 | 必須 | 説明    |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | バックアップの識別子 |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+</p>
+</details>
 
 ---
-
 ## DBセキュリティグループ
 
 ### DBセキュリティグループ進行状態
 
-| 状態            | 説明         |
-|-----------------|--------------|
-| `NONE`          | 進行中の作業がない  |
-| `CREATING_RULE` | ルールポリシーの作成中 |
-| `UPDATING_RULE` | ルールポリシーの修正中 |
-| `DELETING_RULE` | ルールポリシーの削除中 |
+| 状態              | 説明               |
+|-----------------|------------------|
+| `NONE`          | 進行中の作業がない        |
+| `CREATING_RULE` | ルールポリシーの作成中      |
+| `UPDATING_RULE` | ルールポリシーの修正中      |
+| `DELETING_RULE` | ルールポリシーの削除中      |
 
 ### DBセキュリティグループリストを表示
 
@@ -3368,30 +4089,26 @@ GET /v4.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                            | 説明           |
-|--------------------------------------------------|----------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.List | DBセキュリティグループリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-
 #### レスポンス
 
-| 名前                                 | 種類 | 形式     | 説明                              |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DBセキュリティグループリスト                     |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                   |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前            |
-| dbSecurityGroups.description         | Body | String   | DBセキュリティグループの追加情報               |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態              |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | DBセキュリティグループリストの総数 |
+| dbSecurityGroups | Body | Array | DBセキュリティグループリスト |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
+| dbSecurityGroups.description | Body | String | DBセキュリティグループの追加情報 |
+| dbSecurityGroups.progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 作成日時 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3403,101 +4120,17 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DBセキュリティグループの詳細を表示
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明           |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | DBセキュリティグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類 | 形式 | 必須 | 説明          |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
-
-#### レスポンス
-
-| 名前                | 種類 | 形式     | 説明                                                                                                               |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DBセキュリティグループの識別子                                                                                                    |
-| dbSecurityGroupName | Body | String   | DBセキュリティグループを識別できる名前                                                                                             |
-| description         | Body | String   | DBセキュリティグループの追加情報                                                                                                |
-| progressStatus      | Body | Enum     | DBセキュリティグループの現在進行状態                                                                                               |
-| rules               | Body | Array    | DBセキュリティグループルールリスト                                                                                                   |
-| rules.ruleId        | Body | UUID     | DBセキュリティグループルールの識別子                                                                                                 |
-| rules.description   | Body | String   | DBセキュリティグループルールの追加情報                                                                                             |
-| rules.direction     | Body | Enum     | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                     |
-| rules.etherType     | Body | Enum     | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | ポートオブジェクト                                                                                                            |
-| rules.port.portType | Body | Enum     | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。<br/>- `PORT`:指定されたポート値に設定されます。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number   | 最小ポート範囲                                                                                                          |
-| rules.port.maxPort  | Body | Number   | 最大ポート範囲                                                                                                         |
-| rules.cidr          | Body | String   | 許可するトラフィックの遠隔ソース                                                                                                   |
-| rules.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
 }
 ```
 
@@ -3514,46 +4147,44 @@ POST /v4.0/db-security-groups
 
 #### 必要権限
 
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Create | DBセキュリティグループの作成 |
 
 #### リクエスト
 
-| 名前                | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DBセキュリティグループを識別できる名前                                                                                                                                                                |
-| description         | Body | String | X  | DBセキュリティグループの追加情報                                                                                                                                                                   |
-| rules               | Body | Array  | O  | DBセキュリティグループルールリスト                                                                                                                                                                         |
-| rules.description   | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| rules.direction     | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| rules.etherType     | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| rules.port.portType | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| rules.port.minPort  | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| rules.port.maxPort  | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+| rules | Body | Array | O | DBセキュリティグループルールリスト |
+| rules.direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Body | Object | O | ポートオブジェクト |
+| rules.port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| rules.port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | DBセキュリティグループルールの追加情報 |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
     "rules": [
         {
             "direction": "INGRESS",
             "etherType": "IPV4",
             "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
             },
-            "cidr": "0.0.0.0/0"
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
         }
     ]
 }
@@ -3564,48 +4195,9 @@ POST /v4.0/db-security-groups
 
 #### レスポンス
 
-| 名前              | 種類 | 形式 | 説明          |
-|-------------------|------|------|---------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
-
----
-
-### DBセキュリティグループを修正する
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
-
-#### リクエスト
-
-| 名前                | 種類 | 形式   | 必須 | 説明                  |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DBセキュリティグループの識別子       |
-| dbSecurityGroupName | Body | String | X  | DBセキュリティグループを識別できる名前 |
-| description         | Body | String | X  | DBセキュリティグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
 
 <details><summary>例</summary>
 <p>
@@ -3616,13 +4208,13 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
 </p>
 </details>
-
 
 ---
 
@@ -3634,21 +4226,66 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 必要権限
 
-| 権限名                                              | 説明          |
-|----------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroup.Delete | DBセキュリティグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前              | 種類 | 形式 | 必須 | 説明          |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DBセキュリティグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### DBセキュリティグループの詳細を表示
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | DBセキュリティグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | UUID | DBセキュリティグループの識別子 |
+| dbSecurityGroupName | Body | String | DBセキュリティグループを識別できる名前 |
+| description | Body | String | DBセキュリティグループの追加情報 |
+| progressStatus | Body | Enum | DBセキュリティグループの現在進行状態<br/>- NONE: `なし`<br/>- CREATING_RULE: `ルール作成中`<br/>- UPDATING_RULE: `ルール修正中`<br/>- DELETING_RULE: `ルール削除中`<br/>- APPLYING_DEFAULT_RULE: `デフォルトルール適用中` |
+| rules | Body | Array | DBセキュリティグループルールリスト |
+| rules.ruleId | Body | UUID | DBセキュリティグループルールの識別子 |
+| rules.description | Body | String | DBセキュリティグループルールの追加情報 |
+| rules.direction | Body | Enum | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| rules.etherType | Body | Enum | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| rules.port | Body | Object | ポートオブジェクト |
+| rules.port.portType | Body | Enum | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| rules.port.minPort | Body | Number | 最小ポート範囲 |
+| rules.port.maxPort | Body | Number | 最大ポート範囲 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 作成日時 |
+| rules.updatedYmdt | Body | DateTime | 修正日時 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3659,7 +4296,114 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DBセキュリティグループを修正する
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | DBセキュリティグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DBセキュリティグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | DBセキュリティグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### DBセキュリティグループルールを削除する
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | DBセキュリティグループルールの削除 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -3676,26 +4420,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 必要権限
 
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Create | DBセキュリティグループルールの作成 |
 
 #### リクエスト
 
-| 名前              | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                          |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Body | Object | O | ポートオブジェクト |
+| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 <details><summary>例</summary>
 <p>
@@ -3705,11 +4446,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3718,9 +4460,26 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3732,27 +4491,24 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### 必要権限
 
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:DbSecurityGroupRule.Modify | DBセキュリティグループルールの修正 |
 
 #### リクエスト
 
-| 名前              | 種類 | 形式   | 必須 | 説明                                                                                                                                                                                     |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DBセキュリティグループの識別子                                                                                                                                                                          |
-| ruleId            | URL  | UUID   | O  | DBセキュリティグループルールの識別子                                                                                                                                                                       |
-| description       | Body | String | X  | DBセキュリティグループルールの追加情報                                                                                                                                                                |
-| direction         | Body | Enum   | O  | 通信方向<br/>- `INGRESS`:受信<br/>- `EGRESS`:送信                                                                                                                                           |
-| etherType         | Body | Enum   | O  | Etherタイプ<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | ポートオブジェクト                                                                                                                                                                                  |
-| port.portType     | Body | Enum   | O  | ポートタイプ<br/>- `DB_PORT`:各DBインスタンスポート値に設定されます。 `minPort`値と`maxPort`値を必要としません。<br/>- `PORT`:指定されたポート値に設定されます。 `minPort`値と`maxPort`値が同じでなければなりません。<br/>- `PORT_RANGE`:指定されたポート範囲に設定されます。 |
-| port.minPort      | Body | Number | X  | 最小ポート範囲<br/>- 最小値: 1                                                                                                                                                                 |
-| port.maxPort      | Body | Number | X  | 最大ポート範囲<br/>- 最大値: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 許可するトラフィックの遠隔ソース<br/>- 例: `1.1.1.1/32`                                                                                                                                                    |
-
-> [注意]
-> DBポートは送信方向(アウトバウンド)には設定できません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 通信方向<br/>- INGRESS: `受信`<br/>- EGRESS: `送信` |
+| etherType | Body | Enum | O | Etherタイプ<br/>- IPV4: `IPv4形式`<br/>- IPV6: `IPv6形式` |
+| port | Body | Object | O | ポートオブジェクト |
+| port.portType | Body | Enum | O | ポートタイプ<br/>- ALL: `ポート範囲全体(ユーザーコンソールでは使用しない)`<br/>- PORT: `特定ポート`<br/>- DB_PORT: `DB受信ポート`<br/>- PORT_RANGE: `ポート範囲` |
+| port.minPort | Body | Number | X | 最小ポート範囲<br/>- 最小値: `3306` |
+| port.maxPort | Body | Number | X | 最大ポート範囲<br/>- 最大値: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DBセキュリティグループルールの追加情報<br/>- 最大長: `200` |
 
 <details><summary>例</summary>
 <p>
@@ -3762,9 +4518,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
     "direction": "INGRESS",
     "etherType": "IPV4",
     "port": {
-        "portType": "DB_PORT"
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
     },
-    "cidr": "0.0.0.0/0"
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
 }
 ```
 
@@ -3773,41 +4532,28 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### レスポンス
 
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | リクエストした作業の識別子 |
 
----
+<details><summary>例</summary>
+<p>
 
-### DBセキュリティグループルールを削除する
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 必要権限
-
-| 権限名                                                  | 説明             |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DBセキュリティグループルールの削除 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類  | 形式  | 必須 | 説明                |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DBセキュリティグループの識別子     |
-| ruleIds           | Query | Array | O  | DBセキュリティグループルールの識別子リスト |
-
-#### レスポンス
-
-| 名前  | 種類 | 形式 | 説明        |
-|-------|------|------|-------------|
-| jobId | Body | UUID | リクエストした作業の識別子 |
+</p>
+</details>
 
 ---
-
 ## パラメータグループ
 
 ### パラメータグループリストを表示
@@ -3818,30 +4564,28 @@ GET /v4.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                           | 説明          |
-|-------------------------------------------------|---------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.List | パラメータグループリスト表示 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前      | 種類  | 形式 | 必須 | 説明     |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DBエンジンタイプ |
-
 #### レスポンス
 
-| 名前                                 | 種類 | 形式     | 説明                                                              |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | パラメータグループリスト                                                      |
-| parameterGroups.parameterGroupId     | Body | UUID     | パラメータグループの識別子                                                    |
-| parameterGroups.parameterGroupName   | Body | String   | パラメータグループを識別できる名前                                            |
-| parameterGroups.description          | Body | String   | パラメータグループの追加情報                                               |
-| parameterGroups.dbVersion            | Body | Enum     | DBエンジンタイプ                                                        |
-| parameterGroups.parameterGroupStatus | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要 |
-| parameterGroups.createdYmdt          | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | パラメータグループの総数 |
+| parameterGroups | Body | Array | パラメータグループリスト |
+| parameterGroups.parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroups.parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| parameterGroups.description | Body | String | パラメータグループの追加情報 |
+| parameterGroups.dbVersion | Body | Enum | DBエンジンタイプ |
+| parameterGroups.parameterGroupType | Body | Enum | パラメータグループタイプ<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameterGroups.createdYmdt | Body | DateTime | 作成日時 |
+| parameterGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -3853,15 +4597,17 @@ GET /v4.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3869,88 +4615,6 @@ GET /v4.0/parameter-groups
 
 </p>
 </details>
-
-
----
-
-### パラメータグループの詳細を表示
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                          | 説明          |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | パラメータグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-| 名前                          | 種類 | 形式     | 説明                                                                                                   |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | パラメータグループの識別子                                                                                         |
-| parameterGroupName            | Body | String   | パラメータグループを識別できる名前                                                                              |
-| description                   | Body | String   | パラメータグループの追加情報                                                                                 |
-| dbVersion                     | Body | Enum     | DBエンジンタイプ                                                                                             |
-| parameterGroupStatus          | Body | Enum     | パラメータグループの現在状態<br/>- `STABLE`:適用完了<br/>- `NEED_TO_APPLY`:適用必要                                    |
-| parameters                    | Body | Array    | パラメータリスト                                                                                              |
-| parameters.parameterId        | Body | UUID     | パラメータ識別子                                                                                             |
-| parameters.parameterFileGroup | Body | Enum     | パラメータファイルグループタイプ<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | パラメータ名                                                                                              |
-| parameters.fileParameterName  | Body | String   | パラメータファイル名                                                                                           |
-| parameters.value              | Body | String   | 現在設定されている値                                                                                     |
-| parameters.defaultValue       | Body | String   | デフォルト値                                                                                                  |
-| parameters.allowedValue       | Body | String   | 許可された値                                                                                         |
-| parameters.updateType         | Body | Enum     | 修正タイプ<br/>- `VARIABLE`:いつでも修正可能<br/>- `CONSTANT`:修正不可<br/>- `INIT_VARIABLE`: DBインスタンス作成時にのみ修正可能 |
-| parameters.applyType          | Body | Enum     | 適用タイプ<br/>- `SESSION`:セッション適用<br/>- `FILE`:設定ファイル適用(再起動必要)<br/>- `BOTH`:全体(再起動必要)                   |
-| createdYmdt                   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
 
 ---
 
@@ -3962,25 +4626,26 @@ POST /v4.0/parameter-groups
 
 #### 必要権限
 
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Create | パラメータグループの作成 |
 
 #### リクエスト
 
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-| dbVersion          | Body | Enum   | O  | DBエンジンタイプ           |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+| dbVersion | Body | Enum | O | DBエンジンタイプ |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -3989,89 +4654,10 @@ POST /v4.0/parameter-groups
 
 #### レスポンス
 
-| 名前             | 種類 | 形式 | 説明         |
-|------------------|------|------|--------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | parameterGroupId | Body | UUID | パラメータグループの識別子 |
 
----
-
-### パラメータグループをコピーする
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 必要権限
-
-| 権限名                                           | 説明         |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | パラメータグループコピーする |
-
-#### リクエスト
-
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子       |
-| parameterGroupName | Body | String | O  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前             | 種類 | 形式 | 説明         |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | パラメータグループの識別子 |
-
----
-
-### パラメータグループを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前               | 種類 | 形式   | 必須 | 説明                 |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | パラメータグループの識別子       |
-| parameterGroupName | Body | String | X  | パラメータグループを識別できる名前 |
-| description        | Body | String | X  | パラメータグループの追加情報   |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
 <details><summary>例</summary>
 <p>
 
@@ -4081,107 +4667,8 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### パラメータを修正する
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 必要権限
-
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
-
-#### リクエスト
-
-| 名前                           | 種類 | 形式   | 必須 | 説明         |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | パラメータグループの識別子 |
-| modifiedParameters             | Body | Array  | O  | 変更するパラメータリスト |
-| modifiedParameters.parameterId | Body | UUID   | O  | パラメータの識別子  |
-| modifiedParameters.value       | Body | String | O  | 変更するパラメータ値 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### パラメータグループをリセットする
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 必要権限
-
-| 権限名                                            | 説明          |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | パラメータグループのリセット |
-
-#### リクエスト
-
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4198,21 +4685,65 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### 必要権限
 
-| 権限名                                             | 説明         |
-|---------------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:ParameterGroup.Delete | パラメータグループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前             | 種類 | 形式 | 必須 | 説明         |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | パラメータグループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループの詳細を表示
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | パラメータグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+| parameterGroupName | Body | String | パラメータグループを識別できる名前 |
+| description | Body | String | パラメータグループの追加情報 |
+| dbVersion | Body | Enum | DBエンジンタイプ |
+| parameterGroupStatus | Body | Enum | パラメータグループの現在状態<br/>- STABLE: `適用完了`<br/>- NEED_TO_APPLY: `適用必要`<br/>- DELETED: `削除済み` |
+| parameters | Body | Array | パラメータリスト |
+| parameters.parameterId | Body | UUID | パラメータの識別子 |
+| parameters.parameterFileGroup | Body | Enum | パラメータファイルグループタイプ<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | パラメータ名 |
+| parameters.fileParameterName | Body | String | パラメータファイル名 |
+| parameters.value | Body | String | 現在設定されている値 |
+| parameters.defaultValue | Body | String | デフォルト値 |
+| parameters.allowedValue | Body | String | 許可された値 |
+| parameters.updateType | Body | Enum | 修正タイプ<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 適用タイプ<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4223,7 +4754,27 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4232,6 +4783,172 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ---
 
+### パラメータグループを修正する
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループをコピーする
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | パラメータグループコピーする |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | パラメータグループを識別できる名前<br/>- 最小長: `1`<br/>- 最大長: `100` |
+| description | Body | String | X | パラメータグループの追加情報<br/>- 最大長: `100` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | UUID | パラメータグループの識別子 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### パラメータを修正する
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | パラメータグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 変更するパラメータリスト |
+| modifiedParameters.parameterId | Body | UUID | O | パラメータの識別子 |
+| modifiedParameters.value | Body | String | O | 変更するパラメータ値 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
+
+### パラメータグループをリセットする
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | パラメータグループのリセット |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## ユーザーグループ
 
 ### ユーザーグループリストを表示
@@ -4242,8 +4959,8 @@ GET /v4.0/user-groups
 
 #### 必要権限
 
-| 権限名                                      | 説明         |
-|--------------------------------------------|--------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.List | ユーザーグループリスト表示 |
 
 #### リクエスト
@@ -4252,13 +4969,14 @@ GET /v4.0/user-groups
 
 #### レスポンス
 
-| 名前                     | 種類 | 形式     | 説明                              |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | ユーザーグループリスト                       |
-| userGroups.userGroupId   | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName | Body | String   | ユーザーグループを識別できる名前                |
-| userGroups.createdYmdt   | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | ユーザーグループリストの総数 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroups.createdYmdt | Body | DateTime | 作成日時 |
+| userGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4270,74 +4988,15 @@ GET /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### ユーザーグループの詳細を表示
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                     | 説明         |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | ユーザーグループ詳細表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前        | 種類 | 形式 | 必須 | 説明        |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
-
-#### レスポンス
-
-| 名前              | 種類 | 形式     | 説明                                                                                                      |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | ユーザーグループの識別子                                                                                             |
-| userGroupName     | Body | String   | ユーザーグループを識別できる名前                                                                                         |
-| userGroupTypeCode | Body | Enum     | ユーザーグループの種類 <br /> `ENTIRE`:プロジェクトメンバー全体を含むユーザーグループ <br /> `INDIVIDUAL_MEMBER`:特定のプロジェクトメンバーを含むユーザーグループ |
-| members           | Body | Array    | プロジェクトメンバーリスト                                                                                              |
-| members.memberId  | Body | UUID     | プロジェクトメンバーの識別子                                                                                            |
-| createdYmdt       | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4354,34 +5013,26 @@ POST /v4.0/user-groups
 
 #### 必要権限
 
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Create | ユーザーグループの作成 |
 
 #### リクエスト
 
-| 名前          | 種類 | 形式    | 必須 | 説明                                                      |
-|---------------|------|---------|----|-----------------------------------------------------------|
-| userGroupName | Body | String  | O  | ユーザーグループを識別できる名前                                     |
-| memberIds     | Body | Array   | O  | プロジェクトメンバーの識別子リスト <br /> `selectAll`がtrueの場合、該当フィールドの値は無視される |
-| selectAll     | Body | Boolean | X  | プロジェクトメンバー全員かどうか <br /> trueの場合、該当グループは全メンバーに対して設定される       |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | O | プロジェクトメンバーの識別子リスト |
+| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
 
 <details><summary>例</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4390,52 +5041,9 @@ POST /v4.0/user-groups
 
 #### レスポンス
 
-| 名前        | 種類 | 形式 | 説明        |
-|-------------|------|------|-------------|
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
 | userGroupId | Body | UUID | ユーザーグループの識別子 |
-
----
-
-### ユーザーグループを修正する
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | ユーザーグループの修正 |
-
-#### リクエスト
-
-| 名前          | 種類 | 形式    | 必須 | 説明                                               |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | ユーザーグループの識別子                                      |
-| userGroupName | Body | String  | X  | ユーザーグループを識別できる名前                                     |
-| memberIds     | Body | Array   | X  | プロジェクトメンバーの識別子リスト                                  |
-| selectAll     | Body | Boolean | X  | プロジェクトメンバー全員かどうか <br /> trueの場合、該当グループは全メンバーに対して設定される |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
 
 <details><summary>例</summary>
 <p>
@@ -4446,7 +5054,8 @@ PUT /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4463,19 +5072,55 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### 必要権限
 
-| 権限名                                        | 説明        |
-|----------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:UserGroup.Delete | ユーザーグループの削除 |
 
 #### リクエスト
 
-| 名前        | 種類 | 形式 | 必須 | 説明        |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### ユーザーグループの詳細を表示
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | ユーザーグループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| userGroupTypeCode | Body | Enum | ユーザーグループの種類<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | プロジェクトメンバーリスト |
+| members.memberId | Body | UUID | プロジェクトメンバーの識別子 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4486,7 +5131,17 @@ DELETE /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4495,6 +5150,46 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ---
 
+### ユーザーグループを修正する
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | ユーザーグループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | ユーザーグループを識別できる名前 |
+| memberIds | Body | Array | X | プロジェクトメンバーの識別子リスト |
+| selectAll | Body | Boolean | X | プロジェクトメンバー全員を含むかどうか<br/>- デフォルト値: `false` |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## 通知グループ
 
 ### 通知グループリストを表示
@@ -4505,8 +5200,8 @@ GET /v4.0/notification-groups
 
 #### 必要権限
 
-| 権限名                                              | 説明        |
-|----------------------------------------------------|-------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.List | 通知グループリスト表示 |
 
 #### リクエスト
@@ -4515,16 +5210,16 @@ GET /v4.0/notification-groups
 
 #### レスポンス
 
-| 名前                                     | 種類 | 形式     | 説明                              |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 通知グループリスト                        |
-| notificationGroups.notificationGroupId   | Body | UUID     | 通知グループの識別子                      |
-| notificationGroups.notificationGroupName | Body | String   | 通知グループを識別できる名前                  |
-| notificationGroups.notifyEmail           | Body | Boolean  | メール通知                           |
-| notificationGroups.notifySms             | Body | Boolean  | SMS通知                           |
-| notificationGroups.isEnabled             | Body | Boolean  | 有効かどうか                           |
-| notificationGroups.createdYmdt           | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | 通知グループリスト |
+| notificationGroups.notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroups.notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notificationGroups.notifyEmail | Body | Boolean | メール通知の有無 |
+| notificationGroups.notifySms | Body | Boolean | SMS通知の有無 |
+| notificationGroups.isEnabled | Body | Boolean | 有効かどうか |
+| notificationGroups.createdYmdt | Body | DateTime | 作成日時 |
+| notificationGroups.updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4538,13 +5233,13 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -4555,43 +5250,51 @@ GET /v4.0/notification-groups
 
 ---
 
-### アラームグループの詳細を表示
+### 通知グループを作成する
 
 ```http
-GET /v4.0/notification-groups/{notificationGroupId}
+POST /v4.0/notification-groups
 ```
 
 #### 必要権限
 
-| 権限名                                             | 説明        |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | 通知グループ詳細表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Create | 通知グループの作成 |
 
 #### リクエスト
 
-このAPIはリクエスト本文を要求しません。
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 通知グループを識別できる名前<br/>- 最小長さ: `1`<br/>- 最大長さ: `100` |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `true` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `true` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `true` |
+| dbInstanceIds | Body | Array | O | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | O | ユーザーグループの識別子リスト |
 
-| 名前                | 種類 | 形式 | 必須 | 説明       |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
 
 #### レスポンス
 
-| 名前                       | 種類 | 形式     | 説明                              |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 通知グループの識別子                      |
-| notificationGroupName      | Body | String   | 通知グループを識別できる名前                  |
-| notifyEmail                | Body | Boolean  | メール通知                           |
-| notifySms                  | Body | Boolean  | SMS通知                           |
-| isEnabled                  | Body | Boolean  | 有効かどうか                           |
-| dbInstances                | Body | Array    | 監視対象DBインスタンスリスト                |
-| dbInstances.dbInstanceId   | Body | UUID     | DBインスタンスの識別子                    |
-| dbInstances.dbInstanceName | Body | String   | DBインスタンスを識別できる名前                |
-| userGroups                 | Body | Array    | ユーザーグループリスト                       |
-| userGroups.userGroupId     | Body | UUID     | ユーザーグループの識別子                     |
-| userGroups.userGroupName   | Body | String   | ユーザーグループを識別できる名前                |
-| createdYmdt                | Body | DateTime | 作成日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 修正日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
 
 <details><summary>例</summary>
 <p>
@@ -4603,25 +5306,7 @@ GET /v4.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4630,120 +5315,7 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
-### アラームグループを作成する
-
-```http
-POST /v4.0/notification-groups
-```
-
-#### 必要権限
-
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Create | 通知グループの作成 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                        |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 通知グループを識別できる名前             |
-| notifyEmail           | Body | Boolean | X  | メール通知<br/>- デフォルト値: `true`  |
-| notifySms             | Body | Boolean | X  | SMS通知<br/>- デフォルト値: `true`  |
-| isEnabled             | Body | Boolean | X  | 有効かどうか<br/>- デフォルト値: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 監視対象DBインスタンスの識別子リスト     |
-| userGroupIds          | Body | Array   | O  | ユーザーグループの識別子リスト            |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-| 名前                | 種類 | 形式 | 説明       |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 通知グループの識別子 |
-
----
-
-### アラームグループを修正する
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 必要権限
-
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | 通知グループの修正 |
-
-#### リクエスト
-
-| 名前                  | 種類 | 形式    | 必須 | 説明                  |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 通知グループの識別子          |
-| notificationGroupName | Body | String  | X  | 通知グループを識別できる名前     |
-| notifyEmail           | Body | Boolean | X  | メール通知              |
-| notifySms             | Body | Boolean | X  | SMS通知              |
-| isEnabled             | Body | Boolean | X  | 有効かどうか               |
-| dbInstanceIds         | Body | Array   | X  | 監視対象DBインスタンスの識別子リスト |
-| userGroupIds          | Body | Array   | X  | ユーザーグループの識別子リスト      |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンス本文を返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### アラームグループを削除する
+### 通知グループを削除する
 
 ```http
 DELETE /v4.0/notification-groups/{notificationGroupId}
@@ -4751,21 +5323,61 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### 必要権限
 
-| 権限名                                                | 説明       |
-|------------------------------------------------------|------------|
+| 権限名 | 説明 |
+|-----|-----|
 | RDSforMariaDB:NotificationGroup.Delete | 通知グループの削除 |
 
 #### リクエスト
 
 このAPIはリクエスト本文を要求しません。
 
-| 名前                | 種類 | 形式 | 必須 | 説明       |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 通知グループの識別子 |
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンス本文を返しません。
+
+---
+
+### 通知グループの詳細を表示
+
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | 通知グループ詳細表示 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | UUID | 通知グループの識別子 |
+| notificationGroupName | Body | String | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | メール通知の有無 |
+| notifySms | Body | Boolean | SMS通知の有無 |
+| isEnabled | Body | Boolean | 有効かどうか |
+| dbInstances | Body | Array | 監視対象DBインスタンスリスト |
+| dbInstances.dbInstanceId | Body | UUID | DBインスタンスの識別子 |
+| dbInstances.dbInstanceName | Body | String | DBインスタンスを識別できる名前 |
+| userGroups | Body | Array | ユーザーグループリスト |
+| userGroups.userGroupId | Body | UUID | ユーザーグループの識別子 |
+| userGroups.userGroupName | Body | String | ユーザーグループを識別できる名前 |
+| createdYmdt | Body | DateTime | 作成日時 |
+| updatedYmdt | Body | DateTime | 修正日時 |
 
 <details><summary>例</summary>
 <p>
@@ -4776,7 +5388,26 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4785,7 +5416,75 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
+### 通知グループを修正する
+
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | 通知グループの修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | 通知グループを識別できる名前 |
+| notifyEmail | Body | Boolean | X | メール通知の有無<br/>- デフォルト値: `false` |
+| notifySms | Body | Boolean | X | SMS通知の有無<br/>- デフォルト値: `false` |
+| isEnabled | Body | Boolean | X | 有効かどうか<br/>- デフォルト値: `false` |
+| dbInstanceIds | Body | Array | X | 監視対象DBインスタンスの識別子リスト |
+| userGroupIds | Body | Array | X | ユーザーグループの識別子リスト |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 ## モニタリング
+
+### 統計情報照会
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | 統計情報照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+このAPIはレスポンス本文を返しません。
+
+---
 
 ### Metricリスト表示
 
@@ -4795,9 +5494,9 @@ GET /v4.0/metrics
 
 #### 必要権限
 
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 統計情報照会 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | Metricリスト表示 |
 
 #### リクエスト
 
@@ -4805,11 +5504,11 @@ GET /v4.0/metrics
 
 #### レスポンス
 
-| 名前                | 種類 | 形式   | 説明      |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metricリスト |
-| metrics.measureName | Body | Enum   | 照会指標タイプ |
-| metrics.unit        | Body | String | 測定値単位  |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metricリスト |
+| metrics.measureName | Body | String | 照会指標タイプ |
+| metrics.unit | Body | String | 測定値単位 |
 
 <details><summary>例</summary>
 <p>
@@ -4823,74 +5522,8 @@ GET /v4.0/metrics
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 統計情報照会
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### 必要権限
-
-| 権限名                                   | 説明     |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 統計情報照会 |
-
-#### リクエスト
-
-| 名前         | 種類  | 形式     | 必須 | 説明                              |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DBインスタンスの識別子                    |
-| measureNames | Query | Array    | O  | 照会指標リスト<br/>- 最小サイズ: `1`         |
-| from         | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 照会間隔                           |
-
-#### レスポンス
-
-| 名前                              | 種類 | 形式      | 説明     |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 統計情報リスト |
-| metricStatistics.measureName      | Body | Enum      | 測定項目タイプ |
-| metricStatistics.unit             | Body | String    | 測定値単位 |
-| metricStatistics.values           | Body | Array     | 測定値リスト |
-| metricStatistics.values.timestamp | Body | Timestamp | 測定時間  |
-| metricStatistics.values.value     | Body | Object    | 測定値    |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
@@ -4907,102 +5540,14 @@ GET /v4.0/metric-statistics
 
 イベントはカテゴリに分類することができ、下記の通りです。
 
-| イベントカテゴリー  | 説明    |
+| イベントカテゴリー    | 説明      |
 |-------------|---------|
-| ALL         | 全体    |
-| BACKUP      | バックアップ    |
+| ALL         | 全体      |
+| BACKUP      | バックアップ      |
 | DB_INSTANCE | DBインスタンス |
-| JOB         | 作業    |
-| TENANT      | テナント   |
-| MONITORING  | モニタリング  |
-
-### イベントリスト照会
-
-```http
-GET /v4.0/events
-```
-
-#### 必要権限
-
-| 権限名                                  | 説明      |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | イベントリスト表示 |
-
-#### リクエスト
-
-このAPIはリクエスト本文を要求しません。
-
-| 名前              | 種類  | 形式     | 必須 | 説明                                                                                                                                 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| from              | Query | Datetime | O  | 開始日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 終了日時(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 照会するイベントカテゴリータイプ<br/>- `ALL`:全体<br/>- `INSTANCE`: DBインスタンス<br/>- `BACKUP`:バックアップ<br/>- `DB_SECURITY_GROUP`: DBセキュリティグループ<br/>- `TENANT`:テナント |
-| sourceId          | Query | String   | X  | イベントが発生した対象リソースの識別子                                                                                                               |
-| keyword           | Query | String   | X  | イベントメッセージに含まれる文字列検索ワード                                                                                                                      |
-| ascendingOrder    | Query | Enum     | X  | イベントメッセージソート順序<br/>- `ASC`:昇順<br/>- `DESC`:降順<br/>- デフォルト値: `DESC`                                                                 |
-
-#### レスポンス
-
-| 名前                     | 種類 | 形式     | 説明                                  |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 全イベントリストの数                          |
-| events                   | Body | Array    | イベントリスト                              |
-| events.eventCategoryType | Body | Enum     | イベントカテゴリータイプ                         |
-| events.eventCode         | Body | Enum     | 発生したイベントのタイプ                         |
-| events.sourceId          | Body | String   | イベントソースの識別子                         |
-| events.sourceName        | Body | String   | イベントソースを識別できる名前                     |
-| events.messages          | Body | Array    | イベントメッセージリスト                          |
-| events.messages.langCode | Body | String   | 言語コード                               |
-| events.messages.message  | Body | String   | イベントメッセージ                             |
-| events.eventYmdt         | Body | DateTime | イベント発生日時(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
+| JOB         | 作業      |
+| TENANT      | テナント     |
+| MONITORING  | モニタリング    |
 
 ### 購読可能なイベントコード一覧表示
 
@@ -5012,9 +5557,9 @@ GET /v4.0/event-codes
 
 #### 必要権限
 
-| 権限名                                  | 説明      |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | イベントリスト表示 |
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 購読可能なイベントコード一覧表示 |
 
 #### リクエスト
 
@@ -5022,11 +5567,11 @@ GET /v4.0/event-codes
 
 #### レスポンス
 
-| 名前                         | 種類 | 形式  | 説明        |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | イベントコードリスト |
-| eventCodes.eventCode         | Body | Enum  | イベントコード    |
-| eventCodes.eventCategoryType | Body | Enum  | イベントカテゴリータイプ |
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | イベントコードリスト |
+| eventCodes.eventCode | Body | Enum | イベントコード |
+| eventCodes.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>例</summary>
 <p>
@@ -5040,8 +5585,73 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### イベントリスト照会
+
+```http
+GET /v4.0/events
+```
+
+#### 必要権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:Event.List | イベントリスト照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 全イベントリストの数 |
+| events | Body | Array | イベントリスト |
+| events.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | 発生したイベントのタイプ |
+| events.sourceId | Body | UUID | イベントソースの識別子 |
+| events.sourceName | Body | String | イベントソースを識別できる名前 |
+| events.messages | Body | Array | イベントメッセージリスト |
+| events.messages.langCode | Body | Enum | 言語コード<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | イベントメッセージ |
+| events.eventYmdt | Body | DateTime | イベント発生日時 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5062,35 +5672,29 @@ GET /v4.0/event-subscriptions
 #### 必要な権限
 
 | 権限名 | 説明 |
-|---------------------------------------------------------|---------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.List | イベント購読一覧照会 |
 
 #### リクエスト
 
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page | Query | Number | X | 照会する一覧のページ<br/>- デフォルト値：1 <br/>- 最小値：`1` |
-| size | Query | Number | X | 照会する一覧のページサイズ<br/>- デフォルト値：20 |
-| eventSubscriptionId | Query | UUID | X | イベント購読の識別子 |
-| eventSubscriptionName | Query | String | X | イベント購読を識別できる名前 |
-| userGroupId | Query | UUID | X | ユーザーグループの識別子 |
+このAPIはリクエスト本文を要求しません。
 
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-----------------------------------------------|------|----------|---------------------|
+|-----|-----|-----|-----|
 | totalCounts | Body | Number | 全イベント購読一覧数 |
 | eventSubscriptions | Body | Array | イベント購読一覧 |
 | eventSubscriptions.eventSubscriptionId | Body | UUID | イベント購読の識別子 |
-| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリタイプ |
+| eventSubscriptions.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | イベント購読を識別できる名前 |
-| eventSubscriptions.enabled                    | Body | Boolean  | 有効かどうか              |
+| eventSubscriptions.enabled | Body | Boolean | 有効かどうか |
 | eventSubscriptions.notifyEmail | Body | Boolean | メール送信の有無 |
 | eventSubscriptions.notifySms | Body | Boolean | SMS送信の有無 |
 | eventSubscriptions.eventCodes | Body | Array | 購読するイベントコード一覧 |
 | eventSubscriptions.sources | Body | Array | 購読するイベントソース一覧 |
 | eventSubscriptions.sources.sourceId | Body | UUID | イベントソースの識別子 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴーリタイプ |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | イベント購読中のユーザーグループの識別子一覧 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 作成日時 |
 
@@ -5107,25 +5711,23 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
             "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
+            "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
                 }
             ],
             "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
+                "550e8400-e29b-41d4-a716-446655440000"
             ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5145,22 +5747,22 @@ POST /v4.0/event-subscriptions
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Create | イベント購読作成 |
 
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------------------|------|---------|----|-----------------------------------------|
-| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ |
-| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前<br/>- 最大長：`100` |
-| enabled                      | Body | Boolean | O  | 有効かどうか                                |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | イベント購読を識別できる名前 |
+| enabled | Body | Boolean | O | 有効かどうか |
 | notifyEmail | Body | Boolean | O | メール送信の有無 |
 | notifySms | Body | Boolean | O | SMS送信の有無 |
 | eventCodes | Body | Array | O | 購読するイベントコード一覧 |
 | sources | Body | Array | O | 購読するイベントソース一覧 |
 | sources.sourceId | Body | UUID | O | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ |
+| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | userGroupIds | Body | Array | O | イベント購読するユーザーグループの識別子一覧 |
 
 <details><summary>例</summary>
@@ -5168,23 +5770,19 @@ POST /v4.0/event-subscriptions
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5194,7 +5792,7 @@ POST /v4.0/event-subscriptions
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
-|-----------------------|------|------|-------------|
+|-----|-----|-----|-----|
 | eventSubscriptionId | Body | UUID | イベント購読の識別子 |
 
 <details><summary>例</summary>
@@ -5207,86 +5805,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### イベント購読修正
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 必要な権限
-
-| 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | イベント購読修正 |
-
-#### リクエスト
-
-| 名前 | 種類 | 形式 | 必須 | 説明 |
-|------------------------------|------|---------|----|-----------------------------------|
-| eventSubscriptionId | URL | UUID | O | イベント購読の識別子 |
-| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ |
-| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
-| enabled                      | Body | Boolean | X  | 有効かどうか                          |
-| notifyEmail | Body | Boolean | X | メール送信の有無 |
-| notifySms | Body | Boolean | X | SMS送信の有無 |
-| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
-| sources | Body | Array | X | 購読するイベントソース一覧 |
-| sources.sourceId | Body | UUID | X | イベントソースの識別子 |
-| sources.eventCategoryType | Body | Enum | X | イベントカテゴリータイプ |
-| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### レスポンス
-
-このAPIはレスポンスボディを返しません。
-
-<details><summary>例</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5304,18 +5823,107 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 #### 必要な権限
 
 | 権限名 | 説明 |
-|----------------------------------------------------------|--------------|
+|-----|-----|
 | RDSforMariaDB:EventSubscription.Delete | イベント購読削除 |
 
 #### リクエスト
 
+このAPIはリクエスト本文を要求しません。
+
 | 名前 | 種類 | 形式 | 必須 | 説明 |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId | URL | UUID | O | イベント購読の識別子 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### レスポンス
 
 このAPIはレスポンスボディを返しません。
+
+---
+
+### イベント購読修正
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | イベント購読修正 |
+
+#### リクエスト
+
+| 名前 | 種類 | 形式 | 必須 | 説明 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | イベント購読を識別できる名前 |
+| enabled | Body | Boolean | X | 有効かどうか |
+| notifyEmail | Body | Boolean | X | メール送信の有無 |
+| notifySms | Body | Boolean | X | SMS送信の有無 |
+| eventCodes | Body | Array | X | 購読するイベントコード一覧 |
+| sources | Body | Array | X | 購読するイベントソース一覧 |
+| sources.sourceId | Body | UUID | O | イベントソースの識別子 |
+| sources.eventCategoryType | Body | Enum | O | イベントカテゴリータイプ<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | イベント購読するユーザーグループの識別子一覧 |
+
+<details><summary>例</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### レスポンス
+
+このAPIはレスポンスボディを返しません。
+
+---
+
+## アベイラビリティゾーン
+
+### アベイラビリティゾーン一覧照会
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### 必要な権限
+
+| 権限名 | 説明 |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | アベイラビリティゾーン一覧照会 |
+
+#### リクエスト
+
+このAPIはリクエスト本文を要求しません。
+
+#### レスポンス
+
+| 名前 | 種類 | 形式 | 説明 |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | アベイラビリティゾーン一覧 |
+| availabilityZones.availabilityZoneName | Body | String | アベイラビリティゾーン名 |
+| availabilityZones.zoneState | Body | Object | アベイラビリティゾーンの状態 |
+| availabilityZones.zoneState.available | Body | Boolean | アベイラビリティゾーンの使用可否 |
 
 <details><summary>例</summary>
 <p>
@@ -5326,7 +5934,15 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "availabilityZones": [
+        {
+            "availabilityZoneName": "availabilityZoneName-example",
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
 }
 ```
 

--- a/ko/api-guide-v3.0-gov.md
+++ b/ko/api-guide-v3.0-gov.md
@@ -1,45 +1,50 @@
-## Database > RDS for MariaDB > API 가이드
+## RDS for MariaDB API 가이드
+
+**Database > RDS for MariaDB > API v3.0 가이드**
+
 ## RDS for MariaDB API 공통 정보
 
 ### API 엔드포인트
-| 리전        | 엔드포인트                                         |
-|-----------|-----------------------------------------------|
+
+| 리전 | 엔드포인트 |
+|------|----------|
 | 한국(판교) 리전 | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
+
 
 ### 인증 및 권한
 
 RDS for MariaDB API를 사용하려면 User Access Key가 필요합니다. User Access Key는 NHN Cloud 계정 또는 IAM 계정을 기반으로 발급되는 인증 키로, Secret Access Key와 함께 사용하여 API 요청에 대한 인증 수단으로 활용됩니다.
 
 User Access Key와 Secret Access Key는 콘솔의 **API 보안 설정**에서 발급할 수 있습니다. User Access Key 발급 및 사용에 대한 자세한 내용은 [User Access Key](/nhncloud/ko/public-api/user-access-key)를 참고하세요.
-
 생성된 Key는 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름                         | 종류     | 형식     | 필수 | 설명                                                          |
-|----------------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O  | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-TC-AUTHENTICATION-ID     | Header | String | O  | API 보안 설정 메뉴의 User Access Key ID                            |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O  | API 보안 설정 메뉴의 Secret Access Key                             |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | API 보안 설정 메뉴의 User Access Key ID |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | API 보안 설정 메뉴의 Secret Access Key |
 
+또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
-또한 프로젝트 멤버 역할에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`로 구분하여 권한을 부여할 수 있습니다.
-
-* `RDS for MariaDB ADMIN` 권한은 모든 기능을 사용 가능합니다.
-* `RDS for MariaDB VIEWER` 권한은 정보를 조회하는 기능만 사용 가능합니다.
+* `RDS for MariaDB ADMIN` 역할은 API 실행에 필요한 모든 권한이 부여됩니다.
+* `RDS for MariaDB VIEWER` 역할은 정보를 조회하는 권한만 부여됩니다.
     * DB 인스턴스를 생성, 수정, 삭제하거나, DB 인스턴스를 대상으로 하는 어떠한 기능도 사용할 수 없습니다.
-    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용 가능합니다.
+    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용할 수 있습니다.
 
 API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같은 오류가 발생합니다.
 
-| resultCode | resultMessage | 설명          |
-|------------|---------------|-------------|
-| 80401      | Unauthorized  | 인증에 실패했습니다. |
-| 80403      | Forbidden     | 권한이 없습니다.   |
+| resultCode | resultMessage | 설명 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 인증에 실패했습니다. |
+| 80403 | Forbidden | 권한이 없습니다. |
 
 ### 응답 공통 정보
 
 모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
-#### 응답 본문
+<details>
+  <summary><strong>성공 응답</strong></summary>
+
 ```json
 {
     "header": {
@@ -50,53 +55,117 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 }
 ```
 
-#### 필드
-| 이름            | 형식      | 설명                                      |
-|---------------|---------|-----------------------------------------|
-| resultCode    | Number  | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
-| resultMessage | String  | 결과 메시지                                  |
-| isSuccessful  | Boolean | 성공 여부                                   |
+</details>
 
+<details>
+  <summary><strong>실패 응답</strong></summary>
 
+```json
+{
+    "header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
+| resultMessage | String | 결과 메시지 |
+| isSuccessful | Boolean | 성공 여부 |
 ### DB 엔진 유형
 
-| DB 엔진 유형        | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 정보 |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+| DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
 ## 프로젝트 정보
 
-### 리전 목록 보기
-
-```http
-GET /v3.0/project/regions
-```
+### 프로젝트 멤버 목록 보기
 
 #### 요청
+
+```http
+GET /v3.0/project/members
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                 | 종류   | 형식      | 설명                                                                         |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | 리전 목록                                                                      |
-| regions.regionCode | Body | Enum    | 리전 코드<br/>- `KR1`: 한국(판교) 리전 |
-| regions.isEnabled  | Body | Boolean | 리전의 활성화 여부                                                                 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
-<details><summary>예시</summary>
-<p>
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| members.memberName | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | String | 프로젝트 멤버의 전화번호 |
+
+---
+
+### 리전 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/project/regions
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -108,7 +177,7 @@ GET /v3.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
@@ -116,51 +185,11 @@ GET /v3.0/project/regions
 
 </details>
 
----
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v3.0/project/members
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                   | 종류   | 형식     | 설명              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | 프로젝트 멤버 목록      |
-| members.memberId     | Body | UUID   | 프로젝트 멤버의 식별자    |
-| members.memberName   | Body | String | 프로젝트 멤버의 이름     |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber  | Body | String | 프로젝트 멤버의 전화번호   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "홍길동",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| regions | Array | 리전 목록 |
+| regions.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Boolean | 리전의 활성화 여부 |
 
 ---
 
@@ -168,26 +197,20 @@ GET /v3.0/project/members
 
 ### DB 인스턴스 사양 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                     | 종류   | 형식     | 설명              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DB 인스턴스 사양 목록   |
-| dbFlavors.dbFlavorId   | Body | UUID   | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름   |
-| dbFlavors.ram          | Body | Number | 메모리 용량(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU 코어 수        |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -198,17 +221,24 @@ GET /v3.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbFlavors | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Number | CPU 코어 수 |
 
 ---
 
@@ -216,27 +246,20 @@ GET /v3.0/db-flavors
 
 ### 서브넷 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식      | 설명               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | 서브넷 목록           |
-| subnets.subnetId         | Body | UUID    | 서브넷의 식별자         |
-| subnets.subnetName       | Body | String  | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr       | Body | String  | 서브넷의 CIDR        |
-| subnets.usingGateway     | Body | Boolean | 게이트웨이 사용 여부      |
-| subnets.availableIpCount | Body | Number  | 사용 가능한 IP 수      |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -247,18 +270,26 @@ GET /v3.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| subnets | Array | 서브넷 목록 |
+| subnets.subnetId | UUID | 서브넷의 식별자 |
+| subnets.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | String | 서브넷의 CIDR |
+| subnets.usingGateway | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Number | 사용 가능한 IP 수 |
 
 ---
 
@@ -266,25 +297,20 @@ GET /v3.0/network/subnets
 
 ### DB 엔진 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 엔진 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 엔진 유형              |
-| dbVersions.dbVersionName     | Body | String  | DB 엔진 이름              |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -295,39 +321,43 @@ GET /v3.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbVersions | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | String | DB 엔진 이름 |
+| dbVersions.restorableFromObs | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 ---
 
 ## 데이터 스토리지
 
-### 데이터 스토리지 타입 목록 보기
+### 스토리지 타입 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/storage-types
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름           | 종류   | 형식    | 설명             |
-|--------------|------|-------|----------------|
-| storageTypes | Body | Array | 데이터 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -343,29 +373,30 @@ GET /v3.0/storage-types
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageTypes | Array | 스토리지 타입 목록 |
 
 ---
 
-### 데이터 스토리지 목록 보기
+### 스토리지 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/storages
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름       | 종류   | 형식    | 설명          |
-|----------|------|-------|-------------|
-| storages | Body | Array | 데이터 스토리지 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -381,8 +412,11 @@ GET /v3.0/storages
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storages | Array | 스토리지 목록 |
 
 ---
 
@@ -407,32 +441,26 @@ GET /v3.0/storages
 
 ### 작업 정보 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름    | 종류  | 형식   | 필수 | 설명      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 작업의 식별자 |
-
 #### 응답
 
-| 이름                             | 종류   | 형식       | 설명                                |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 작업의 식별자                           |
-| jobStatus                      | Body | Enum     | 작업의 현재 상태                         |
-| resourceRelations              | Body | Array    | 연관 리소스 목록                         |
-| resourceRelations.resourceType | Body | Enum     | 연관 리소스 유형                         |
-| resourceRelations.resourceId   | Body | UUID     | 연관 리소스의 식별자                       |
-| createdYmdt                    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -441,21 +469,30 @@ GET /v3.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+| jobStatus | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | String | 연관 리소스의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -463,26 +500,20 @@ GET /v3.0/jobs/{jobId}
 
 ### DB 인스턴스 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                 | 종류   | 형식       | 설명                                                                       |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB 인스턴스 그룹 목록                                                            |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                          |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -493,49 +524,49 @@ GET /v3.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 그룹 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| replicationType              | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성                                                              |
-| dbInstances                  | Body | Array    | DB 인스턴스 그룹에 속한 DB 인스턴스 목록                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -544,22 +575,32 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -587,8 +628,8 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 | `BACKING_UP`               | 백업 중         |
 | `CANCELING`                | 취소 중         |
 | `CREATING`                 | 생성 중         |
-| `CREATING_SCHEMA`          | DB 스키마 생성 중	 |
-| `CREATING_USER`            | 사용자 생성 중	    |
+| `CREATING_SCHEMA`          | DB 스키마 생성 중  |
+| `CREATING_USER`            | 사용자 생성 중     |
 | `DELETING`                 | 삭제 중         |
 | `DELETING_SCHEMA`          | DB 스키마 삭제 중  |
 | `DELETING_USER`            | 사용자 삭제 중     |
@@ -607,38 +648,25 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 | `STARTING`                 | 시작 중         |
 | `STOPPING`                 | 정지 중         |
 | `SYNCING_SCHEMA`           | DB 스키마 동기화 중 |
-| `SYNCING_USER`             | 사용자 동기화 중	   |
-| `UPDATING_USER`            | 사용자 수정 중	    |
+| `SYNCING_USER`             | 사용자 동기화 중    |
+| `UPDATING_USER`            | 사용자 수정 중     |
 
 ### DB 인스턴스 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB 인스턴스 목록                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| dbInstances.description       | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB 인스턴스의 현재 진행 상태                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -649,165 +677,76 @@ GET /v3.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
----
-
-### DB 인스턴스 상세 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                          | 종류   | 형식       | 설명                                                                                                                                    |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstanceGroupId           | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceName              | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| description                 | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbVersion                   | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbPort                      | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstanceStatus            | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| progressStatus              | Body | Enum     | DB 인스턴스의 현재 작업 진행 상태                                                                                                                  |
-| dbFlavorId                  | Body | UUID     | DB 인스턴스 사양의 식별자                                                                                                                       |
-| parameterGroupId            | Body | UUID     | DB 인스턴스에 적용된 파라미터 그룹의 식별자                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록                                                                                                         |
-| notificationGroupIds        | Body | Array    | DB 인스턴스에 적용된 알림 그룹의 식별자 목록                                                                                                            |
-| useDeletionProtection       | Body | Boolean  | DB 인스턴스 삭제 보호 여부                                                                                                                      |
-| supportAuthenticationPlugin | Body | Boolean  | 인증 플러그인 지원 여부                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 최신 파라미터 그룹 적용 필요 여부                                                                                                                   |
-| needMigration               | Body | Boolean  | 마이그레이션 필요 여부                                                                                                                          |
-| supportDbVersionUpgrade     | Body | Boolean  | DB 버전 업그레이드 지원 여부                                                                                                                     |
-| createdYmdt                 | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstances | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | String | DB 엔진 유형 |
+| dbInstances.dbPort | Number | DB 포트 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 생성하기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### 요청
+#### 요청 본문
 
-| 이름                      | 종류   | 형식      | 필수 | 설명                                                                  |
-|-------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName          | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId              | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbVersion               | Body | Enum    | O  | DB 엔진 유형                                                            |
-| dbPort                  | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| dbUserName              | Body | String  | O  | DB 사용자 계정명                                                          |
-| dbPassword              | Body | String  | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                    |
-| parameterGroupId        | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds      | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds            | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability     | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval            | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification  | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection   | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         |
-| authenticationPlugin                         | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                  |
-| network.subnetId                             | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                    |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능  여부<br/>- 기본값: `false`                                                                                                                                                                                             |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                                                                                                    |
-| storage                                      | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                                                                                                  |    
-| storage.storageType                          | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                                                                                                         |
-| storage.storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                    |
-| backup.backupPeriod                          | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                          |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                     |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -815,460 +754,63 @@ POST /v3.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-| 이름                      | 종류   | 형식      | 필수 | 설명                                         |
-|-------------------------|------|---------|----|--------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB 인스턴스의 식별자                               |
-| dbInstanceName          | Body | String  | X  | DB 인스턴스를 식별할 수 있는 마스터 이름                   |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                          |
-| dbPort                  | Body | Number  | X  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306` |
-| dbFlavorId         | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                           |
-| parameterGroupId   | Body | UUID    | X  | 파라미터 그룹의 식별자                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                          |
-| executeBackup      | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| useOnlineFailover  | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| authenticationPlugin | Enum | N | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 삭제하기
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재시작하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-### DB 인스턴스 강제 재시작하기
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 인스턴스 시작하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 정지하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 백업하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### 요청
-
-| 이름           | 종류   | 형식     | 필수 | 설명              |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자    |
-| backupName   | Body | String | O  | 백업을 식별할 수 있는 이름 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 백업 후 내보내기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 복제하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                        |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                  |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                               |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                         |
-| dbFlavorId               | Body | UUID    | X  | DB 인스턴스 사양의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                   |
-| dbPort                   | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`        |
-| parameterGroupId         | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                      |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록<br/>- 기본값: 원본 DB 인스턴스 값                                  |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                            |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                            |
-| useDeletionProtection    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                               |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                                |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: 원본 DB 인스턴스 값                                       |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                  |
-| storage                  | Body | Object  | X  | 데이터 스토리지 정보 객체                                                            |    
-| storage.storageType      | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                        |
-| storage.storageSize      | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
-| backup                   | Body | Object  | X  | 백업 정보 객체                                                                  |
-| backup.backupPeriod      | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | 백업 시작 시각<br/>- 예시: `00:00:00`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간<br/>- 기본값: 원본 DB 인스턴스 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 승격하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 복원 정보 조회
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                      | 종류   | 형식       | 설명                                                                                                                                                                           |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 가장 오래된 복원 가능한 시각                                                                                                                                                             |
-| latestRestorableYmdt                    | Body | DateTime | 가장 최신의 복원 가능한 시각                                                                                                                                                             |
-| restorableBackups                       | Body | Array    | 복원 가능한 백업 목록                                                                                                                                                                 |
-| restorableBackups.backup                | Body | Object   | 백업 정보 객체                                                                                                                                                                     |
-| restorableBackups.backup.backupId       | Body | UUID     | 백업의 식별자                                                                                                                                                                      |
-| restorableBackups.backup.backupName     | Body | String   | 백업 이름                                                                                                                                                                        |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | 테이블 잠금 사용 여부                                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | 백업 크기                                                                                                                                                                        |
-| restorableBackups.backup.backupType     | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`: 수동                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | 백업 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                                              |
-| restorableBackups.backup.dbInstanceName | Body | String   | 원본 DB 인스턴스의 이름                                                                                                                                                               |
-| restorableBackups.backup.dbVersion      | Body | String   | DB 엔진 유형                                                                                                                                                                     |
-| restorableBackups.backup.failoverCount  | Body | Number   | 장애 조치 횟수                                                                                                                                                                     |
-| restorableBackups.backup.binLogFileName | Body | String   | 바이너리 로그 파일 이름                                                                                                                                                                |
-| restorableBackups.backup.binLogPosition | Body | Number   | 바이너리 로그 파일 위치                                                                                                                                                                |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | 백업 생성 일시                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | 백업 갱신 일시                                                                                                                                                                     |
-| restorableBackups.restorableBinLogs     | Body | Array    | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록                                                                                                                                             |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 복원될 마지막 쿼리 조회
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 공통 요청
-
-| 이름           | 종류    | 형식   | 필수 | 설명                                                                                                                          |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DB 인스턴스의 식별자                                                                                                                |
-| restoreType  | Query | Enum | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입 |
-
-#### restoreType이 `TIMESTAMP`인 경우
-
-| 이름          | 종류    | 형식       | 필수 | 설명                                        |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreType이 `BINLOG`인 경우
-
-| 이름             | 종류    | 형식     | 필수 | 설명                 |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| binLogFileName | Query | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| binLogPosition | Query | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-#### 응답
-
-| 이름           | 종류   | 형식       | 설명                                   |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 마지막 수행 쿼리                            |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1277,496 +819,148 @@ GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### 복원
+### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 공통 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                                                                                             |
-|--------------------------|------|---------|----|------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                   |
-| restore                  | Body | Object  | O  | 복원 정보 객체                                                                                                                                       |
-| restore.restoreType      | Body | Enum    | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능 시간 범위 내의 특정 시각으로 시점 복원<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 지정하여 시점 복원<br/>- `BACKUP`: 기존에 생성한 백업을 이용하여 스냅숏 복원 |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                                                                                       |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                                                                                                    |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                              |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                                                                                |
-| dbPort                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                                                                                                     |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                                                                                   |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                               |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                 |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                                                                                                  |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                            |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                 |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                     |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                       |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                 |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                       |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                 |
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                            |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                              |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                                                                                                       |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                    |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                             |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                        |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br>기본값: `false`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름                  | 종류   | 형식       | 필수 | 설명                                                                                             |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능하다. |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름                            | 종류   | 형식     | 필수 | 설명                 |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| restore.binLog                | Body | Object | O  | 바이너리 로그 정보 객체      |
-| restore.binLog.binLogFileName | Body | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-* 바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름               | 종류   | 형식   | 필수                           | 설명              |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreType이 `BACKUP`인 경우) | 복원에 사용할 백업의 식별자 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-### 오브젝트 스토리지로부터 복원
+#### 요청
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### 요청
+#### 요청 본문
 
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| restore                  | Body | Object  | O  | 복원 정보 객체                                                            |
-| restore.tenantId         | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 테넌트 ID                                           |
-| restore.username         | Body | String  | O  | NHN Cloud 계정 또는 IAM 계정 ID                                           |
-| restore.password         | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 API 비밀번호                                         |
-| restore.targetContainer  | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 컨테이너                                             |
-| restore.objectPath       | Body | String  | O  | 컨테이너에 저장된 백업의 경로                                                    |
-| dbVersion                | Body | Enum    | O  | DB 엔진 유형                                                            |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbPort                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                          |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                            |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                            |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                      |
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                 |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                            |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
     "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-
-### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O  | 삭제 보호 여부     |
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-### 고가용성 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
+### DB 인스턴스 삭제하기
 
 #### 요청
 
-| 이름                  | 종류   | 형식      | 필수 | 설명                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB 인스턴스의 식별자                                         |
-| useHighAvailability | Body | Boolean | O  | 고가용성 사용 여부                                           |
-| pingInterval        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 다시 시작하기
-
 ```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
+DELETE /v3.0/db-instances/{dbInstanceId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 일시 중지하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 복구하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 분리하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 데이터 스토리지 정보 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름            | 종류   | 형식     | 설명                                                                                   |
-|---------------|------|--------|--------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | 데이터 스토리지 타입                                                                          |
-| storageSize   | Body | Number | 데이터 스토리지 크기(GB)                                                                      |
-| storageStatus | Body | Enum   | 데이터 스토리지의 현재 상태<br/>- `DETACHED`: 부착되지 않음<br/>- `ATTACHED`: 부착됨<br/>- `DELETED`: 삭제됨 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1775,69 +969,258 @@ GET /v3.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### 데이터 스토리지 정보 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### DB 인스턴스 상세 보기
 
 #### 요청
 
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| storageSize       | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: 현재값<br/>- 최댓값: `2048`                          |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "NONE",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "supportAuthenticationPlugin": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| dbPort | Number | DB 포트 |
+| dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | DB 인스턴스 삭제 보호 여부 |
+| supportAuthenticationPlugin | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### DB 인스턴스 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbVersion | String | N | DB 엔진 버전 코드 |
+| useDummy | Boolean | N | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 백업하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "backupName": "backupName"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupName | String | Y | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 정보 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름                                | 종류   | 형식      | 설명             |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | 백업 보관 기간(일)    |
-| ftwrlWaitTimeout                  | Body | Number  | 쿼리 지연 대기 시간(초) |
-| backupRetryCount                  | Body | Number  | 백업 재시도 횟수      |
-| replicationRegion                 | Body | Enum    | 백업 복제 리전       |
-| useBackupLock                     | Body | Boolean | 테이블 잠금 사용 여부   |
-| backupSchedules                   | Body | Array   | 예정된 자동 백업 목록   |
-| backupSchedules.backupWndBgnTime  | Body | String  | 백업 시작 시각       |
-| backupSchedules.backupWndDuration | Body | Enum    | 백업 Duration    |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1847,101 +1230,86 @@ GET /v3.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backupPeriod | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Number | 백업 재시도 횟수 |
+| replicationRegion | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### 백업 정보 수정하기
 
+#### 요청
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                                    | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                          |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                |
-| backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부                                                                                                                                                                                                                |
-| backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 네트워크 정보 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름                     | 종류   | 형식     | 설명                                                                                                                                      |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DB 인스턴스를 생성할 가용성 영역                                                                                                                     |
-| subnet                 | Body | Object | 서브넷 객체                                                                                                                                  |
-| subnet.subnetId        | Body | UUID   | 서브넷의 식별자                                                                                                                                |
-| subnet.subnetName      | Body | UUID   | 서브넷을 식별할 수 있는 이름                                                                                                                        |
-| subnet.subnetCidr      | Body | UUID   | 서브넷의 CIDR                                                                                                                               |
-| endPoints              | Body | Array  | 접속 정보 목록                                                                                                                                |
-| endPoints.domain       | Body | String | 도메인                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP 주소                                                                                                                                   |
-| endPoints.endPointType | Body | Enum   | 접속 정보 타입<br>-`EXTERNAL`: 외부 접속 도메인<br>-`INTERNAL`: 내부 접속 도메인<br>-`PUBLIC`: (Deprecated) 외부 접속 도메인<br>-`PRIVATE`: (Deprecated) 내부 접속 도메인 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1950,78 +1318,61 @@ GET /v3.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 네트워크 정보 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 요청
-
-| 이름              | 종류   | 형식      | 필수 | 설명           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O  | 외부 접속 가능  여부 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### DB 사용자 목록 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
+### DB 인스턴스 오브젝트 스토리지로 백업
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB 사용자 목록                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DB 사용자의 식별자                                                                                                                 |
-| dbUsers.dbUserName           | Body | String   | DB 사용자 계정 이름                                                                                                                |
-| dbUsers.host                 | Body | String   | DB 사용자 계정의 호스트 이름                                                                                                           |
-| dbUsers.authorityType        | Body | Enum     | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/>            |
-| dbUsers.dbUserStatus         | Body | Enum     | DB 사용자의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `UPDATING`: 수정 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbUsers.authenticationPlugin         | Body | Enum    | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-| dbUsers.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2030,150 +1381,64 @@ GET /v3.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### DB 사용자 생성하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
+### 테스트 용 DB 이미지 메타 변경
 
 #### 요청
 
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserName           | Body | String | O  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `32`                                                                  |
-| dbPassword           | Body | String | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| host                 | Body | String | O  | DB 사용자 계정의 호스트명<br/>- 예시: `1.1.1.%`                                                                              |
-| authorityType        | Body | Enum   | O  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 수정하기
-
 ```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserId             | URL  | UUID   | O  | DB 사용자의 식별자                                                                                                      |
-| dbPassword           | Body | String | X  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| authorityType        | Body | Enum   | X  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 삭제하기
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbUserId     | URL | UUID | O  | DB 사용자의 식별자  |
-
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ### DB 스키마 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                                                                                   |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB 스키마 목록                                                                                            |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB 스키마의 식별자                                                                                          |
-| dbSchemas.dbSchemaName   | Body | String   | DB 스키마 이름                                                                                            |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB 스키마의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbSchemas.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                    |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2184,92 +1449,666 @@ GET /v3.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
             "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSchemas | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | UUID | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### DB 스키마 생성하기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름           | 종류   | 형식     | 필수 | 설명           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O  | DB 스키마 이름    |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 스키마 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbSchemaId   | URL | UUID | O  | DB 스키마의 식별자  |
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbUsers | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
+| dbUsers.dbUserName | String | DB 사용자 계정 이름 |
+| dbUsers.host | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+---
+
+### DB 사용자 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | String | Y | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Enum | Y | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Enum | N | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 삭제 보호 설정 변경
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 삭제 보호 여부 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 강제 재시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 고가용성 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 고가용성 사용 여부 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 일시 중지하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 복구하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 다시 시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 분리하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 로그 파일 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/log-files
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식    | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileTypes | Query | Array | X  | 로그 파일 타입 종류 목록<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | 로그 파일 목록                                                                                                                                                                                     |
-| logFiles.logFileName | Body | String   | 로그 파일 이름                                                                                                                                                                                     |
-| logFiles.logFileType | Body | Enum     | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | 로그 파일 크기(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2280,60 +2119,821 @@ GET /v3.0/db-instances/{dbInstanceId}/log-files
     },
     "logFiles": [
         {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| logFiles | Array | 로그 파일 목록 |
+| logFiles.logFileName | String | 로그 파일 이름 |
+| logFiles.logFileType | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 로그 파일 내보내기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름              | 종류   | 형식     | 필수 | 설명                             |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                   |
-| logFileNames    | Body | Array  | O  | 로그 파일 이름 목록<br/>- 최소 크기: `1`   |
-| tenantId        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID      |
-| password        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 로그 파일의 경로            |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | 로그 파일 이름 목록 |
+| tenantId | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 로그 파일의 경로 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 네트워크 정보 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZone | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Object | 서브넷 객체 |
+| subnet.subnetId | UUID | 서브넷의 식별자 |
+| subnet.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | String | 서브넷의 CIDR |
+| endPoints | Array | 접속 정보 목록 |
+| endPoints.domain | String | 도메인 |
+| endPoints.ipAddress | String | IP 주소 |
+| endPoints.endPointType | String | 접속 정보 타입 |
+
+---
+
+### 네트워크 정보 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 외부 접속 가능 여부 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 승격하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 복제하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부 |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | N | 스토리지 정보 객체 |
+| storage.storageType | Enum | N | 데이터 스토리지 타입 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | N | 백업 정보 객체 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 재시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 복원 정보 조회
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 복원될 마지막 쿼리 조회
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| executedYmdt | DateTime | 쿼리 수행 일시 |
+| lastQuery | String | 마지막 수행 쿼리 |
+
+---
+
+### DB 인스턴스 복원
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.restoreType | Enum | Y | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | String | N | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Object | N | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB 인스턴스 복원 일시 |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Object | N | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/start
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 정지하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 스토리지 정보 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageType | Enum | 데이터 스토리지 타입 |
+| storageSize | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+
+---
+
+### 스토리지 정보 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2351,40 +2951,20 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### 백업 목록 조회
 
+#### 요청
+
 ```http
 GET /v3.0/backups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식     | 필수 | 설명                                                       |
-|--------------|-------|--------|----|----------------------------------------------------------|
-| page         | Query | Number | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                               |
-| size         | Query | Number | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`           |
-| backupType   | Query | Enum   | X  | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동<br/>- 기본값: 전체 |
-| dbInstanceId | Query | UUID   | X  | 원본 DB 인스턴스의 식별자                                          |
-| dbVersion    | Query | Enum   | X  | DB 엔진 유형                                                 |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 전체 백업 목록 수                        |
-| backups              | Body | Array    | 백업 목록                             |
-| backups.backupId     | Body | UUID     | 백업의 식별자                           |
-| backups.backupName   | Body | String   | 백업을 식별할 수 있는 이름                   |
-| backups.backupStatus | Body | Enum     | 백업의 현재 상태                         |
-| backups.dbInstanceId | Body | UUID     | 원본 DB 인스턴스의 식별자                   |
-| backups.dbVersion    | Body | Enum     | DB 엔진 유형                          |
-| backups.backupType   | Body | Enum     | 백업 유형                             |
-| backups.backupSize   | Body | Number   | 백업의 크기(Byte)                      |
-| createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2396,120 +2976,180 @@ GET /v3.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 백업 목록 수 |
+| backups | Array | 백업 목록 |
+| backups.backupId | UUID | 백업의 식별자 |
+| backups.backupName | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | String | DB 엔진 유형 |
+| backups.utilVersion | String | 유틸리티 버전 |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | DateTime | 생성 일시 |
+| backups.updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 백업 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/backups/{backupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 내보내기
 
+#### 요청
+
 ```http
 POST /v3.0/backups/{backupId}/export
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | 백업의 식별자                     |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
-> [주의]
-> 수동 백업의 경우 백업이 수행된 DB 인스턴스가 존재하지 않으면, 백업을 오브젝트 스토리지로 내보낼 수 없습니다.
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 복원하기
 
+#### 요청
+
 ```http
 POST /v3.0/backups/{backupId}/restore
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                 | URL  | UUID    | O  | 백업의 식별자                                                             |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbPort                   | Body | Integer | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         | 
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                          |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                            |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                            |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                      |    
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                 |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                            |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -2517,7 +3157,11 @@ POST /v3.0/backups/{backupId}/restore
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -2528,36 +3172,59 @@ POST /v3.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
----
-
-### 백업 삭제하기
-
-```http
-DELETE /v3.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 요청
+</details>
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2574,28 +3241,20 @@ DELETE /v3.0/backups/{backupId}
 
 ### DB 보안 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-security-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                   | 종류   | 형식       | 설명                                |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB 보안 그룹 목록                       |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                     |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름             |
-| dbSecurityGroups.description         | Body | String   | DB 보안 그룹에 대한 추가 정보                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2606,61 +3265,150 @@ GET /v3.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### DB 보안 그룹 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-security-groups
+```
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
+        {
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Array | Y | DB 보안 그룹 규칙 목록 |
+| rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | Y | 포트 객체 |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | 보안 그룹 규칙에 대한 추가 정보 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+
+---
+
+### DB 보안 그룹 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ### DB 보안 그룹 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
 #### 응답
 
-| 이름                  | 종류   | 형식       | 설명                                                                                                                 |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                                                                                                      |
-| dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                              |
-| description         | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                 |
-| progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                                                                                                 |
-| rules               | Body | Array    | DB 보안 그룹 규칙 목록                                                                                                     |
-| rules.ruleId        | Body | UUID     | DB 보안 그룹 규칙의 식별자                                                                                                   |
-| rules.description   | Body | String   | DB 보안 그룹 규칙에 대한 추가 정보                                                                                              |
-| rules.direction     | Body | Enum     | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                       |
-| rules.etherType     | Body | Enum     | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | 포트 객체                                                                                                              |
-| rules.port.portType | Body | Enum     | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number   | 최소 포트 범위                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 최대 포트 범위                                                                                                           |
-| rules.cidr          | Body | String   | 허용할 트래픽의 원격 소스                                                                                                     |
-| rules.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2670,300 +3418,278 @@ GET /v3.0/db-security-groups/{dbSecurityGroupId}
         "isSuccessful": true
     },
     "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "description": "description-example",
         "progressStatus": "NONE",
         "rules": [
             {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
                 "direction": "INGRESS",
                 "etherType": "IPV4",
                 "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
                 },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
             }
         ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
 
-</p>
 </details>
 
----
-
-### DB 보안 그룹 생성하기
-
-```http
-POST /v3.0/db-security-groups
-```
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                    |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB 보안 그룹 규칙 목록                                                                                                                                                                           |
-| rules.description   | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| rules.port.maxPort  | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                | 종류   | 형식   | 설명            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB 보안 그룹 |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroup.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroup.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.rules | Array | DB 보안 그룹 규칙 목록 |
+| dbSecurityGroup.rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| dbSecurityGroup.rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| dbSecurityGroup.rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| dbSecurityGroup.rules.port | Object | 포트 객체 |
+| dbSecurityGroup.rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.minPort | Number | 최소 포트 범위 |
+| dbSecurityGroup.rules.port.maxPort | Number | 최대 포트 범위 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 수정 일시 |
+| dbSecurityGroup.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 수정하기
 
+#### 요청
+
 ```http
 PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                  | 종류   | 형식     | 필수 | 설명                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB 보안 그룹의 식별자         |
-| dbSecurityGroupName | Body | String | X  | DB 보안 그룹을 식별할 수 있는 이름 |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보    |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB 보안 그룹 규칙의 식별자                                                                                                                                                                         |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류    | 형식    | 필수 | 설명                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB 보안 그룹의 식별자       |
-| ruleIds           | Query | Array | O  | DB 보안 그룹 규칙의 식별자 목록 |
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2971,33 +3697,20 @@ DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 
 ### 파라미터 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/parameter-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름        | 종류    | 형식   | 필수 | 설명       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB 엔진 유형 |
-
 #### 응답
 
-| 이름                                   | 종류   | 형식       | 설명                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | 파라미터 그룹 목록                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | 파라미터 그룹의 식별자                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                              |
-| parameterGroups.description          | Body | String   | 파라미터 그룹에 대한 추가 정보                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB 엔진 유형                                                          |
-| parameterGroups.parameterGroupStatus | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요 |
-| parameterGroups.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3008,62 +3721,66 @@ GET /v3.0/parameter-groups
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroups | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | String | DB 엔진 유형 |
+| parameterGroups.parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
-```
+### 파라미터 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/parameter-groups
+```
 
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | String | Y | DB 엔진 유형 |
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                     |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | 파라미터 그룹의 식별자                                                                                           |
-| parameterGroupName            | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                                                                   |
-| description                   | Body | String   | 파라미터 그룹에 대한 추가 정보                                                                                      |
-| dbVersion                     | Body | Enum     | DB 엔진 유형                                                                                               |
-| parameterGroupStatus          | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요                                      |
-| parameters                    | Body | Array    | 파라미터 목록                                                                                                |
-| parameters.parameterId        | Body | UUID     | 파라미터 식별자                                                                                               |
-| parameters.parameterFileGroup | Body | Enum     | 파라미터 파일 그룹 타입<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | 파라미터 이름                                                                                                |
-| parameters.fileParameterName  | Body | String   | 파라미터 파일 이름                                                                                             |
-| parameters.value              | Body | String   | 현재 설정된 값                                                                                               |
-| parameters.defaultValue       | Body | String   | 기본값                                                                                                    |
-| parameters.allowedValue       | Body | String   | 허용된 값                                                                                                  |
-| parameters.updateType         | Body | Enum     | 수정 타입<br/>- `VARIABLE`: 언제든 수정 가능<br/>- `CONSTANT`: 수정 불가능<br/>- `INIT_VARIABLE`: DB 인스턴스 생성 시에만 수정 가능 |
-| parameters.applyType          | Body | Enum     | 적용 타입<br/>- `SESSION`: 세션 적용<br/>- `FILE`: 설정 파일 적용(재시작 필요)<br/>- `BOTH`: 전체(재시작 필요)                   |
-| createdYmdt                   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3072,261 +3789,64 @@ GET /v3.0/parameter-groups/{parameterGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v3.0/parameter-groups
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-| dbVersion          | Body | Enum   | O  | DB 엔진 유형             |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | X  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 요청
-
-| 이름                             | 종류   | 형식     | 필수 | 설명           |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | 파라미터 그룹의 식별자 |
-| modifiedParameters             | Body | Array  | O  | 변경할 파라미터 목록  |
-| modifiedParameters.parameterId | Body | UUID   | O  | 파라미터의 식별자    |
-| modifiedParameters.value       | Body | String | O  | 변경할 파라미터 값   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 요청
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 파라미터 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3334,12 +3854,215 @@ DELETE /v3.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Array | 파라미터 목록 |
+| parameters.parameterId | UUID | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | 파라미터 이름 |
+| parameters.fileParameterName | String | 파라미터 파일 이름 |
+| parameters.value | String | 현재 설정된 값 |
+| parameters.defaultValue | String | 기본값 |
+| parameters.allowedValue | String | 허용된 값 |
+| parameters.updateType | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 파라미터 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+#### 요청
+
+```http
+POST /v3.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+
+---
+
+### 파라미터 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | UUID | Y | 파라미터의 식별자 |
+| modifiedParameters.value | String | Y | 변경할 파라미터 값 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -3347,26 +4070,20 @@ DELETE /v3.0/parameter-groups/{parameterGroupId}
 
 ### 사용자 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/user-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId   | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| userGroups.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3377,48 +4094,60 @@ GET /v3.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 사용자 그룹 상세 보기
-
-```http
-GET /v3.0/user-groups/{userGroupId}
-```
+### 사용자 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/user-groups
+```
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | Y | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름                | 종류   | 형식       | 설명                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | 사용자 그룹의 식별자                                                                                               |
-| userGroupName     | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                                                                       |
-| userGroupTypeCode | Body | Enum     | 사용자 그룹 종류    <br /> `ENTIRE`: 프로젝트 멤버 전체를 포함하는 사용자 그룹 <br /> `INDIVIDUAL_MEMBER`: 특정 프로젝트 멤버를 포함하는 사용자 그룹 |
-| members           | Body | Array    | 프로젝트 멤버 목록                                                                                                |
-| members.memberId  | Body | UUID     | 프로젝트 멤버의 식별자                                                                                              |
-| createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3427,139 +4156,64 @@ GET /v3.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 사용자 그룹 생성하기
-
-```http
-POST /v3.0/user-groups
-```
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                          |
-|---------------|------|---------|----|-------------------------------------------------------------|
-| userGroupName | Body | String  | O  | 사용자 그룹을 식별할 수 있는 이름                                         |
-| memberIds     | Body | Array   | O  | 프로젝트 멤버의 식별자 목록 <br /> `selectAllYN`이 true인 경우 해당 필드 값은 무시됨 |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨          |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름          | 종류   | 형식   | 설명          |
-|-------------|------|------|-------------|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
----
-
-### 사용자 그룹 수정하기
-
-```http
-PUT /v3.0/user-groups/{userGroupId}
-```
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | 사용자 그룹의 식별자                                        |
-| userGroupName | Body | String  | X  | 사용자 그룹을 식별할 수 있는 이름                                |
-| memberIds     | Body | Array   | X  | 프로젝트 멤버의 식별자 목록                                    |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
 
 ---
 
 ### 사용자 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/user-groups/{userGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 사용자 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/user-groups/{userGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3567,12 +4221,72 @@ DELETE /v3.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 사용자 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/user-groups/{userGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | N | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -3580,29 +4294,20 @@ DELETE /v3.0/user-groups/{userGroupId}
 
 ### 알림 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/notification-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                       | 종류   | 형식       | 설명                                |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 알림 그룹 목록                          |
-| notificationGroups.notificationGroupId   | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroups.notificationGroupName | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notificationGroups.notifyEmail           | Body | Boolean  | 이메일 알림 여부                         |
-| notificationGroups.notifySms             | Body | Boolean  | SMS 알림 여부                         |
-| notificationGroups.isEnabled             | Body | Boolean  | 활성화 여부                            |
-| notificationGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3613,57 +4318,72 @@ GET /v3.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroups | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 알림 그룹 상세 보기
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
-```
+### 알림 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/notification-groups
+```
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름                         | 종류   | 형식       | 설명                                |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroupName      | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notifyEmail                | Body | Boolean  | 이메일 알림 여부                         |
-| notifySms                  | Body | Boolean  | SMS 알림 여부                         |
-| isEnabled                  | Body | Boolean  | 활성화 여부                            |
-| dbInstances                | Body | Array    | 감시 대상 DB 인스턴스 목록                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DB 인스턴스의 식별자                      |
-| dbInstances.dbInstanceName | Body | String   | DB 인스턴스를 식별할 수 있는 이름              |
-| userGroups                 | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId     | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName   | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| createdYmdt                | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3672,154 +4392,64 @@ GET /v3.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 알림 그룹 생성하기
-
-```http
-POST /v3.0/notification-groups
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 알림 그룹을 식별할 수 있는 이름          |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled             | Body | Boolean | X  | 활성화 여부<br/>- 기본값: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 감시 대상 DB 인스턴스의 식별자 목록       |
-| userGroupIds          | Body | Array   | O  | 사용자 그룹의 식별자 목록              |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                  | 종류   | 형식   | 설명         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
----
-
-### 알림 그룹 수정하기
-
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 알림 그룹의 식별자            |
-| notificationGroupName | Body | String  | X  | 알림 그룹을 식별할 수 있는 이름    |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부             |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부             |
-| isEnabled             | Body | Boolean | X  | 활성화 여부                |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
 
 ---
 
 ### 알림 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 알림 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3827,37 +4457,132 @@ DELETE /v3.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | 이메일 알림 여부 |
+| notifySms | Boolean | SMS 알림 여부 |
+| isEnabled | Boolean | 활성화 여부 |
+| dbInstances | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 알림 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Array | N | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ## 모니터링
 
-### Metric 목록 보기
-
-```http
-GET /v3.0/metrics
-```
+### 통계 정보 조회
 
 #### 요청
+
+```http
+GET /v3.0/metric-statistics
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                  | 종류   | 형식     | 설명        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metric 목록 |
-| metrics.measureName | Body | Enum   | 조회 지표 유형  |
-| metrics.unit        | Body | String | 측정값 단위    |
+이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### Metric 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/metrics
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3868,75 +4593,20 @@ GET /v3.0/metrics
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
----
-
-### 통계 정보 조회
-
-```http
-GET /v3.0/metric-statistics
-```
-
-#### 요청
-
-| 이름           | 종류    | 형식       | 필수 | 설명                                |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB 인스턴스의 식별자                      |
-| measureNames | Query | Array    | O  | 조회 지표 목록<br/>- 최소 크기: `1`         |
-| from         | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 조회 간격                             |
-
-#### 응답
-
-| 이름                                | 종류   | 형식        | 설명       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 통계 정보 목록 |
-| metricStatistics.measureName      | Body | Enum      | 측정 항목 유형 |
-| metricStatistics.unit             | Body | String    | 측정값 단위   |
-| metricStatistics.values           | Body | Array     | 측정값 목록   |
-| metricStatistics.values.timestamp | Body | Timestamp | 측정 시간    |
-| metricStatistics.values.value     | Body | Object    | 측정값      |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| metrics | Array | Metric 목록 |
+| metrics.measureName | String | 조회 지표 유형 |
+| metrics.unit | String | 측정값 단위 |
 
 ---
 
@@ -3955,108 +4625,22 @@ GET /v3.0/metric-statistics
 | TENANT      | 테넌트     |
 | MONITORING  | 모니터링    |
 
-### 이벤트 목록 조회
-
-```http
-GET /v3.0/events
-```
+### 구독 가능한 이벤트 코드 목록 보기
 
 #### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`                                                                                       |
-| from              | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 조회할 이벤트 카테고리 유형<br/>- `ALL`: 전체<br/>- `INSTANCE`: DB 인스턴스<br/>- `BACKUP`: 백업<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `TENANT`: 테넌트 |
-| sourceId          | Query | String   | X  | 이벤트가 발생한 대상 리소스의 식별자                                                                                                                 |
-| keyword           | Query | String   | X  | 이벤트 메시지에 포함된 문자열 검색어                                                                                                                 |
-| ascendingOrder    | Query | Enum     | X  | 이벤트 메시지 정렬 순서<br/>- `ASC`: 오름차순<br/>- `DESC`: 내림차순<br/>- 기본값: `DESC`                                                                 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                    |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 전체 이벤트 목록 수                           |
-| events                   | Body | Array    | 이벤트 목록                                |
-| events.eventCategoryType | Body | Enum     | 이벤트 카테고리 유형                           |
-| events.eventCode         | Body | Enum     | 발생한 이벤트의 유형                           |
-| events.sourceId          | Body | String   | 이벤트 소스의 식별자                           |
-| events.sourceName        | Body | String   | 이벤트 소스를 식별할 수 있는 이름                   |
-| events.messages          | Body | Array    | 이벤트 메시지 목록                            |
-| events.messages.langCode | Body | String   | 언어 코드                                 |
-| events.messages.message  | Body | String   | 이벤트 메시지                               |
-| events.eventYmdt         | Body | DateTime | 이벤트 발생 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 구독 가능한 이벤트 코드 목록 보기
 
 ```http
 GET /v3.0/event-codes
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식    | 설명          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | 이벤트 코드 목록   |
-| eventCodes.eventCode         | Body | Enum  | 이벤트 코드      |
-| eventCodes.eventCategoryType | Body | Enum  | 이벤트 카테고리 유형 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4067,14 +4651,304 @@ GET /v3.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventCodes | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
 ---
+
+### 이벤트 목록 조회
+
+#### 요청
+
+```http
+GET /v3.0/events
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 목록 수 |
+| events | Array | 이벤트 목록 |
+| events.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | UUID | 이벤트 소스의 식별자 |
+| events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | 이벤트 메세지 |
+| events.eventYmdt | DateTime | 이벤트 발생 일시 |
+
+---
+
+## 이벤트 구독
+
+### 이벤트 구독 목록 조회
+
+#### 요청
+
+```http
+GET /v3.0/event-subscriptions
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "eventSubscriptions": [
+        {
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
+            "notifySms": false,
+            "eventCodes": [],
+            "sources": [
+                {
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
+                }
+            ],
+            "userGroupIds": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | UUID | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | DateTime | 생성 일시 |
+
+---
+
+### 이벤트 구독 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/event-subscriptions
+```
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | Y | 활성화 여부 |
+| notifyEmail | Boolean | Y | 이메일 발송 여부 |
+| notifySms | Boolean | Y | SMS 발송 여부 |
+| eventCodes | Array | Y | 구독할 이벤트 코드 목록 |
+| sources | Array | Y | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+
+---
+
+### 이벤트 구독 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 이벤트 구독 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | N | 활성화 여부 |
+| notifyEmail | Boolean | N | 이메일 발송 여부 |
+| notifySms | Boolean | N | SMS 발송 여부 |
+| eventCodes | Array | N | 구독할 이벤트 코드 목록 |
+| sources | Array | N | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+

--- a/ko/api-guide-v3.0.md
+++ b/ko/api-guide-v3.0.md
@@ -1,45 +1,50 @@
-## Database > RDS for MariaDB > API 가이드
+## RDS for MariaDB API 가이드
+
+**Database > RDS for MariaDB > API v3.0 가이드**
+
 ## RDS for MariaDB API 공통 정보
 
 ### API 엔드포인트
-| 리전        | 엔드포인트                                         |
-|-----------|-----------------------------------------------|
+
+| 리전 | 엔드포인트 |
+|------|----------|
 | 한국(판교) 리전 | https://kr1-rds-mariadb.api.nhncloudservice.com |
+
 
 ### 인증 및 권한
 
 RDS for MariaDB API를 사용하려면 User Access Key가 필요합니다. User Access Key는 NHN Cloud 계정 또는 IAM 계정을 기반으로 발급되는 인증 키로, Secret Access Key와 함께 사용하여 API 요청에 대한 인증 수단으로 활용됩니다.
 
 User Access Key와 Secret Access Key는 콘솔의 **API 보안 설정**에서 발급할 수 있습니다. User Access Key 발급 및 사용에 대한 자세한 내용은 [User Access Key](/nhncloud/ko/public-api/user-access-key)를 참고하세요.
-
 생성된 Key는 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름                         | 종류     | 형식     | 필수 | 설명                                                          |
-|----------------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY               | Header | String | O  | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-TC-AUTHENTICATION-ID     | Header | String | O  | API 보안 설정 메뉴의 User Access Key ID                            |
-| X-TC-AUTHENTICATION-SECRET | Header | String | O  | API 보안 설정 메뉴의 Secret Access Key                             |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-TC-AUTHENTICATION-ID | Header | String | Y | API 보안 설정 메뉴의 User Access Key ID |
+| X-TC-AUTHENTICATION-SECRET | Header | String | Y | API 보안 설정 메뉴의 Secret Access Key |
 
+또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
-또한 프로젝트 멤버 역할에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`로 구분하여 권한을 부여할 수 있습니다.
-
-* `RDS for MariaDB ADMIN` 권한은 모든 기능을 사용 가능합니다.
-* `RDS for MariaDB VIEWER` 권한은 정보를 조회하는 기능만 사용 가능합니다.
+* `RDS for MariaDB ADMIN` 역할은 API 실행에 필요한 모든 권한이 부여됩니다.
+* `RDS for MariaDB VIEWER` 역할은 정보를 조회하는 권한만 부여됩니다.
     * DB 인스턴스를 생성, 수정, 삭제하거나, DB 인스턴스를 대상으로 하는 어떠한 기능도 사용할 수 없습니다.
-    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용 가능합니다.
+    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용할 수 있습니다.
 
 API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같은 오류가 발생합니다.
 
-| resultCode | resultMessage | 설명          |
-|------------|---------------|-------------|
-| 80401      | Unauthorized  | 인증에 실패했습니다. |
-| 80403      | Forbidden     | 권한이 없습니다.   |
+| resultCode | resultMessage | 설명 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 인증에 실패했습니다. |
+| 80403 | Forbidden | 권한이 없습니다. |
 
 ### 응답 공통 정보
 
 모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
-#### 응답 본문
+<details>
+  <summary><strong>성공 응답</strong></summary>
+
 ```json
 {
     "header": {
@@ -50,53 +55,117 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 }
 ```
 
-#### 필드
-| 이름            | 형식      | 설명                                      |
-|---------------|---------|-----------------------------------------|
-| resultCode    | Number  | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
-| resultMessage | String  | 결과 메시지                                  |
-| isSuccessful  | Boolean | 성공 여부                                   |
+</details>
 
+<details>
+  <summary><strong>실패 응답</strong></summary>
 
+```json
+{
+    "header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
+| resultMessage | String | 결과 메시지 |
+| isSuccessful | Boolean | 성공 여부 |
 ### DB 엔진 유형
 
-| DB 엔진 유형        | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 정보 |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+| DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
 ## 프로젝트 정보
 
-### 리전 목록 보기
-
-```http
-GET /v3.0/project/regions
-```
+### 프로젝트 멤버 목록 보기
 
 #### 요청
+
+```http
+GET /v3.0/project/members
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                 | 종류   | 형식      | 설명                                                                         |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | 리전 목록                                                                      |
-| regions.regionCode | Body | Enum    | 리전 코드<br/>- `KR1`: 한국(판교) 리전 |
-| regions.isEnabled  | Body | Boolean | 리전의 활성화 여부                                                                 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
-<details><summary>예시</summary>
-<p>
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
+            "memberName": "memberName-example",
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| members.memberName | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | String | 프로젝트 멤버의 전화번호 |
+
+---
+
+### 리전 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/project/regions
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -108,7 +177,7 @@ GET /v3.0/project/regions
     "regions": [
         {
             "regionCode": "KR1",
-            "isEnabled": true
+            "isEnabled": false
         }
     ]
 }
@@ -116,51 +185,11 @@ GET /v3.0/project/regions
 
 </details>
 
----
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v3.0/project/members
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                   | 종류   | 형식     | 설명              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | 프로젝트 멤버 목록      |
-| members.memberId     | Body | UUID   | 프로젝트 멤버의 식별자    |
-| members.memberName   | Body | String | 프로젝트 멤버의 이름     |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber  | Body | String | 프로젝트 멤버의 전화번호   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "홍길동",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
-        }
-    ]
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| regions | Array | 리전 목록 |
+| regions.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Boolean | 리전의 활성화 여부 |
 
 ---
 
@@ -168,26 +197,20 @@ GET /v3.0/project/members
 
 ### DB 인스턴스 사양 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-flavors
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                     | 종류   | 형식     | 설명              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DB 인스턴스 사양 목록   |
-| dbFlavors.dbFlavorId   | Body | UUID   | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름   |
-| dbFlavors.ram          | Body | Number | 메모리 용량(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU 코어 수        |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -198,17 +221,24 @@ GET /v3.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbFlavors | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Number | CPU 코어 수 |
 
 ---
 
@@ -216,27 +246,20 @@ GET /v3.0/db-flavors
 
 ### 서브넷 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/network/subnets
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식      | 설명               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | 서브넷 목록           |
-| subnets.subnetId         | Body | UUID    | 서브넷의 식별자         |
-| subnets.subnetName       | Body | String  | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr       | Body | String  | 서브넷의 CIDR        |
-| subnets.usingGateway     | Body | Boolean | 게이트웨이 사용 여부      |
-| subnets.availableIpCount | Body | Number  | 사용 가능한 IP 수      |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -247,18 +270,26 @@ GET /v3.0/network/subnets
     },
     "subnets": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
             "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "usingGateway": false,
+            "availableIpCount": 1
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| subnets | Array | 서브넷 목록 |
+| subnets.subnetId | UUID | 서브넷의 식별자 |
+| subnets.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | String | 서브넷의 CIDR |
+| subnets.usingGateway | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Number | 사용 가능한 IP 수 |
 
 ---
 
@@ -266,25 +297,20 @@ GET /v3.0/network/subnets
 
 ### DB 엔진 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-versions
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 엔진 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 엔진 유형              |
-| dbVersions.dbVersionName     | Body | String  | DB 엔진 이름              |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -295,39 +321,43 @@ GET /v3.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "dbVersion": "MYSQL_V8036",
+            "dbVersionName": "dbVersionName-example",
+            "restorableFromObs": false
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbVersions | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | String | DB 엔진 이름 |
+| dbVersions.restorableFromObs | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 ---
 
 ## 데이터 스토리지
 
-### 데이터 스토리지 타입 목록 보기
+### 스토리지 타입 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/storage-types
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름           | 종류   | 형식    | 설명             |
-|--------------|------|-------|----------------|
-| storageTypes | Body | Array | 데이터 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -343,29 +373,30 @@ GET /v3.0/storage-types
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageTypes | Array | 스토리지 타입 목록 |
 
 ---
 
-### 데이터 스토리지 목록 보기
+### 스토리지 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/storages
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름       | 종류   | 형식    | 설명          |
-|----------|------|-------|-------------|
-| storages | Body | Array | 데이터 스토리지 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -381,8 +412,11 @@ GET /v3.0/storages
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storages | Array | 스토리지 목록 |
 
 ---
 
@@ -407,32 +441,26 @@ GET /v3.0/storages
 
 ### 작업 정보 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/jobs/{jobId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름    | 종류  | 형식   | 필수 | 설명      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 작업의 식별자 |
-
 #### 응답
 
-| 이름                             | 종류   | 형식       | 설명                                |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 작업의 식별자                           |
-| jobStatus                      | Body | Enum     | 작업의 현재 상태                         |
-| resourceRelations              | Body | Array    | 연관 리소스 목록                         |
-| resourceRelations.resourceType | Body | Enum     | 연관 리소스 유형                         |
-| resourceRelations.resourceId   | Body | UUID     | 연관 리소스의 식별자                       |
-| createdYmdt                    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -441,21 +469,30 @@ GET /v3.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "jobStatus": "DELETED",
     "resourceRelations": [
         {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
+            "resourceType": "resourceType-example",
+            "resourceId": "resourceId-example"
         }
     ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+| jobStatus | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | String | 연관 리소스의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -463,26 +500,20 @@ GET /v3.0/jobs/{jobId}
 
 ### DB 인스턴스 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instance-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                 | 종류   | 형식       | 설명                                                                       |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB 인스턴스 그룹 목록                                                            |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                          |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -493,49 +524,49 @@ GET /v3.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 그룹 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| replicationType              | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성                                                              |
-| dbInstances                  | Body | Array    | DB 인스턴스 그룹에 속한 DB 인스턴스 목록                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -544,22 +575,32 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
+            "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -587,8 +628,8 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 | `BACKING_UP`               | 백업 중         |
 | `CANCELING`                | 취소 중         |
 | `CREATING`                 | 생성 중         |
-| `CREATING_SCHEMA`          | DB 스키마 생성 중	 |
-| `CREATING_USER`            | 사용자 생성 중	    |
+| `CREATING_SCHEMA`          | DB 스키마 생성 중  |
+| `CREATING_USER`            | 사용자 생성 중     |
 | `DELETING`                 | 삭제 중         |
 | `DELETING_SCHEMA`          | DB 스키마 삭제 중  |
 | `DELETING_USER`            | 사용자 삭제 중     |
@@ -607,38 +648,25 @@ GET /v3.0/db-instance-groups/{dbInstanceGroupId}
 | `STARTING`                 | 시작 중         |
 | `STOPPING`                 | 정지 중         |
 | `SYNCING_SCHEMA`           | DB 스키마 동기화 중 |
-| `SYNCING_USER`             | 사용자 동기화 중	   |
-| `UPDATING_USER`            | 사용자 수정 중	    |
+| `SYNCING_USER`             | 사용자 동기화 중    |
+| `UPDATING_USER`            | 사용자 수정 중     |
 
 ### DB 인스턴스 목록 보기
+
+#### 요청
 
 ```http
 GET /v3.0/db-instances
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB 인스턴스 목록                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| dbInstances.description       | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB 인스턴스의 현재 진행 상태                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -649,165 +677,76 @@ GET /v3.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
+            "dbPort": 1,
             "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
+            "dbInstanceStatus": "BEFORE_CREATE",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
----
-
-### DB 인스턴스 상세 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                          | 종류   | 형식       | 설명                                                                                                                                    |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstanceGroupId           | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceName              | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| description                 | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbVersion                   | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbPort                      | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstanceStatus            | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| progressStatus              | Body | Enum     | DB 인스턴스의 현재 작업 진행 상태                                                                                                                  |
-| dbFlavorId                  | Body | UUID     | DB 인스턴스 사양의 식별자                                                                                                                       |
-| parameterGroupId            | Body | UUID     | DB 인스턴스에 적용된 파라미터 그룹의 식별자                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록                                                                                                         |
-| notificationGroupIds        | Body | Array    | DB 인스턴스에 적용된 알림 그룹의 식별자 목록                                                                                                            |
-| useDeletionProtection       | Body | Boolean  | DB 인스턴스 삭제 보호 여부                                                                                                                      |
-| supportAuthenticationPlugin | Body | Boolean  | 인증 플러그인 지원 여부                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 최신 파라미터 그룹 적용 필요 여부                                                                                                                   |
-| needMigration               | Body | Boolean  | 마이그레이션 필요 여부                                                                                                                          |
-| supportDbVersionUpgrade     | Body | Boolean  | DB 버전 업그레이드 지원 여부                                                                                                                     |
-| createdYmdt                 | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstances | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | String | DB 엔진 유형 |
+| dbInstances.dbPort | Number | DB 포트 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 생성하기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances
 ```
 
-#### 요청
+#### 요청 본문
 
-| 이름                      | 종류   | 형식      | 필수 | 설명                                                                  |
-|-------------------------|------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName          | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId              | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbVersion               | Body | Enum    | O  | DB 엔진 유형                                                            |
-| dbPort                  | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| dbUserName              | Body | String  | O  | DB 사용자 계정명                                                          |
-| dbPassword              | Body | String  | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                    |
-| parameterGroupId        | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds      | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds            | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability     | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval            | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification  | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection   | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         |
-| authenticationPlugin                         | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                  |
-| network.subnetId                             | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                    |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능  여부<br/>- 기본값: `false`                                                                                                                                                                                             |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                                                                                                    |
-| storage                                      | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                                                                                                  |    
-| storage.storageType                          | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                                                                                                         |
-| storage.storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                           |
-| backup                                       | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                    |
-| backup.backupPeriod                          | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                          |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                     |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -815,460 +754,63 @@ POST /v3.0/db-instances
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-| 이름                      | 종류   | 형식      | 필수 | 설명                                         |
-|-------------------------|------|---------|----|--------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB 인스턴스의 식별자                               |
-| dbInstanceName          | Body | String  | X  | DB 인스턴스를 식별할 수 있는 마스터 이름                   |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                          |
-| dbPort                  | Body | Number  | X  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306` |
-| dbFlavorId         | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                           |
-| parameterGroupId   | Body | UUID    | X  | 파라미터 그룹의 식별자                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                          |
-| executeBackup      | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| useOnlineFailover  | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
-    "dbSecurityGroupIds": [],
-    "executeBackup": true
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| authenticationPlugin | Enum | N | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 삭제하기
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재시작하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-### DB 인스턴스 강제 재시작하기
-```http
-POST /v3.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 인스턴스 시작하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/start
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 정지하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 백업하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup
-```
-
-#### 요청
-
-| 이름           | 종류   | 형식     | 필수 | 설명              |
-|--------------|------|--------|----|-----------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자    |
-| backupName   | Body | String | O  | 백업을 식별할 수 있는 이름 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 백업 후 내보내기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
-```
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 복제하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                        |
-|--------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                  |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                               |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                         |
-| dbFlavorId               | Body | UUID    | X  | DB 인스턴스 사양의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                   |
-| dbPort                   | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`        |
-| parameterGroupId         | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                      |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록<br/>- 기본값: 원본 DB 인스턴스 값                                  |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                            |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                            |
-| useDeletionProtection    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                               |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                                |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: 원본 DB 인스턴스 값                                       |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                  |
-| storage                  | Body | Object  | X  | 데이터 스토리지 정보 객체                                                            |    
-| storage.storageType      | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                        |
-| storage.storageSize      | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
-| backup                   | Body | Object  | X  | 백업 정보 객체                                                                  |
-| backup.backupPeriod      | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`       |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | 백업 시작 시각<br/>- 예시: `00:00:00`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간<br/>- 기본값: 원본 DB 인스턴스 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 승격하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 복원 정보 조회
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                      | 종류   | 형식       | 설명                                                                                                                                                                           |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 가장 오래된 복원 가능한 시각                                                                                                                                                             |
-| latestRestorableYmdt                    | Body | DateTime | 가장 최신의 복원 가능한 시각                                                                                                                                                             |
-| restorableBackups                       | Body | Array    | 복원 가능한 백업 목록                                                                                                                                                                 |
-| restorableBackups.backup                | Body | Object   | 백업 정보 객체                                                                                                                                                                     |
-| restorableBackups.backup.backupId       | Body | UUID     | 백업의 식별자                                                                                                                                                                      |
-| restorableBackups.backup.backupName     | Body | String   | 백업 이름                                                                                                                                                                        |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | 테이블 잠금 사용 여부                                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | 백업 크기                                                                                                                                                                        |
-| restorableBackups.backup.backupType     | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`: 수동                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | 백업 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                                              |
-| restorableBackups.backup.dbInstanceName | Body | String   | 원본 DB 인스턴스의 이름                                                                                                                                                               |
-| restorableBackups.backup.dbVersion      | Body | String   | DB 엔진 유형                                                                                                                                                                     |
-| restorableBackups.backup.failoverCount  | Body | Number   | 장애 조치 횟수                                                                                                                                                                     |
-| restorableBackups.backup.binLogFileName | Body | String   | 바이너리 로그 파일 이름                                                                                                                                                                |
-| restorableBackups.backup.binLogPosition | Body | Number   | 바이너리 로그 파일 위치                                                                                                                                                                |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | 백업 생성 일시                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | 백업 갱신 일시                                                                                                                                                                     |
-| restorableBackups.restorableBinLogs     | Body | Array    | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록                                                                                                                                             |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 복원될 마지막 쿼리 조회
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 공통 요청
-
-| 이름           | 종류    | 형식   | 필수 | 설명                                                                                                                          |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DB 인스턴스의 식별자                                                                                                                |
-| restoreType  | Query | Enum | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입 |
-
-#### restoreType이 `TIMESTAMP`인 경우
-
-| 이름          | 종류    | 형식       | 필수 | 설명                                        |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreType이 `BINLOG`인 경우
-
-| 이름             | 종류    | 형식     | 필수 | 설명                 |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| binLogFileName | Query | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| binLogPosition | Query | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-#### 응답
-
-| 이름           | 종류   | 형식       | 설명                                   |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 마지막 수행 쿼리                            |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1277,496 +819,148 @@ GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### 복원
+### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
 
-```http
-POST /v3.0/db-instances/{dbInstanceId}/restore
-```
-
-#### 공통 요청
-
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                                                                                             |
-|--------------------------|------|---------|----|------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId             | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                   |
-| restore                  | Body | Object  | O  | 복원 정보 객체                                                                                                                                       |
-| restore.restoreType      | Body | Enum    | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능 시간 범위 내의 특정 시각으로 시점 복원<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 지정하여 시점 복원<br/>- `BACKUP`: 기존에 생성한 백업을 이용하여 스냅숏 복원 |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                                                                                       |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                                                                                                    |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                              |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                                                                                |
-| dbPort                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                                                                                                     |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                                                                                   |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                               |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                 |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                                                                                                  |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                            |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                 |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                     |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                       |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                 |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                       |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                 |
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                            |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                              |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                                                                                                       |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                    |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                             |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                        |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br>기본값: `false`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름                  | 종류   | 형식       | 필수 | 설명                                                                                             |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능하다. |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름                            | 종류   | 형식     | 필수 | 설명                 |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| restore.binLog                | Body | Object | O  | 바이너리 로그 정보 객체      |
-| restore.binLog.binLogFileName | Body | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-* 바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름               | 종류   | 형식   | 필수                           | 설명              |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreType이 `BACKUP`인 경우) | 복원에 사용할 백업의 식별자 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-### 오브젝트 스토리지로부터 복원
+#### 요청
 
 ```http
 POST /v3.0/db-instances/restore-from-obs
 ```
 
-#### 요청
+#### 요청 본문
 
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| restore                  | Body | Object  | O  | 복원 정보 객체                                                            |
-| restore.tenantId         | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 테넌트 ID                                           |
-| restore.username         | Body | String  | O  | NHN Cloud 계정 또는 IAM 계정 ID                                           |
-| restore.password         | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 API 비밀번호                                         |
-| restore.targetContainer  | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 컨테이너                                             |
-| restore.objectPath       | Body | String  | O  | 컨테이너에 저장된 백업의 경로                                                    |
-| dbVersion                | Body | Enum    | O  | DB 엔진 유형                                                            |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbPort                   | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    |
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                          |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                            |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                            |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                      |
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                 |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                            |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "MYSQL_V8036",
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
     "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "0123456789abcdef0123456789abcdef",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-
-### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O  | 삭제 보호 여부     |
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-### 고가용성 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/high-availability
-```
+### DB 인스턴스 삭제하기
 
 #### 요청
 
-| 이름                  | 종류   | 형식      | 필수 | 설명                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB 인스턴스의 식별자                                         |
-| useHighAvailability | Body | Boolean | O  | 고가용성 사용 여부                                           |
-| pingInterval        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 다시 시작하기
-
 ```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
+DELETE /v3.0/db-instances/{dbInstanceId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 일시 중지하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 복구하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 분리하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 데이터 스토리지 정보 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름            | 종류   | 형식     | 설명                                                                                   |
-|---------------|------|--------|--------------------------------------------------------------------------------------|
-| storageType   | Body | Enum   | 데이터 스토리지 타입                                                                          |
-| storageSize   | Body | Number | 데이터 스토리지 크기(GB)                                                                      |
-| storageStatus | Body | Enum   | 데이터 스토리지의 현재 상태<br/>- `DETACHED`: 부착되지 않음<br/>- `ATTACHED`: 부착됨<br/>- `DELETED`: 삭제됨 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1775,69 +969,258 @@ GET /v3.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### 데이터 스토리지 정보 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/storage-info
-```
+### DB 인스턴스 상세 보기
 
 #### 요청
 
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| storageSize       | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: 현재값<br/>- 최댓값: `2048`                          |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
+```http
+GET /v3.0/db-instances/{dbInstanceId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "NONE",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "useDeletionProtection": false,
+    "supportAuthenticationPlugin": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| dbPort | Number | DB 포트 |
+| dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | DB 인스턴스 삭제 보호 여부 |
+| supportAuthenticationPlugin | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### DB 인스턴스 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "MYSQL_V8036",
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbVersion | String | N | DB 엔진 버전 코드 |
+| useDummy | Boolean | N | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 백업하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "backupName": "backupName"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupName | String | Y | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 정보 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름                                | 종류   | 형식      | 설명             |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | 백업 보관 기간(일)    |
-| ftwrlWaitTimeout                  | Body | Number  | 쿼리 지연 대기 시간(초) |
-| backupRetryCount                  | Body | Number  | 백업 재시도 횟수      |
-| replicationRegion                 | Body | Enum    | 백업 복제 리전       |
-| useBackupLock                     | Body | Boolean | 테이블 잠금 사용 여부   |
-| backupSchedules                   | Body | Array   | 예정된 자동 백업 목록   |
-| backupSchedules.backupWndBgnTime  | Body | String  | 백업 시작 시각       |
-| backupSchedules.backupWndDuration | Body | Enum    | 백업 Duration    |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1847,101 +1230,86 @@ GET /v3.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
             "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backupPeriod | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Number | 백업 재시도 횟수 |
+| replicationRegion | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### 백업 정보 수정하기
 
+#### 요청
+
 ```http
 PUT /v3.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                                    | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                          |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                |
-| backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부                                                                                                                                                                                                                |
-| backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndBgnTime": "00:00:00",
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 네트워크 정보 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름                     | 종류   | 형식     | 설명                                                                                                                                      |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DB 인스턴스를 생성할 가용성 영역                                                                                                                     |
-| subnet                 | Body | Object | 서브넷 객체                                                                                                                                  |
-| subnet.subnetId        | Body | UUID   | 서브넷의 식별자                                                                                                                                |
-| subnet.subnetName      | Body | UUID   | 서브넷을 식별할 수 있는 이름                                                                                                                        |
-| subnet.subnetCidr      | Body | UUID   | 서브넷의 CIDR                                                                                                                               |
-| endPoints              | Body | Array  | 접속 정보 목록                                                                                                                                |
-| endPoints.domain       | Body | String | 도메인                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP 주소                                                                                                                                   |
-| endPoints.endPointType | Body | Enum   | 접속 정보 타입<br>-`EXTERNAL`: 외부 접속 도메인<br>-`INTERNAL`: 내부 접속 도메인<br>-`PUBLIC`: (Deprecated) 외부 접속 도메인<br>-`PRIVATE`: (Deprecated) 내부 접속 도메인 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1950,78 +1318,61 @@ GET /v3.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 네트워크 정보 수정하기
-
-```http
-PUT /v3.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 요청
-
-| 이름              | 종류   | 형식      | 필수 | 설명           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O  | 외부 접속 가능  여부 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### DB 사용자 목록 보기
-
-```http
-GET /v3.0/db-instances/{dbInstanceId}/db-users
-```
+### DB 인스턴스 오브젝트 스토리지로 백업
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/db-instances/{dbInstanceId}/backup-to-object-storage
+```
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB 사용자 목록                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DB 사용자의 식별자                                                                                                                 |
-| dbUsers.dbUserName           | Body | String   | DB 사용자 계정 이름                                                                                                                |
-| dbUsers.host                 | Body | String   | DB 사용자 계정의 호스트 이름                                                                                                           |
-| dbUsers.authorityType        | Body | Enum     | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/>            |
-| dbUsers.dbUserStatus         | Body | Enum     | DB 사용자의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `UPDATING`: 수정 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbUsers.authenticationPlugin         | Body | Enum    | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-| dbUsers.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2030,150 +1381,64 @@ GET /v3.0/db-instances/{dbInstanceId}/db-users
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
-### DB 사용자 생성하기
-
-```http
-POST /v3.0/db-instances/{dbInstanceId}/db-users
-```
+### 테스트 용 DB 이미지 메타 변경
 
 #### 요청
 
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserName           | Body | String | O  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `32`                                                                  |
-| dbPassword           | Body | String | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| host                 | Body | String | O  | DB 사용자 계정의 호스트명<br/>- 예시: `1.1.1.%`                                                                              |
-| authorityType        | Body | Enum   | O  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 수정하기
-
 ```http
-PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+PUT /v3.0/db-instances/{dbInstanceId}/change-image-meta
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserId             | URL  | UUID   | O  | DB 사용자의 식별자                                                                                                      |
-| dbPassword           | Body | String | X  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| authorityType        | Body | Enum   | X  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 삭제하기
-
-```http
-DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbUserId     | URL | UUID | O  | DB 사용자의 식별자  |
-
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ### DB 스키마 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                                                                                   |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB 스키마 목록                                                                                            |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB 스키마의 식별자                                                                                          |
-| dbSchemas.dbSchemaName   | Body | String   | DB 스키마 이름                                                                                            |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB 스키마의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbSchemas.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                    |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2184,92 +1449,666 @@ GET /v3.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSchemaName": "dbSchemaName-example",
             "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSchemas | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | UUID | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### DB 스키마 생성하기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름           | 종류   | 형식     | 필수 | 설명           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O  | DB 스키마 이름    |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 스키마 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbSchemaId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbSchemaId   | URL | UUID | O  | DB 스키마의 식별자  |
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbUserName": "dbUserName-example",
+            "host": "192.168.0.1",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbUsers | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
+| dbUsers.dbUserName | String | DB 사용자 계정 이름 |
+| dbUsers.host | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+---
+
+### DB 사용자 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "192.168.0.1",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | String | Y | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Enum | Y | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 사용자 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+| dbUserId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Enum | N | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 삭제 보호 설정 변경
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 삭제 보호 여부 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 강제 재시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 고가용성 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 고가용성 사용 여부 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 일시 중지하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 복구하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 다시 시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 고가용성 분리하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 로그 파일 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-instances/{dbInstanceId}/log-files
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식    | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileTypes | Query | Array | X  | 로그 파일 타입 종류 목록<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | 로그 파일 목록                                                                                                                                                                                     |
-| logFiles.logFileName | Body | String   | 로그 파일 이름                                                                                                                                                                                     |
-| logFiles.logFileType | Body | Enum     | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | 로그 파일 크기(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2280,60 +2119,821 @@ GET /v3.0/db-instances/{dbInstanceId}/log-files
     },
     "logFiles": [
         {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| logFiles | Array | 로그 파일 목록 |
+| logFiles.logFileName | String | 로그 파일 이름 |
+| logFiles.logFileType | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 로그 파일 내보내기
 
+#### 요청
+
 ```http
 POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름              | 종류   | 형식     | 필수 | 설명                             |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                   |
-| logFileNames    | Body | Array  | O  | 로그 파일 이름 목록<br/>- 최소 크기: `1`   |
-| tenantId        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID      |
-| password        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 로그 파일의 경로            |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
+    "logFileNames": [],
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | 로그 파일 이름 목록 |
+| tenantId | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 로그 파일의 경로 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 네트워크 정보 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "kr-pub-a",
+    "subnet": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "192.168.0.0/24"
+    },
+    "endPoints": [
+        {
+            "domain": "domain-example",
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZone | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Object | 서브넷 객체 |
+| subnet.subnetId | UUID | 서브넷의 식별자 |
+| subnet.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | String | 서브넷의 CIDR |
+| endPoints | Array | 접속 정보 목록 |
+| endPoints.domain | String | 도메인 |
+| endPoints.ipAddress | String | IP 주소 |
+| endPoints.endPointType | String | 접속 정보 타입 |
+
+---
+
+### 네트워크 정보 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 외부 접속 가능 여부 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 승격하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 복제하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부 |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | N | 스토리지 정보 객체 |
+| storage.storageType | Enum | N | 데이터 스토리지 타입 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | N | 백업 정보 객체 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 재시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 복원 정보 조회
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 복원될 마지막 쿼리 조회
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| executedYmdt | DateTime | 쿼리 수행 일시 |
+| lastQuery | String | 마지막 수행 쿼리 |
+
+---
+
+### DB 인스턴스 복원
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "imageId": "550e8400-e29b-41d4-a716-446655440000",
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "General SSD",
+        "storageSize": 20
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "kr-pub-a"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndBgnTime": "00:00:00",
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| imageId | UUID | N | 이미지의 식별자 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.restoreType | Enum | Y | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | String | N | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Object | N | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB 인스턴스 복원 일시 |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Object | N | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 시작하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/start
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 인스턴스 정지하기
+
+#### 요청
+
+```http
+POST /v3.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### 스토리지 정보 보기
+
+#### 요청
+
+```http
+GET /v3.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "General SSD",
+    "storageSize": 1,
+    "storageStatus": "DELETED"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageType | Enum | 데이터 스토리지 타입 |
+| storageSize | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+
+---
+
+### 스토리지 정보 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "storageSize": 1
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2351,40 +2951,20 @@ POST /v3.0/db-instances/{dbInstanceId}/log-files/export
 
 ### 백업 목록 조회
 
+#### 요청
+
 ```http
 GET /v3.0/backups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식     | 필수 | 설명                                                       |
-|--------------|-------|--------|----|----------------------------------------------------------|
-| page         | Query | Number | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                               |
-| size         | Query | Number | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`           |
-| backupType   | Query | Enum   | X  | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동<br/>- 기본값: 전체 |
-| dbInstanceId | Query | UUID   | X  | 원본 DB 인스턴스의 식별자                                          |
-| dbVersion    | Query | Enum   | X  | DB 엔진 유형                                                 |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 전체 백업 목록 수                        |
-| backups              | Body | Array    | 백업 목록                             |
-| backups.backupId     | Body | UUID     | 백업의 식별자                           |
-| backups.backupName   | Body | String   | 백업을 식별할 수 있는 이름                   |
-| backups.backupStatus | Body | Enum     | 백업의 현재 상태                         |
-| backups.dbInstanceId | Body | UUID     | 원본 DB 인스턴스의 식별자                   |
-| backups.dbVersion    | Body | Enum     | DB 엔진 유형                          |
-| backups.backupType   | Body | Enum     | 백업 유형                             |
-| backups.backupSize   | Body | Number   | 백업의 크기(Byte)                      |
-| createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2396,120 +2976,180 @@ GET /v3.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
+            "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 백업 목록 수 |
+| backups | Array | 백업 목록 |
+| backups.backupId | UUID | 백업의 식별자 |
+| backups.backupName | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | String | DB 엔진 유형 |
+| backups.utilVersion | String | 유틸리티 버전 |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | DateTime | 생성 일시 |
+| backups.updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 백업 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/backups/{backupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 내보내기
 
+#### 요청
+
 ```http
 POST /v3.0/backups/{backupId}/export
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | 백업의 식별자                     |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "0123456789abcdef0123456789abcdef",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
-> [주의]
-> 수동 백업의 경우 백업이 수행된 DB 인스턴스가 존재하지 않으면, 백업을 오브젝트 스토리지로 내보낼 수 없습니다.
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### 백업 복원하기
 
+#### 요청
+
 ```http
 POST /v3.0/backups/{backupId}/restore
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                       | 종류   | 형식      | 필수 | 설명                                                                  |
-|--------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                 | URL  | UUID    | O  | 백업의 식별자                                                             |
-| dbInstanceName           | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName  | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름                                         |
-| description              | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId               | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbPort                   | Body | Integer | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId         | Body | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds       | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds             | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability      | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval             | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification   | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection    | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         | 
-| network                  | Body | Object  | O  | 네트워크 정보 객체                                                          |
-| network.subnetId         | Body | UUID    | O  | 서브넷의 식별자                                                            |
-| network.usePublicAccess  | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                            |
-| storage                  | Body | Object  | O  | 데이터 스토리지 정보 객체                                                      |    
-| storage.storageType      | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                 |
-| storage.storageSize      | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| backup                   | Body | Object  | O  | 백업 정보 객체                                                            |
-| backup.backupPeriod      | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout  | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount  | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
         "availabilityZone": "kr-pub-a"
     },
     "storage": {
@@ -2517,7 +3157,11 @@ POST /v3.0/backups/{backupId}/restore
         "storageSize": 20
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
                 "backupWndBgnTime": "00:00:00",
@@ -2528,36 +3172,59 @@ POST /v3.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
----
-
-### 백업 삭제하기
-
-```http
-DELETE /v3.0/backups/{backupId}
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
 ```
 
-#### 요청
+</details>
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2574,28 +3241,20 @@ DELETE /v3.0/backups/{backupId}
 
 ### DB 보안 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-security-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                   | 종류   | 형식       | 설명                                |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB 보안 그룹 목록                       |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                     |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름             |
-| dbSecurityGroups.description         | Body | String   | DB 보안 그룹에 대한 추가 정보                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2606,61 +3265,150 @@ GET /v3.0/db-security-groups
     },
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
             "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroups | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### DB 보안 그룹 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-security-groups
+```
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
+        {
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
+            },
+            "cidr": "192.168.0.0/24",
+            "description": "description-example"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Array | Y | DB 보안 그룹 규칙 목록 |
+| rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | Y | 포트 객체 |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | 보안 그룹 규칙에 대한 추가 정보 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+
+---
+
+### DB 보안 그룹 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ### DB 보안 그룹 상세 보기
 
+#### 요청
+
 ```http
 GET /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
 #### 응답
 
-| 이름                  | 종류   | 형식       | 설명                                                                                                                 |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                                                                                                      |
-| dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                              |
-| description         | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                 |
-| progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                                                                                                 |
-| rules               | Body | Array    | DB 보안 그룹 규칙 목록                                                                                                     |
-| rules.ruleId        | Body | UUID     | DB 보안 그룹 규칙의 식별자                                                                                                   |
-| rules.description   | Body | String   | DB 보안 그룹 규칙에 대한 추가 정보                                                                                              |
-| rules.direction     | Body | Enum     | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                       |
-| rules.etherType     | Body | Enum     | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | 포트 객체                                                                                                              |
-| rules.port.portType | Body | Enum     | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number   | 최소 포트 범위                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 최대 포트 범위                                                                                                           |
-| rules.cidr          | Body | String   | 허용할 트래픽의 원격 소스                                                                                                     |
-| rules.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2670,300 +3418,278 @@ GET /v3.0/db-security-groups/{dbSecurityGroupId}
         "isSuccessful": true
     },
     "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
+        "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
+        "dbSecurityGroupName": "dbSecurityGroupName-example",
+        "description": "description-example",
         "progressStatus": "NONE",
         "rules": [
             {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
+                "ruleId": "550e8400-e29b-41d4-a716-446655440000",
+                "description": "description-example",
                 "direction": "INGRESS",
                 "etherType": "IPV4",
                 "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
+                    "portType": "ALL",
+                    "minPort": 1,
+                    "maxPort": 1
                 },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
+                "cidr": "192.168.0.0/24",
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
             }
         ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
     }
 }
 ```
 
-</p>
 </details>
 
----
-
-### DB 보안 그룹 생성하기
-
-```http
-POST /v3.0/db-security-groups
-```
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                    |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB 보안 그룹 규칙 목록                                                                                                                                                                           |
-| rules.description   | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| rules.port.maxPort  | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                | 종류   | 형식   | 설명            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroup | Object | DB 보안 그룹 |
+| dbSecurityGroup.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroup.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroup.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroup.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroup.rules | Array | DB 보안 그룹 규칙 목록 |
+| dbSecurityGroup.rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
+| dbSecurityGroup.rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| dbSecurityGroup.rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| dbSecurityGroup.rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| dbSecurityGroup.rules.port | Object | 포트 객체 |
+| dbSecurityGroup.rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| dbSecurityGroup.rules.port.minPort | Number | 최소 포트 범위 |
+| dbSecurityGroup.rules.port.maxPort | Number | 최대 포트 범위 |
+| dbSecurityGroup.rules.cidr | String | CIDR |
+| dbSecurityGroup.rules.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.rules.updatedYmdt | DateTime | 수정 일시 |
+| dbSecurityGroup.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroup.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 수정하기
 
+#### 요청
+
 ```http
 PUT /v3.0/db-security-groups/{dbSecurityGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름                  | 종류   | 형식     | 필수 | 설명                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB 보안 그룹의 식별자         |
-| dbSecurityGroupName | Body | String | X  | DB 보안 그룹을 식별할 수 있는 이름 |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보    |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v3.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB 보안 그룹 규칙의 식별자                                                                                                                                                                         |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값을 필요로 하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류    | 형식    | 필수 | 설명                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB 보안 그룹의 식별자       |
-| ruleIds           | Query | Array | O  | DB 보안 그룹 규칙의 식별자 목록 |
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "192.168.0.0/24",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
@@ -2971,33 +3697,20 @@ DELETE /v3.0/db-security-groups/{dbSecurityGroupId}/rules
 
 ### 파라미터 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/parameter-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름        | 종류    | 형식   | 필수 | 설명       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB 엔진 유형 |
-
 #### 응답
 
-| 이름                                   | 종류   | 형식       | 설명                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | 파라미터 그룹 목록                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | 파라미터 그룹의 식별자                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                              |
-| parameterGroups.description          | Body | String   | 파라미터 그룹에 대한 추가 정보                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB 엔진 유형                                                          |
-| parameterGroups.parameterGroupStatus | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요 |
-| parameterGroups.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3008,62 +3721,66 @@ GET /v3.0/parameter-groups
     },
     "parameterGroups": [
         {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "MYSQL_V8036",
             "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroups | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | String | DB 엔진 유형 |
+| parameterGroups.parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v3.0/parameter-groups/{parameterGroupId}
-```
+### 파라미터 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/parameter-groups
+```
 
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | String | Y | DB 엔진 유형 |
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                     |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | 파라미터 그룹의 식별자                                                                                           |
-| parameterGroupName            | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                                                                   |
-| description                   | Body | String   | 파라미터 그룹에 대한 추가 정보                                                                                      |
-| dbVersion                     | Body | Enum     | DB 엔진 유형                                                                                               |
-| parameterGroupStatus          | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요                                      |
-| parameters                    | Body | Array    | 파라미터 목록                                                                                                |
-| parameters.parameterId        | Body | UUID     | 파라미터 식별자                                                                                               |
-| parameters.parameterFileGroup | Body | Enum     | 파라미터 파일 그룹 타입<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | 파라미터 이름                                                                                                |
-| parameters.fileParameterName  | Body | String   | 파라미터 파일 이름                                                                                             |
-| parameters.value              | Body | String   | 현재 설정된 값                                                                                               |
-| parameters.defaultValue       | Body | String   | 기본값                                                                                                    |
-| parameters.allowedValue       | Body | String   | 허용된 값                                                                                                  |
-| parameters.updateType         | Body | Enum     | 수정 타입<br/>- `VARIABLE`: 언제든 수정 가능<br/>- `CONSTANT`: 수정 불가능<br/>- `INIT_VARIABLE`: DB 인스턴스 생성 시에만 수정 가능 |
-| parameters.applyType          | Body | Enum     | 적용 타입<br/>- `SESSION`: 세션 적용<br/>- `FILE`: 설정 파일 적용(재시작 필요)<br/>- `BOTH`: 전체(재시작 필요)                   |
-| createdYmdt                   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3072,261 +3789,64 @@ GET /v3.0/parameter-groups/{parameterGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v3.0/parameter-groups
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-| dbVersion          | Body | Enum   | O  | DB 엔진 유형             |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v3.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | X  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 요청
-
-| 이름                             | 종류   | 형식     | 필수 | 설명           |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | 파라미터 그룹의 식별자 |
-| modifiedParameters             | Body | Array  | O  | 변경할 파라미터 목록  |
-| modifiedParameters.parameterId | Body | UUID   | O  | 파라미터의 식별자    |
-| modifiedParameters.value       | Body | String | O  | 변경할 파라미터 값   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v3.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 요청
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/parameter-groups/{parameterGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 파라미터 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3334,12 +3854,215 @@ DELETE /v3.0/parameter-groups/{parameterGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "MYSQL_V8036",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Array | 파라미터 목록 |
+| parameters.parameterId | UUID | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | 파라미터 이름 |
+| parameters.fileParameterName | String | 파라미터 파일 이름 |
+| parameters.value | String | 현재 설정된 값 |
+| parameters.defaultValue | String | 기본값 |
+| parameters.allowedValue | String | 허용된 값 |
+| parameters.updateType | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 파라미터 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+#### 요청
+
+```http
+POST /v3.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+
+---
+
+### 파라미터 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | UUID | Y | 파라미터의 식별자 |
+| modifiedParameters.value | String | Y | 변경할 파라미터 값 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+#### 요청
+
+```http
+PUT /v3.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -3347,26 +4070,20 @@ DELETE /v3.0/parameter-groups/{parameterGroupId}
 
 ### 사용자 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/user-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId   | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| userGroups.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3377,48 +4094,60 @@ GET /v3.0/user-groups
     },
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 사용자 그룹 상세 보기
-
-```http
-GET /v3.0/user-groups/{userGroupId}
-```
+### 사용자 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/user-groups
+```
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | Y | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름                | 종류   | 형식       | 설명                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | 사용자 그룹의 식별자                                                                                               |
-| userGroupName     | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                                                                       |
-| userGroupTypeCode | Body | Enum     | 사용자 그룹 종류    <br /> `ENTIRE`: 프로젝트 멤버 전체를 포함하는 사용자 그룹 <br /> `INDIVIDUAL_MEMBER`: 특정 프로젝트 멤버를 포함하는 사용자 그룹 |
-| members           | Body | Array    | 프로젝트 멤버 목록                                                                                                |
-| members.memberId  | Body | UUID     | 프로젝트 멤버의 식별자                                                                                              |
-| createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3427,139 +4156,64 @@ GET /v3.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 사용자 그룹 생성하기
-
-```http
-POST /v3.0/user-groups
-```
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                          |
-|---------------|------|---------|----|-------------------------------------------------------------|
-| userGroupName | Body | String  | O  | 사용자 그룹을 식별할 수 있는 이름                                         |
-| memberIds     | Body | Array   | O  | 프로젝트 멤버의 식별자 목록 <br /> `selectAllYN`이 true인 경우 해당 필드 값은 무시됨 |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨          |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAllYN":true
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름          | 종류   | 형식   | 설명          |
-|-------------|------|------|-------------|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
----
-
-### 사용자 그룹 수정하기
-
-```http
-PUT /v3.0/user-groups/{userGroupId}
-```
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | 사용자 그룹의 식별자                                        |
-| userGroupName | Body | String  | X  | 사용자 그룹을 식별할 수 있는 이름                                |
-| memberIds     | Body | Array   | X  | 프로젝트 멤버의 식별자 목록                                    |
-| selectAllYN   | Body | Boolean | X  | 프로젝트 멤버 전체 유무 <br /> true인 경우 해당 그룹은 전체 멤버에 대해 설정됨 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
 
 ---
 
 ### 사용자 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/user-groups/{userGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 사용자 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/user-groups/{userGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3567,12 +4221,72 @@ DELETE /v3.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 사용자 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/user-groups/{userGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAllYN": false
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | N | 프로젝트 멤버의 식별자 목록 |
+| selectAllYN | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -3580,29 +4294,20 @@ DELETE /v3.0/user-groups/{userGroupId}
 
 ### 알림 그룹 목록 보기
 
+#### 요청
+
 ```http
 GET /v3.0/notification-groups
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                       | 종류   | 형식       | 설명                                |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 알림 그룹 목록                          |
-| notificationGroups.notificationGroupId   | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroups.notificationGroupName | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notificationGroups.notifyEmail           | Body | Boolean  | 이메일 알림 여부                         |
-| notificationGroups.notifySms             | Body | Boolean  | SMS 알림 여부                         |
-| notificationGroups.isEnabled             | Body | Boolean  | 활성화 여부                            |
-| notificationGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3613,57 +4318,72 @@ GET /v3.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
             "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroups | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
-### 알림 그룹 상세 보기
-
-```http
-GET /v3.0/notification-groups/{notificationGroupId}
-```
+### 알림 그룹 생성하기
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v3.0/notification-groups
+```
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName",
+    "notifyEmail": true,
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름                         | 종류   | 형식       | 설명                                |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroupName      | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notifyEmail                | Body | Boolean  | 이메일 알림 여부                         |
-| notifySms                  | Body | Boolean  | SMS 알림 여부                         |
-| isEnabled                  | Body | Boolean  | 활성화 여부                            |
-| dbInstances                | Body | Array    | 감시 대상 DB 인스턴스 목록                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DB 인스턴스의 식별자                      |
-| dbInstances.dbInstanceName | Body | String   | DB 인스턴스를 식별할 수 있는 이름              |
-| userGroups                 | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId     | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName   | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| createdYmdt                | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3672,154 +4392,64 @@ GET /v3.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-</p>
 </details>
 
----
-
-### 알림 그룹 생성하기
-
-```http
-POST /v3.0/notification-groups
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 알림 그룹을 식별할 수 있는 이름          |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled             | Body | Boolean | X  | 활성화 여부<br/>- 기본값: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 감시 대상 DB 인스턴스의 식별자 목록       |
-| userGroupIds          | Body | Array   | O  | 사용자 그룹의 식별자 목록              |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                  | 종류   | 형식   | 설명         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
----
-
-### 알림 그룹 수정하기
-
-```http
-PUT /v3.0/notification-groups/{notificationGroupId}
-```
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 알림 그룹의 식별자            |
-| notificationGroupName | Body | String  | X  | 알림 그룹을 식별할 수 있는 이름    |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부             |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부             |
-| isEnabled             | Body | Boolean | X  | 활성화 여부                |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
 
 ---
 
 ### 알림 그룹 삭제하기
 
+#### 요청
+
 ```http
 DELETE /v3.0/notification-groups/{notificationGroupId}
 ```
 
-#### 요청
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### 알림 그룹 상세 보기
+
+#### 요청
+
+```http
+GET /v3.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3827,37 +4457,132 @@ DELETE /v3.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
+        {
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceName": "dbInstanceName-example"
+        }
+    ],
+    "userGroups": [
+        {
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | 이메일 알림 여부 |
+| notifySms | Boolean | SMS 알림 여부 |
+| isEnabled | Boolean | 활성화 여부 |
+| dbInstances | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
+
+---
+
+### 알림 그룹 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/notification-groups/{notificationGroupId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Array | N | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
 ## 모니터링
 
-### Metric 목록 보기
-
-```http
-GET /v3.0/metrics
-```
+### 통계 정보 조회
 
 #### 요청
+
+```http
+GET /v3.0/metric-statistics
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                  | 종류   | 형식     | 설명        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metric 목록 |
-| metrics.measureName | Body | Enum   | 조회 지표 유형  |
-| metrics.unit        | Body | String | 측정값 단위    |
+이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
+---
+
+### Metric 목록 보기
+
+#### 요청
+
+```http
+GET /v3.0/metrics
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3868,75 +4593,20 @@ GET /v3.0/metrics
     },
     "metrics": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
+            "measureName": "measureName-example",
+            "unit": "unit-example"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
----
-
-### 통계 정보 조회
-
-```http
-GET /v3.0/metric-statistics
-```
-
-#### 요청
-
-| 이름           | 종류    | 형식       | 필수 | 설명                                |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB 인스턴스의 식별자                      |
-| measureNames | Query | Array    | O  | 조회 지표 목록<br/>- 최소 크기: `1`         |
-| from         | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 조회 간격                             |
-
-#### 응답
-
-| 이름                                | 종류   | 형식        | 설명       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 통계 정보 목록 |
-| metricStatistics.measureName      | Body | Enum      | 측정 항목 유형 |
-| metricStatistics.unit             | Body | String    | 측정값 단위   |
-| metricStatistics.values           | Body | Array     | 측정값 목록   |
-| metricStatistics.values.timestamp | Body | Timestamp | 측정 시간    |
-| metricStatistics.values.value     | Body | Object    | 측정값      |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
-}
-```
-
-</p>
-</details>
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| metrics | Array | Metric 목록 |
+| metrics.measureName | String | 조회 지표 유형 |
+| metrics.unit | String | 측정값 단위 |
 
 ---
 
@@ -3955,108 +4625,22 @@ GET /v3.0/metric-statistics
 | TENANT      | 테넌트     |
 | MONITORING  | 모니터링    |
 
-### 이벤트 목록 조회
-
-```http
-GET /v3.0/events
-```
+### 구독 가능한 이벤트 코드 목록 보기
 
 #### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | O  | 조회할 목록의 페이지<br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | O  | 조회할 목록의 페이지 크기<br/>- 최솟값: `1`<br/>- 최댓값: `100`                                                                                       |
-| from              | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 조회할 이벤트 카테고리 유형<br/>- `ALL`: 전체<br/>- `INSTANCE`: DB 인스턴스<br/>- `BACKUP`: 백업<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `TENANT`: 테넌트 |
-| sourceId          | Query | String   | X  | 이벤트가 발생한 대상 리소스의 식별자                                                                                                                 |
-| keyword           | Query | String   | X  | 이벤트 메시지에 포함된 문자열 검색어                                                                                                                 |
-| ascendingOrder    | Query | Enum     | X  | 이벤트 메시지 정렬 순서<br/>- `ASC`: 오름차순<br/>- `DESC`: 내림차순<br/>- 기본값: `DESC`                                                                 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                    |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 전체 이벤트 목록 수                           |
-| events                   | Body | Array    | 이벤트 목록                                |
-| events.eventCategoryType | Body | Enum     | 이벤트 카테고리 유형                           |
-| events.eventCode         | Body | Enum     | 발생한 이벤트의 유형                           |
-| events.sourceId          | Body | String   | 이벤트 소스의 식별자                           |
-| events.sourceName        | Body | String   | 이벤트 소스를 식별할 수 있는 이름                   |
-| events.messages          | Body | Array    | 이벤트 메시지 목록                            |
-| events.messages.langCode | Body | String   | 언어 코드                                 |
-| events.messages.message  | Body | String   | 이벤트 메시지                               |
-| events.eventYmdt         | Body | DateTime | 이벤트 발생 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 구독 가능한 이벤트 코드 목록 보기
 
 ```http
 GET /v3.0/event-codes
 ```
 
-#### 요청
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식    | 설명          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | 이벤트 코드 목록   |
-| eventCodes.eventCode         | Body | Enum  | 이벤트 코드      |
-| eventCodes.eventCategoryType | Body | Enum  | 이벤트 카테고리 유형 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4067,14 +4651,304 @@ GET /v3.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCode": "ENUM_VALUE",
+            "eventCategoryType": "ALL"
         }
     ]
 }
 ```
 
-</p>
 </details>
 
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventCodes | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+
 ---
+
+### 이벤트 목록 조회
+
+#### 요청
+
+```http
+GET /v3.0/events
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 목록 수 |
+| events | Array | 이벤트 목록 |
+| events.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | UUID | 이벤트 소스의 식별자 |
+| events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | 이벤트 메세지 |
+| events.eventYmdt | DateTime | 이벤트 발생 일시 |
+
+---
+
+## 이벤트 구독
+
+### 이벤트 구독 목록 조회
+
+#### 요청
+
+```http
+GET /v3.0/event-subscriptions
+```
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "eventSubscriptions": [
+        {
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
+            "notifySms": false,
+            "eventCodes": [],
+            "sources": [
+                {
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+                    "eventCategoryType": "ALL"
+                }
+            ],
+            "userGroupIds": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | UUID | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | DateTime | 생성 일시 |
+
+---
+
+### 이벤트 구독 생성하기
+
+#### 요청
+
+```http
+POST /v3.0/event-subscriptions
+```
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | Y | 활성화 여부 |
+| notifyEmail | Boolean | Y | 이메일 발송 여부 |
+| notifySms | Boolean | Y | SMS 발송 여부 |
+| eventCodes | Array | Y | 구독할 이벤트 코드 목록 |
+| sources | Array | Y | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+
+---
+
+### 이벤트 구독 삭제하기
+
+#### 요청
+
+```http
+DELETE /v3.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 이벤트 구독 수정하기
+
+#### 요청
+
+```http
+PUT /v3.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | N | 활성화 여부 |
+| notifyEmail | Boolean | N | 이메일 발송 여부 |
+| notifySms | Boolean | N | SMS 발송 여부 |
+| eventCodes | Array | N | 구독할 이벤트 코드 목록 |
+| sources | Array | N | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -84,6 +84,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 GET /v4.0/project/members
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | 프로젝트 멤버 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -130,6 +136,12 @@ GET /v4.0/project/members
 GET /v4.0/project/regions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | 리전 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -173,6 +185,12 @@ GET /v4.0/project/regions
 ```http
 GET /v4.0/db-flavors
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbFlavor.List | DB 인스턴스 사양 목록 보기 |
 
 #### 요청
 
@@ -221,6 +239,12 @@ GET /v4.0/db-flavors
 ```http
 GET /v4.0/network/subnets
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Network.List | 서브넷 목록 보기 |
 
 #### 요청
 
@@ -272,6 +296,12 @@ GET /v4.0/network/subnets
 GET /v4.0/db-versions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbVersion.List | DB 엔진 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -317,6 +347,12 @@ GET /v4.0/db-versions
 ```http
 GET /v4.0/storage-types
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Storage.List | 스토리지 타입 목록 보기 |
 
 #### 요청
 
@@ -371,6 +407,12 @@ GET /v4.0/storage-types
 ```http
 GET /v4.0/jobs/{jobId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Job.Get | 작업 정보 상세 보기 |
 
 #### 요청
 
@@ -428,6 +470,12 @@ GET /v4.0/jobs/{jobId}
 GET /v4.0/db-instance-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -473,6 +521,12 @@ GET /v4.0/db-instance-groups
 ```http
 GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
 
 #### 요청
 
@@ -577,6 +631,12 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 GET /v4.0/db-instances
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.List | DB 인스턴스 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -636,6 +696,12 @@ GET /v4.0/db-instances
 ```http
 POST /v4.0/db-instances
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
 
 #### 공통 요청
 
@@ -774,6 +840,12 @@ POST /v4.0/db-instances
 ```http
 POST /v4.0/db-instances/restore-from-obs
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | 오브젝트 스토리지를 이용한 DB 인스턴스 복원 |
 
 #### 공통 요청
 
@@ -918,6 +990,12 @@ POST /v4.0/db-instances/restore-from-obs
 DELETE /v4.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | DB 인스턴스 삭제하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -967,6 +1045,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
 
 #### 요청
 
@@ -1047,6 +1131,12 @@ GET /v4.0/db-instances/{dbInstanceId}
 PUT /v4.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1123,6 +1213,12 @@ PUT /v4.0/db-instances/{dbInstanceId}
 GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 백업 정보 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1178,6 +1274,12 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 백업 정보 수정하기 |
 
 #### 요청
 
@@ -1246,6 +1348,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | 바이너리 로그 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1294,6 +1402,12 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | 바이너리 로그 삭제 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1324,6 +1438,12 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.List | 인증서 파일 목록 보기 |
 
 #### 요청
 
@@ -1374,6 +1494,12 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.Export | 인증서 파일 내보내기 |
 
 #### 요청
 
@@ -1435,6 +1561,12 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | DB 스키마 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1484,6 +1616,12 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | DB 스키마 생성하기 |
 
 #### 요청
 
@@ -1535,6 +1673,12 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | DB 스키마 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1574,6 +1718,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/db-users
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | DB 사용자 목록 보기 |
 
 #### 요청
 
@@ -1635,6 +1785,12 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 POST /v4.0/db-instances/{dbInstanceId}/db-users
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | DB 사용자 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1695,6 +1851,12 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | DB 사용자 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1734,6 +1896,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | DB 사용자 수정하기 |
 
 #### 요청
 
@@ -1792,6 +1960,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 삭제 보호 설정 변경 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1823,6 +1997,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 POST /v4.0/db-instances/{dbInstanceId}/force-restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1842,6 +2022,12 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/high-availability
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 고가용성 정보 보기 |
 
 #### 요청
 
@@ -1887,6 +2073,12 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
 
 #### 공통 요청
 
@@ -1946,6 +2138,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | 고가용성 일시 중지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1984,6 +2182,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | 고가용성 복구하기 |
 
 #### 요청
 
@@ -2024,6 +2228,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | 고가용성 다시 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2063,6 +2273,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | 고가용성 분리하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2101,6 +2317,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/log-files
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | 로그 파일 목록 보기 |
 
 #### 요청
 
@@ -2151,6 +2373,12 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | 로그 파일 내보내기 |
 
 #### 요청
 
@@ -2212,6 +2440,12 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | 로그 파일 내용 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2251,6 +2485,12 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/maintenances
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | DB 인스턴스 유지 관리 목록 보기 |
 
 #### 요청
 
@@ -2326,6 +2566,12 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | DB 인스턴스 유지 관리 즉시 실행하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2384,6 +2630,12 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | DB 인스턴스 유지 관리 예약하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2423,6 +2675,12 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | DB 인스턴스 유지 관리 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2443,6 +2701,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/network-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 네트워크 정보 보기 |
 
 #### 요청
 
@@ -2503,6 +2767,12 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 PUT /v4.0/db-instances/{dbInstanceId}/network-info
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 네트워크 정보 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2553,6 +2823,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 POST /v4.0/db-instances/{dbInstanceId}/promote
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | DB 인스턴스 승격하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2592,6 +2868,12 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 POST /v4.0/db-instances/{dbInstanceId}/rebuild
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | DB 인스턴스 재구축하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2630,6 +2912,12 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/replicate
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
 
 #### 공통 요청
 
@@ -2748,6 +3036,12 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 POST /v4.0/db-instances/{dbInstanceId}/restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | DB 인스턴스 재시작하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2803,6 +3097,12 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB 인스턴스 복원 정보 조회 |
 
 #### 요청
 
@@ -2884,6 +3184,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 복원될 마지막 쿼리 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2924,6 +3230,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원 |
 
 #### 공통 요청
 
@@ -3089,6 +3401,12 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 POST /v4.0/db-instances/{dbInstanceId}/start
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | DB 인스턴스 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3128,6 +3446,12 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 POST /v4.0/db-instances/{dbInstanceId}/stop
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | DB 인스턴스 정지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3166,6 +3490,12 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 스토리지 정보 보기 |
 
 #### 요청
 
@@ -3220,6 +3550,12 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 스토리지 정보 수정하기 |
 
 #### 공통 요청
 
@@ -3296,6 +3632,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 GET /v4.0/backups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.List | 백업 목록 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3356,6 +3698,12 @@ GET /v4.0/backups
 POST /v4.0/backups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Create | 백업 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3411,6 +3759,12 @@ POST /v4.0/backups
 DELETE /v4.0/backups/{backupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | 백업 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3449,6 +3803,12 @@ DELETE /v4.0/backups/{backupId}
 ```http
 GET /v4.0/backups/{backupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | 백업 단건 조회 |
 
 #### 요청
 
@@ -3525,6 +3885,12 @@ GET /v4.0/backups/{backupId}
 POST /v4.0/backups/{backupId}/export
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Export | 백업 내보내기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3582,6 +3948,12 @@ POST /v4.0/backups/{backupId}/export
 ```http
 POST /v4.0/backups/{backupId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Restore | 백업 복원하기 |
 
 #### 공통 요청
 
@@ -3723,6 +4095,12 @@ POST /v4.0/backups/{backupId}/restore
 GET /v4.0/db-security-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3774,6 +4152,12 @@ GET /v4.0/db-security-groups
 ```http
 POST /v4.0/db-security-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
 
 #### 요청
 
@@ -3848,6 +4232,12 @@ POST /v4.0/db-security-groups
 DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3867,6 +4257,12 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 ```http
 GET /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
 
 #### 요청
 
@@ -3945,6 +4341,12 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3977,6 +4379,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 ```http
 DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | DB 보안 그룹 규칙 삭제하기 |
 
 #### 요청
 
@@ -4017,6 +4425,12 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
 
 #### 요청
 
@@ -4082,6 +4496,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
 
 #### 요청
 
@@ -4151,6 +4571,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 GET /v4.0/parameter-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.List | 파라미터 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4207,6 +4633,12 @@ GET /v4.0/parameter-groups
 POST /v4.0/parameter-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Create | 파라미터 그룹 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4260,6 +4692,12 @@ POST /v4.0/parameter-groups
 DELETE /v4.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4279,6 +4717,12 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 ```http
 GET /v4.0/parameter-groups/{parameterGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | 파라미터 그룹 상세 보기 |
 
 #### 요청
 
@@ -4354,6 +4798,12 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 PUT /v4.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4386,6 +4836,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 ```http
 POST /v4.0/parameter-groups/{parameterGroupId}/copy
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
 
 #### 요청
 
@@ -4439,6 +4895,12 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | 파라미터 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4477,6 +4939,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4498,6 +4966,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 ```http
 GET /v4.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.List | 사용자 그룹 목록 보기 |
 
 #### 요청
 
@@ -4546,6 +5020,12 @@ GET /v4.0/user-groups
 ```http
 POST /v4.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Create | 사용자 그룹 생성하기 |
 
 #### 요청
 
@@ -4600,6 +5080,12 @@ POST /v4.0/user-groups
 DELETE /v4.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Delete | 사용자 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4619,6 +5105,12 @@ DELETE /v4.0/user-groups/{userGroupId}
 ```http
 GET /v4.0/user-groups/{userGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | 사용자 그룹 상세 보기 |
 
 #### 요청
 
@@ -4674,6 +5166,12 @@ GET /v4.0/user-groups/{userGroupId}
 PUT /v4.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | 사용자 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4710,6 +5208,12 @@ PUT /v4.0/user-groups/{userGroupId}
 ```http
 GET /v4.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.List | 알림 그룹 목록 보기 |
 
 #### 요청
 
@@ -4762,6 +5266,12 @@ GET /v4.0/notification-groups
 ```http
 POST /v4.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Create | 알림 그룹 생성하기 |
 
 #### 요청
 
@@ -4822,6 +5332,12 @@ POST /v4.0/notification-groups
 DELETE /v4.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Delete | 알림 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4841,6 +5357,12 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 ```http
 GET /v4.0/notification-groups/{notificationGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | 알림 그룹 상세 보기 |
 
 #### 요청
 
@@ -4911,6 +5433,12 @@ GET /v4.0/notification-groups/{notificationGroupId}
 PUT /v4.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | 알림 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4954,6 +5482,12 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 GET /v4.0/metric-statistics
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | 통계 정보 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4969,6 +5503,12 @@ GET /v4.0/metric-statistics
 ```http
 GET /v4.0/metrics
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | Metric 목록 보기 |
 
 #### 요청
 
@@ -5027,6 +5567,12 @@ GET /v4.0/metrics
 GET /v4.0/event-codes
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 구독 가능한 이벤트 코드 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5068,6 +5614,12 @@ GET /v4.0/event-codes
 ```http
 GET /v4.0/events
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 이벤트 목록 조회 |
 
 #### 요청
 
@@ -5129,6 +5681,12 @@ GET /v4.0/events
 ```http
 GET /v4.0/event-subscriptions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.List | 이벤트 구독 목록 조회 |
 
 #### 요청
 
@@ -5196,6 +5754,12 @@ GET /v4.0/event-subscriptions
 ```http
 POST /v4.0/event-subscriptions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Create | 이벤트 구독 생성하기 |
 
 #### 요청
 
@@ -5267,6 +5831,12 @@ POST /v4.0/event-subscriptions
 DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Delete | 이벤트 구독 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5286,6 +5856,12 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```http
 PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | 이벤트 구독 수정하기 |
 
 #### 요청
 
@@ -5340,6 +5916,12 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 ```http
 GET /v4.0/availability-zones
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | 가용성 영역 목록 보기 |
 
 #### 요청
 

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -1,6 +1,13 @@
-## Database > RDS for MariaDB > API 가이드
+## Database > RDS for MariaDB > API v4.0 가이드
 
 ## RDS for MariaDB API 공통 정보
+
+### API 엔드포인트
+
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
+
 
 ### 인증 및 권한
 
@@ -47,12 +54,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
 | isSuccessful | Boolean | 성공 여부 |
-
-### API 엔드포인트
-
-| 리전 | 엔드포인트 |
-|------|----------|
-| 한국(판교) 리전 | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
 
 ### DB 엔진 유형
 

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -118,8 +118,8 @@ GET /v4.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -275,7 +275,7 @@ GET /v4.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -743,7 +743,7 @@ POST /v4.0/db-instances
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -802,7 +802,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -877,7 +877,7 @@ POST /v4.0/db-instances/restore-from-obs
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -938,7 +938,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1244,7 +1244,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
@@ -1264,7 +1264,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1299,7 +1299,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1314,7 +1314,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2751,13 +2751,13 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example"
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2956,7 +2956,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 스토리지 자동 확장 사용 시
@@ -3001,7 +3001,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3271,7 +3271,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
@@ -3352,7 +3352,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3995,7 +3995,7 @@ POST /v4.0/backups/{backupId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -4049,7 +4049,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4198,7 +4198,7 @@ POST /v4.0/db-security-groups
                 "minPort": 3306,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4327,7 +4327,7 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
@@ -4465,7 +4465,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4537,7 +4537,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -374,7 +374,10 @@ GET /v4.0/storage-types
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageTypes": []
+    "storageTypes": [
+        "General SSD",
+        "General HDD"
+    ]
 }
 ```
 
@@ -1107,8 +1110,12 @@ GET /v4.0/db-instances/{dbInstanceId}
     "progressStatus": "NONE",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "notificationGroupIds": [],
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
     "useSlowQueryAnalysis": false,
     "supportAuthenticationPlugin": false,
@@ -5737,7 +5744,9 @@ GET /v4.0/event-subscriptions
                     "eventCategoryType": "ALL"
                 }
             ],
-            "userGroupIds": [],
+            "userGroupIds": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -944,7 +944,7 @@ POST /v4.0/db-instances/restore-from-obs
         ]
     },
     "restore": {
-        "tenantId": "tenantId-example",
+        "tenantId": "0123456789abcdef0123456789abcdef",
         "username": "username-example",
         "password": "password-example",
         "targetContainer": "targetContainer-example",
@@ -1526,7 +1526,7 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```json
 {
     "certificateTypes": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -1769,7 +1769,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
         {
             "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
-            "host": "host-example",
+            "host": "192.168.0.1",
             "authorityType": "CUSTOM",
             "dbUserStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -1817,7 +1817,7 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 {
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
-    "host": "host-example",
+    "host": "192.168.0.1",
     "authorityType": "CUSTOM",
     "authenticationPlugin": "NATIVE",
     "tlsOption": "NONE"
@@ -2405,7 +2405,7 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```json
 {
     "logFileNames": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -3914,7 +3914,7 @@ POST /v4.0/backups/{backupId}/export
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -5640,7 +5640,7 @@ GET /v4.0/events
 | events | Body | Array | 이벤트 목록 |
 | events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
 | events.messages | Body | Array | 이벤트 메세지 목록 |
 | events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
@@ -5662,7 +5662,7 @@ GET /v4.0/events
         {
             "eventCategoryType": "ALL",
             "eventCode": "ENUM_VALUE",
-            "sourceId": "sourceId-example",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "sourceName": "sourceName-example",
             "messages": [
                 {
@@ -5713,7 +5713,7 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
 | eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
 | eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
@@ -5740,7 +5740,7 @@ GET /v4.0/event-subscriptions
             "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "sourceId-example",
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
                     "eventCategoryType": "ALL"
                 }
             ],

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -1,4 +1,6 @@
-## Database > RDS for MariaDB > API v4.0 가이드
+## RDS for MariaDB API 가이드
+
+**Database > RDS for MariaDB > API v4.0 가이드**
 
 ## RDS for MariaDB API 공통 정보
 
@@ -14,10 +16,10 @@
 RDS for MariaDB은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| X-TC-APP-KEY | Header | String | O | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public API로 발급 받은 Bearer 유형 토큰 |
 
 또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
@@ -37,7 +39,9 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 
 모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
-#### 응답 본문
+<details>
+  <summary><strong>성공 응답</strong></summary>
+
 ```json
 {
     "header": {
@@ -48,13 +52,28 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 }
 ```
 
-#### 필드
-| 이름 | 형식 | 설명 |
+</details>
+
+<details>
+  <summary><strong>실패 응답</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
 |-----|-----|-----|
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
 | isSuccessful | Boolean | 성공 여부 |
-
 ### DB 엔진 유형
 
 | DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
@@ -69,9 +88,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | MARIADB_V101108 | O | O | NATIVE, ED25519 |
 | MARIADB_V101113 | O | O | NATIVE, ED25519 |
 | MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
 | MARIADB_V11407 | O | O | NATIVE, ED25519 |
 | MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
 | MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
@@ -79,10 +101,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 ## 프로젝트 정보
 
 ### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
 
 #### 필요 권한
 
@@ -92,20 +110,18 @@ GET /v4.0/project/members
 
 #### 요청
 
+```http
+GET /v4.0/project/members
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| members.memberName | Body | String | 프로젝트 멤버의 이름 |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -125,16 +141,19 @@ GET /v4.0/project/members
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| members.memberName | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | String | 프로젝트 멤버의 전화번호 |
 
 ---
 
 ### 리전 목록 보기
-
-```http
-GET /v4.0/project/regions
-```
 
 #### 필요 권한
 
@@ -144,18 +163,18 @@ GET /v4.0/project/regions
 
 #### 요청
 
+```http
+GET /v4.0/project/regions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| regions | Body | Array | 리전 목록 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -173,18 +192,19 @@ GET /v4.0/project/regions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| regions | Array | 리전 목록 |
+| regions.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Boolean | 리전의 활성화 여부 |
 
 ---
 
 ## DB 인스턴스 사양
 
 ### DB 인스턴스 사양 목록 보기
-
-```http
-GET /v4.0/db-flavors
-```
 
 #### 필요 권한
 
@@ -194,20 +214,18 @@ GET /v4.0/db-flavors
 
 #### 요청
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -227,18 +245,21 @@ GET /v4.0/db-flavors
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbFlavors | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Number | CPU 코어 수 |
 
 ---
 
 ## 네트워크
 
 ### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
 
 #### 필요 권한
 
@@ -248,21 +269,18 @@ GET /v4.0/network/subnets
 
 #### 요청
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -283,18 +301,22 @@ GET /v4.0/network/subnets
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| subnets | Array | 서브넷 목록 |
+| subnets.subnetId | UUID | 서브넷의 식별자 |
+| subnets.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | String | 서브넷의 CIDR |
+| subnets.usingGateway | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Number | 사용 가능한 IP 수 |
 
 ---
 
 ## DB 엔진
 
 ### DB 엔진 목록 보기
-
-```http
-GET /v4.0/db-versions
-```
 
 #### 필요 권한
 
@@ -304,19 +326,18 @@ GET /v4.0/db-versions
 
 #### 요청
 
+```http
+GET /v4.0/db-versions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB 엔진 목록 |
-| dbVersions.dbVersion | Body | String | DB 엔진 유형 |
-| dbVersions.dbVersionName | Body | String | DB 엔진 이름 |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -335,18 +356,20 @@ GET /v4.0/db-versions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbVersions | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | String | DB 엔진 이름 |
+| dbVersions.restorableFromObs | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 ---
 
 ## 데이터 스토리지
 
 ### 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
 
 #### 필요 권한
 
@@ -356,16 +379,18 @@ GET /v4.0/storage-types
 
 #### 요청
 
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -381,8 +406,11 @@ GET /v4.0/storage-types
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageTypes | Array | 스토리지 타입 목록 |
 
 ---
 
@@ -407,10 +435,6 @@ GET /v4.0/storage-types
 
 ### 작업 정보 상세 보기
 
-```http
-GET /v4.0/jobs/{jobId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -419,26 +443,24 @@ GET /v4.0/jobs/{jobId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -460,18 +482,23 @@ GET /v4.0/jobs/{jobId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+| jobStatus | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | String | 연관 리소스의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ## DB 인스턴스 그룹
 
 ### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
 
 #### 필요 권한
 
@@ -481,20 +508,18 @@ GET /v4.0/db-instance-groups
 
 #### 요청
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -514,16 +539,19 @@ GET /v4.0/db-instance-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 필요 권한
 
@@ -533,27 +561,24 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -576,8 +601,18 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -630,10 +665,6 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DB 인스턴스 목록 보기
 
-```http
-GET /v4.0/db-instances
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -642,27 +673,18 @@ GET /v4.0/db-instances
 
 #### 요청
 
+```http
+GET /v4.0/db-instances
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
-| dbInstances.dbPort | Body | Number | DB 포트 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| dbInstances.progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -689,16 +711,26 @@ GET /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstances | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | String | DB 엔진 유형 |
+| dbInstances.dbPort | Number | DB 포트 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 생성하기
-
-```http
-POST /v4.0/db-instances
-```
 
 #### 필요 권한
 
@@ -706,62 +738,16 @@ POST /v4.0/db-instances
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
-| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| authenticationPlugin | Body | Enum | X | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 데이터 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+POST /v4.0/db-instances
+```
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -810,17 +796,64 @@ POST /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| authenticationPlugin | Enum | N | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 데이터 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -833,16 +866,15 @@ POST /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
 
 #### 필요 권한
 
@@ -850,64 +882,16 @@ POST /v4.0/db-instances/restore-from-obs
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | 오브젝트 스토리지를 이용한 DB 인스턴스 복원 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | O | DB 포트 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
-| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
-| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
-| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
-| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -959,17 +943,66 @@ POST /v4.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -982,16 +1015,15 @@ POST /v4.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1001,13 +1033,20 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| deleteAutoBackup | Body | Boolean | X | 자동 백업 삭제 여부<br/>- 기본값: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1015,17 +1054,16 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | 자동 백업 삭제 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1038,16 +1076,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 상세 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1057,40 +1094,24 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| dbPort | Body | Number | DB 포트 |
-| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
-| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
-| useSlowQueryAnalysis | Body | Boolean | Slow query 분석 여부 |
-| supportAuthenticationPlugin | Body | Boolean | 인증 plugin 지원 여부 |
-| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
-| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
-| supportDbVersionUpgrade | Body | Boolean | DB 버전 업그레이드 지원 여부 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1127,16 +1148,35 @@ GET /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| dbPort | Number | DB 포트 |
+| dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | DB 인스턴스 삭제 보호 여부 |
+| useSlowQueryAnalysis | Boolean | Slow query 분석 여부 |
+| supportAuthenticationPlugin | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1146,26 +1186,20 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부 |
-| useDummy | Body | Boolean | X | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
-| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
-| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
-| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1186,17 +1220,29 @@ PUT /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbVersion | String | N | DB 엔진 버전 코드 |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부 |
+| useDummy | Boolean | N | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1209,16 +1255,15 @@ PUT /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1228,27 +1273,24 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | 백업 보관 기간(일) |
-| ftwrlWaitTimeout | Body | Number | 쿼리 지연 대기 시간(초) |
-| backupRetryCount | Body | Number | 백업 재시도 횟수 |
-| replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
-| backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1271,16 +1313,22 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backupPeriod | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Number | 백업 재시도 횟수 |
+| replicationRegion | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### 백업 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1290,20 +1338,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
-| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1321,17 +1369,23 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1344,16 +1398,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 바이너리 로그 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
 
 #### 필요 권한
 
@@ -1363,23 +1416,24 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLog 파일 목록 |
-| binLogs.binLogFileName | Body | String | BinLog 파일 이름 |
-| binLogs.binLogFileSize | Body | Number | BinLog 파일 크기 (Byte) |
-| binLogs.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1398,16 +1452,18 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| binLogs | Array | BinLog 파일 목록 |
+| binLogs.binLogFileName | String | BinLog 파일 이름 |
+| binLogs.binLogFileSize | Number | BinLog 파일 크기 (Byte) |
+| binLogs.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 바이너리 로그 삭제
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
 
 #### 필요 권한
 
@@ -1417,13 +1473,20 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1431,8 +1494,11 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
 
 #### 응답
 
@@ -1442,10 +1508,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 ### 인증서 파일 목록 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -1454,24 +1516,24 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| certificates | Body | Array | 인증서 파일 목록 |
-| certificates.fileName | Body | String | 인증서 파일 이름 |
-| certificates.certificateType | Body | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | 인증서 파일 크기(Byte) |
-| certificates.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1491,16 +1553,19 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| certificates | Array | 인증서 파일 목록 |
+| certificates.fileName | String | 인증서 파일 이름 |
+| certificates.certificateType | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | 인증서 파일 크기(Byte) |
+| certificates.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 인증서 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
 
 #### 필요 권한
 
@@ -1510,18 +1575,20 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| certificateTypes | Body | Array | O | 업로드할 인증서 타입 목록 |
-| tenantId | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
-| password | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 인증서 파일의 경로 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1534,17 +1601,21 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | 업로드할 인증서 타입 목록 |
+| tenantId | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 인증서 파일의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1557,16 +1628,15 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 스키마 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
 
 #### 필요 권한
 
@@ -1576,24 +1646,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DB 스키마 목록 |
-| dbSchemas.dbSchemaId | Body | UUID | DB 스키마의 식별자 |
-| dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
-| dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1613,16 +1683,19 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSchemas | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | UUID | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### DB 스키마 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
 
 #### 필요 권한
 
@@ -1632,13 +1705,20 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1646,17 +1726,16 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1669,16 +1748,15 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 스키마 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
 
 #### 필요 권한
 
@@ -1688,21 +1766,25 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbSchemaId | URL | UUID | O | DB 스키마의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbSchemaId | URL | UUID | Y | DB 스키마의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1715,16 +1797,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -1734,29 +1815,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
-| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
-| dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
-| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
-| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
-| dbUsers.authenticationPlugin | Body | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| dbUsers.tlsOption | Body | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1781,16 +1857,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbUsers | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
+| dbUsers.dbUserName | String | DB 사용자 계정 이름 |
+| dbUsers.host | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 ---
 
 ### DB 사용자 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -1800,18 +1884,20 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
-| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| host | Body | String | O | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
-| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1824,17 +1910,21 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | String | Y | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Enum | Y | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1847,16 +1937,15 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -1866,21 +1955,25 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | DB 사용자의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1893,16 +1986,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -1912,17 +2004,21 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
-| dbPassword | Body | String | X | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| authorityType | Body | Enum | X | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | DB 사용자의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1933,17 +2029,19 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Enum | N | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1956,16 +2054,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제 보호 설정 변경
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 필요 권한
 
@@ -1975,13 +2072,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1989,8 +2093,11 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 삭제 보호 여부 |
 
 #### 응답
 
@@ -2000,10 +2107,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DB 인스턴스 강제 재시작하기
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2012,11 +2115,19 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2026,10 +2137,6 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 ### 고가용성 정보 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2038,23 +2145,24 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
-| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
-| pingInterval | Body | Number | Ping 간격(초) |
-| pingType | Body | String | Ping 방식 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2070,16 +2178,18 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| useHighAvailability | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
+| haStatus | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Number | Ping 간격(초) |
+| pingType | String | Ping 방식 |
 
 ---
 
 ### 고가용성 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
 
 #### 필요 권한
 
@@ -2087,22 +2197,22 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2111,17 +2221,23 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 고가용성 사용 여부 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2134,16 +2250,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 일시 중지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
 
 #### 필요 권한
 
@@ -2153,20 +2268,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2179,16 +2298,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 복구하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
 
 #### 필요 권한
 
@@ -2198,20 +2316,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2224,16 +2346,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 다시 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
 
 #### 필요 권한
 
@@ -2243,20 +2364,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2269,16 +2394,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 분리하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
 
 #### 필요 권한
 
@@ -2288,20 +2412,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2314,16 +2442,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 로그 파일 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
 
 #### 필요 권한
 
@@ -2333,24 +2460,24 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | 로그 파일 목록 |
-| logFiles.logFileName | Body | String | 로그 파일 이름 |
-| logFiles.logFileType | Body | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | 로그 파일 크기(Byte) |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2370,16 +2497,19 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| logFiles | Array | 로그 파일 목록 |
+| logFiles.logFileName | String | 로그 파일 이름 |
+| logFiles.logFileType | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 로그 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
 
 #### 필요 권한
 
@@ -2389,18 +2519,20 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | 로그 파일 이름 목록 |
-| tenantId | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
-| password | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 로그 파일의 경로 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2413,17 +2545,21 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | 로그 파일 이름 목록 |
+| tenantId | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 로그 파일의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2436,16 +2572,15 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 로그 파일 내용 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
 
 #### 필요 권한
 
@@ -2455,21 +2590,25 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| logFileName | URL | UUID | O | 로그 파일 이름 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| logFileName | URL | UUID | Y | 로그 파일 이름 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| content | Body | String | 로그 파일 내용 (최대 65533 bytes) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2482,16 +2621,15 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| content | String | 로그 파일 내용 (최대 65533 bytes) |
 
 ---
 
 ### DB 인스턴스 유지 관리 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
 
 #### 필요 권한
 
@@ -2501,37 +2639,27 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 유지 관리 목록 갯수 |
-| maintenances | Body | Array | 유지 관리 목록 |
-| maintenances.maintenanceId | Body | UUID | 유지 관리 아이디 |
-| maintenances.dbInstanceId | Body | UUID | DB 인스턴스 아이디 |
-| maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| maintenances.description | Body | String | 유지 관리 설명 |
-| maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| maintenances.payload | Body | Object | 유지 관리 타입에 따른 Payload |
-| maintenances.required | Body | Boolean | 유지 관리 필수 여부 |
-| maintenances.deadlineYmdt | Body | DateTime | 유지 관리 강제 적용 일시 |
-| maintenances.status | Body | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
-| maintenances.addedYmdt | Body | DateTime | 유지 관리 스케줄 등록 일시 |
-| maintenances.executionStartedYmdt | Body | DateTime | 유지 관리 시작 일시 |
-| maintenances.executionCompletedYmdt | Body | DateTime | 유지 관리 종료 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2562,16 +2690,29 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 유지 관리 목록 갯수 |
+| maintenances | Array | 유지 관리 목록 |
+| maintenances.maintenanceId | UUID | 유지 관리 아이디 |
+| maintenances.dbInstanceId | UUID | DB 인스턴스 아이디 |
+| maintenances.category | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| maintenances.description | String | 유지 관리 설명 |
+| maintenances.type | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| maintenances.payload | Object | 유지 관리 타입에 따른 Payload |
+| maintenances.required | Boolean | 유지 관리 필수 여부 |
+| maintenances.deadlineYmdt | DateTime | 유지 관리 강제 적용 일시 |
+| maintenances.status | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
+| maintenances.addedYmdt | DateTime | 유지 관리 스케줄 등록 일시 |
+| maintenances.executionStartedYmdt | DateTime | 유지 관리 시작 일시 |
+| maintenances.executionCompletedYmdt | DateTime | 유지 관리 종료 일시 |
 
 ---
 
 ### DB 인스턴스 유지 관리 즉시 실행하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
 
 #### 필요 권한
 
@@ -2581,17 +2722,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| configId | Body | String | O | 설정 아이디 |
-| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| description | Body | String | X | 유지 관리 설명 |
-| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2603,17 +2747,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| configId | String | Y | 설정 아이디 |
+| category | Enum | Y | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | String | N | 유지 관리 설명 |
+| type | Enum | Y | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | String | Y | 유지 관리 타입에 따른 Payload |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2626,16 +2773,15 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 유지 관리 예약하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
 
 #### 필요 권한
 
@@ -2645,17 +2791,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| configId | Body | String | O | 설정 아이디 |
-| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| description | Body | String | X | 유지 관리 설명 |
-| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2667,8 +2816,15 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| configId | String | Y | 설정 아이디 |
+| category | Enum | Y | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | String | N | 유지 관리 설명 |
+| type | Enum | Y | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | String | Y | 유지 관리 타입에 따른 Payload |
 
 #### 응답
 
@@ -2678,10 +2834,6 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 ### DB 인스턴스 유지 관리 삭제하기
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2690,12 +2842,20 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| maintenanceId | URL | UUID | O | 유지 관리 아이디 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| maintenanceId | URL | UUID | Y | 유지 관리 아이디 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2705,10 +2865,6 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 ### 네트워크 정보 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2717,28 +2873,24 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
-| subnet | Body | Object | 서브넷 객체 |
-| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
-| endPoints | Body | Array | 접속 정보 목록 |
-| endPoints.domain | Body | String | 도메인 |
-| endPoints.ipAddress | Body | String | IP 주소 |
-| endPoints.endPointType | Body | String | 접속 정보 타입 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2763,16 +2915,23 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZone | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Object | 서브넷 객체 |
+| subnet.subnetId | UUID | 서브넷의 식별자 |
+| subnet.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | String | 서브넷의 CIDR |
+| endPoints | Array | 접속 정보 목록 |
+| endPoints.domain | String | 도메인 |
+| endPoints.ipAddress | String | IP 주소 |
+| endPoints.endPointType | String | 접속 정보 타입 |
 
 ---
 
 ### 네트워크 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 필요 권한
 
@@ -2782,13 +2941,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2796,17 +2962,16 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 외부 접속 가능 여부 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2819,16 +2984,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 승격하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 필요 권한
 
@@ -2838,20 +3002,24 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2864,16 +3032,15 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 재구축하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
 
 #### 필요 권한
 
@@ -2883,20 +3050,24 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2909,16 +3080,15 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 복제하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
 
 #### 필요 권한
 
@@ -2926,49 +3096,22 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부 |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | X | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | X | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 스토리지 자동 확장 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3009,17 +3152,50 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부 |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | N | 스토리지 정보 객체 |
+| storage.storageType | Enum | N | 데이터 스토리지 타입 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | N | 백업 정보 객체 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3032,16 +3208,15 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 필요 권한
 
@@ -3051,16 +3226,20 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
-| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
-| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
-| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3071,17 +3250,19 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3094,16 +3275,15 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 복원 정보 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 필요 권한
 
@@ -3113,38 +3293,24 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
-| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
-| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
-| restorableBackups.backup | Body | Object | 백업 정보 객체 |
-| restorableBackups.backup.backupId | Body | UUID | 백업의 식별자 |
-| restorableBackups.backup.backupName | Body | String | 백업 이름 |
-| restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
-| restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
-| restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | 백업 크기 |
-| restorableBackups.backup.useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
-| restorableBackups.backup.failoverCount | Body | Number | 장애 조치 횟수 |
-| restorableBackups.backup.binLogFileName | Body | String | 바이너리 로그 파일 이름 |
-| restorableBackups.backup.binLogPosition | Body | Object | 바이너리 로그 파일 위치 |
-| restorableBackups.backup.createdYmdt | Body | DateTime | 백업 생성 일시 |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
-| restorableBackups.restorableBinLogs | Body | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3180,16 +3346,33 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backup | Object | 백업 정보 객체 |
+| restorableBackups.backup.backupId | UUID | 백업의 식별자 |
+| restorableBackups.backup.backupName | String | 백업 이름 |
+| restorableBackups.backup.backupStatus | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.backup.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.backup.dbVersion | String | DB 엔진 유형 |
+| restorableBackups.backup.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | 백업 크기 |
+| restorableBackups.backup.useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| restorableBackups.backup.failoverCount | Number | 장애 조치 횟수 |
+| restorableBackups.backup.binLogFileName | String | 바이너리 로그 파일 이름 |
+| restorableBackups.backup.binLogPosition | Object | 바이너리 로그 파일 위치 |
+| restorableBackups.backup.createdYmdt | DateTime | 백업 생성 일시 |
+| restorableBackups.backup.updatedYmdt | DateTime | 백업 갱신 일시 |
+| restorableBackups.restorableBinLogs | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
 
 ---
 
 ### 복원될 마지막 쿼리 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
 
 #### 필요 권한
 
@@ -3199,21 +3382,24 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시 |
-| lastQuery | Body | String | 마지막 수행 쿼리 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3227,16 +3413,16 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| executedYmdt | DateTime | 쿼리 수행 일시 |
+| lastQuery | String | 마지막 수행 쿼리 |
 
 ---
 
 ### DB 인스턴스 복원
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
 
 #### 필요 권한
 
@@ -3244,85 +3430,22 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
-| dbPort | Body | Number | X | DB 포트 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| storage | Body | Object | X | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
-| storage.storageType | Body | Enum | X | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| network | Body | Object | X | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
-| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
-| backup | Body | Object | X | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
-| restore.binLog.binLogFileName | Body | String | X | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Object | X | 복원에 사용할 바이너리 로그 위치 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
-| restore.binLog | Body | Object | X | 복원에 사용할 바이너리 로그 정보 객체 |
-
-바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3374,17 +3497,86 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
+| dbPort | Number | N | DB 포트 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | N | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
+| storage.storageType | Enum | N | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Object | N | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
+| network.subnetId | UUID | N | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
+| backup | Object | N | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.restoreType | Enum | Y | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | String | N | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Object | N | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Object | N | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3397,16 +3589,15 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
 
 #### 필요 권한
 
@@ -3416,20 +3607,24 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3442,16 +3637,15 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 정지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 필요 권한
 
@@ -3461,20 +3655,24 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3487,16 +3685,15 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 스토리지 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3506,27 +3703,24 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageType | Body | String | 데이터 스토리지 타입 |
-| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
-| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
-| storageAutoscale | Body | Object | 데이터 스토리지 자동 확장 객체 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부 |
-| storageAutoscale.threshold | Body | Number | 자동 확장 조건(%) |
-| storageAutoscale.maxStorageSize | Body | Number | 자동 확장 최대 크기(GB) |
-| storageAutoscale.cooldownTime | Body | Number | 자동 확장 쿨다운 시간(분) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3547,16 +3741,22 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageType | String | 데이터 스토리지 타입 |
+| storageSize | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+| storageAutoscale | Object | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Boolean | 스토리지 자동 확장 여부 |
+| storageAutoscale.threshold | Number | 자동 확장 조건(%) |
+| storageAutoscale.maxStorageSize | Number | 자동 확장 최대 크기(GB) |
+| storageAutoscale.cooldownTime | Number | 자동 확장 쿨다운 시간(분) |
 
 ---
 
 ### 스토리지 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3564,25 +3764,22 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | 스토리지 정보 수정하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
-| storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 스토리지 자동 확장 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3593,17 +3790,26 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+| storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부 |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3616,8 +3822,11 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -3635,10 +3844,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 
 ### 백업 목록 조회
 
-```http
-GET /v4.0/backups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -3647,27 +3852,18 @@ GET /v4.0/backups
 
 #### 요청
 
+```http
+GET /v4.0/backups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 백업 목록 수 |
-| backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | UUID | 백업의 식별자 |
-| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
-| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| backups.dbVersion | Body | Enum | DB 엔진 유형 |
-| backups.utilVersion | Body | String | 유틸리티 버전 |
-| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | 백업의 크기(Byte) |
-| backups.createdYmdt | Body | DateTime | 생성 일시 |
-| backups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3694,16 +3890,26 @@ GET /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 백업 목록 수 |
+| backups | Array | 백업 목록 |
+| backups.backupId | UUID | 백업의 식별자 |
+| backups.backupName | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | String | DB 엔진 유형 |
+| backups.utilVersion | String | 유틸리티 버전 |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | DateTime | 생성 일시 |
+| backups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 백업 생성하기
-
-```http
-POST /v4.0/backups
-```
 
 #### 필요 권한
 
@@ -3713,15 +3919,14 @@ POST /v4.0/backups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| baseBackupId | Body | UUID | X | 원본 백업의 식별자 |
-| dbInstanceId | Body | UUID | X | DB 인스턴스의 식별자 |
-| backupMethodType | Body | Enum | O | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3732,17 +3937,19 @@ POST /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupName | String | Y | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| baseBackupId | UUID | N | 원본 백업의 식별자 |
+| dbInstanceId | UUID | N | DB 인스턴스의 식별자 |
+| backupMethodType | Enum | Y | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3755,16 +3962,15 @@ POST /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 삭제하기
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
 
 #### 필요 권한
 
@@ -3774,20 +3980,24 @@ DELETE /v4.0/backups/{backupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3800,16 +4010,15 @@ DELETE /v4.0/backups/{backupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 단건 조회
-
-```http
-GET /v4.0/backups/{backupId}
-```
 
 #### 필요 권한
 
@@ -3819,37 +4028,24 @@ GET /v4.0/backups/{backupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| backup | Body | Object | 백업 상세 정보 |
-| backup.backupId | Body | UUID | 백업의 식별자 |
-| backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
-| backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
-| backup.dbVersion | Body | Enum | DB 엔진 버전 |
-| backup.utilVersion | Body | String | 유틸리티 버전 |
-| backup.backupType | Body | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | 백업의 크기(Byte) |
-| backup.isReplicable | Body | Boolean | 복제 가능 여부 |
-| backup.binLogFileName | Body | String | 바이너리 로그 파일명 |
-| backup.binLogPosition | Body | Object | 바이너리 로그 위치 |
-| backup.createdYmdt | Body | DateTime | 생성 일시 |
-| backup.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3881,16 +4077,32 @@ GET /v4.0/backups/{backupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backup | Object | 백업 상세 정보 |
+| backup.backupId | UUID | 백업의 식별자 |
+| backup.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| backup.backupName | String | 백업을 식별할 수 있는 이름 |
+| backup.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backup.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
+| backup.dbVersion | String | DB 엔진 버전 |
+| backup.utilVersion | String | 유틸리티 버전 |
+| backup.backupType | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | 백업의 크기(Byte) |
+| backup.isReplicable | Boolean | 복제 가능 여부 |
+| backup.binLogFileName | String | 바이너리 로그 파일명 |
+| backup.binLogPosition | Object | 바이너리 로그 위치 |
+| backup.createdYmdt | DateTime | 생성 일시 |
+| backup.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 백업 내보내기
-
-```http
-POST /v4.0/backups/{backupId}/export
-```
 
 #### 필요 권한
 
@@ -3900,17 +4112,20 @@ POST /v4.0/backups/{backupId}/export
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
-| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3922,17 +4137,20 @@ POST /v4.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3945,16 +4163,15 @@ POST /v4.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 복원하기
-
-```http
-POST /v4.0/backups/{backupId}/restore
-```
 
 #### 필요 권한
 
@@ -3962,58 +4179,22 @@ POST /v4.0/backups/{backupId}/restore
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | 백업 복원하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| dbPort | Body | Number | X | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| network | Body | Object | X | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
-| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
-| storage | Body | Object | X | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageType | Body | Enum | X | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | X | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| backupId | URL | UUID | Y |  |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4057,17 +4238,59 @@ POST /v4.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbPort | Number | N | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Object | N | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| network.subnetId | UUID | N | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
+| storage | Object | N | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageType | Enum | N | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | N | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4080,8 +4303,11 @@ POST /v4.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -4098,10 +4324,6 @@ POST /v4.0/backups/{backupId}/restore
 
 ### DB 보안 그룹 목록 보기
 
-```http
-GET /v4.0/db-security-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4110,23 +4332,18 @@ GET /v4.0/db-security-groups
 
 #### 요청
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4149,16 +4366,22 @@ GET /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 생성하기
-
-```http
-POST /v4.0/db-security-groups
-```
 
 #### 필요 권한
 
@@ -4168,22 +4391,14 @@ POST /v4.0/db-security-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4205,17 +4420,26 @@ POST /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Array | Y | DB 보안 그룹 규칙 목록 |
+| rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | Y | 포트 객체 |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | 보안 그룹 규칙에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4228,16 +4452,15 @@ POST /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
 
 ---
 
 ### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4247,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4261,10 +4492,6 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 상세 보기
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4273,37 +4500,24 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
-| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | 포트 객체 |
-| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | 최소 포트 범위 |
-| rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 생성 일시 |
-| rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4337,16 +4551,32 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
+| rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | 포트 객체 |
+| rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | 최소 포트 범위 |
+| rules.port.maxPort | Number | 최대 포트 범위 |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | 생성 일시 |
+| rules.updatedYmdt | DateTime | 수정 일시 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4356,14 +4586,20 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4372,8 +4608,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
@@ -4383,10 +4623,6 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 규칙 삭제하기
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4395,21 +4631,25 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4422,16 +4662,15 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
 
 #### 필요 권한
 
@@ -4441,20 +4680,20 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4470,17 +4709,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4493,16 +4738,15 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
 
 #### 필요 권한
 
@@ -4512,21 +4756,21 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4542,17 +4786,23 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4565,18 +4815,17 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ## 파라미터 그룹
 
 ### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4586,25 +4835,18 @@ GET /v4.0/parameter-groups
 
 #### 요청
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4629,16 +4871,24 @@ GET /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | String | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4648,14 +4898,14 @@ POST /v4.0/parameter-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4665,17 +4915,18 @@ POST /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | String | Y | DB 엔진 유형 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4688,16 +4939,15 @@ POST /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4707,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4721,10 +4979,6 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 상세 보기
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4733,36 +4987,24 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | UUID | 파라미터의 식별자 |
-| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4794,16 +5036,31 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Array | 파라미터 목록 |
+| parameters.parameterId | UUID | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | 파라미터 이름 |
+| parameters.fileParameterName | String | 파라미터 파일 이름 |
+| parameters.value | String | 현재 설정된 값 |
+| parameters.defaultValue | String | 기본값 |
+| parameters.allowedValue | String | 허용된 값 |
+| parameters.updateType | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4813,14 +5070,20 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4829,8 +5092,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
@@ -4840,10 +5107,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 복사하기
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4852,14 +5115,20 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4868,17 +5137,17 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4891,16 +5160,15 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 필요 권한
 
@@ -4910,15 +5178,20 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4931,8 +5204,13 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | UUID | Y | 파라미터의 식별자 |
+| modifiedParameters.value | String | Y | 변경할 파라미터 값 |
 
 #### 응답
 
@@ -4942,10 +5220,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 ### 파라미터 그룹 재설정하기
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4954,11 +5228,19 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4970,10 +5252,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 ### 사용자 그룹 목록 보기
 
-```http
-GET /v4.0/user-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4982,21 +5260,18 @@ GET /v4.0/user-groups
 
 #### 요청
 
+```http
+GET /v4.0/user-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
-| userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5017,16 +5292,20 @@ GET /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 사용자 그룹 목록 수 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 생성하기
-
-```http
-POST /v4.0/user-groups
-```
 
 #### 필요 권한
 
@@ -5036,14 +5315,14 @@ POST /v4.0/user-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
-| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5053,17 +5332,18 @@ POST /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | Y | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5076,16 +5356,15 @@ POST /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
 
 ---
 
 ### 사용자 그룹 삭제하기
-
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -5095,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5109,10 +5396,6 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ### 사용자 그룹 상세 보기
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5121,26 +5404,24 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5162,16 +5443,21 @@ GET /v4.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 수정하기
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -5181,15 +5467,20 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
-| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5199,8 +5490,13 @@ PUT /v4.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | N | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
@@ -5212,10 +5508,6 @@ PUT /v4.0/user-groups/{userGroupId}
 
 ### 알림 그룹 목록 보기
 
-```http
-GET /v4.0/notification-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5224,23 +5516,18 @@ GET /v4.0/notification-groups
 
 #### 요청
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | 알림 그룹 목록 |
-| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
-| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
-| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5263,16 +5550,22 @@ GET /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroups | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 생성하기
-
-```http
-POST /v4.0/notification-groups
-```
 
 #### 필요 권한
 
@@ -5282,17 +5575,14 @@ POST /v4.0/notification-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
-| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5305,17 +5595,21 @@ POST /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5328,16 +5622,15 @@ POST /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
 
 ---
 
 ### 알림 그룹 삭제하기
-
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5347,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5361,10 +5662,6 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ### 알림 그룹 상세 보기
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5373,32 +5670,24 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notifySms | Body | Boolean | SMS 알림 여부 |
-| isEnabled | Body | Boolean | 활성화 여부 |
-| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5429,16 +5718,27 @@ GET /v4.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | 이메일 알림 여부 |
+| notifySms | Boolean | SMS 알림 여부 |
+| isEnabled | Boolean | 활성화 여부 |
+| dbInstances | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 수정하기
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5448,18 +5748,20 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
-| dbInstanceIds | Body | Array | X | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5472,8 +5774,16 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Array | N | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
@@ -5485,10 +5795,6 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 ### 통계 정보 조회
 
-```http
-GET /v4.0/metric-statistics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5496,6 +5802,12 @@ GET /v4.0/metric-statistics
 | RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -5507,10 +5819,6 @@ GET /v4.0/metric-statistics
 
 ### Metric 목록 보기
 
-```http
-GET /v4.0/metrics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5519,18 +5827,18 @@ GET /v4.0/metrics
 
 #### 요청
 
+```http
+GET /v4.0/metrics
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.measureName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5548,8 +5856,13 @@ GET /v4.0/metrics
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| metrics | Array | Metric 목록 |
+| metrics.measureName | String | 조회 지표 유형 |
+| metrics.unit | String | 측정값 단위 |
 
 ---
 
@@ -5570,10 +5883,6 @@ GET /v4.0/metrics
 
 ### 구독 가능한 이벤트 코드 목록 보기
 
-```http
-GET /v4.0/event-codes
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5582,18 +5891,18 @@ GET /v4.0/event-codes
 
 #### 요청
 
+```http
+GET /v4.0/event-codes
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | 이벤트 코드 목록 |
-| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
-| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5611,16 +5920,17 @@ GET /v4.0/event-codes
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventCodes | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### 이벤트 목록 조회
-
-```http
-GET /v4.0/events
-```
 
 #### 필요 권한
 
@@ -5630,25 +5940,18 @@ GET /v4.0/events
 
 #### 요청
 
+```http
+GET /v4.0/events
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 목록 수 |
-| events | Body | Array | 이벤트 목록 |
-| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
-| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
-| events.messages | Body | Array | 이벤트 메세지 목록 |
-| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | 이벤트 메세지 |
-| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5676,18 +5979,26 @@ GET /v4.0/events
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 목록 수 |
+| events | Array | 이벤트 목록 |
+| events.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | UUID | 이벤트 소스의 식별자 |
+| events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | 이벤트 메세지 |
+| events.eventYmdt | DateTime | 이벤트 발생 일시 |
 
 ---
 
 ## 이벤트 구독
 
 ### 이벤트 구독 목록 조회
-
-```http
-GET /v4.0/event-subscriptions
-```
 
 #### 필요 권한
 
@@ -5697,29 +6008,18 @@ GET /v4.0/event-subscriptions
 
 #### 요청
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
-| eventSubscriptions | Body | Array | 이벤트 구독 목록 |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
-| eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
-| eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
-| eventSubscriptions.notifyEmail | Body | Boolean | 이메일 발송 여부 |
-| eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
-| eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
-| eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
-| eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5753,16 +6053,28 @@ GET /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | UUID | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 이벤트 구독 생성하기
-
-```http
-POST /v4.0/event-subscriptions
-```
 
 #### 필요 권한
 
@@ -5772,21 +6084,14 @@ POST /v4.0/event-subscriptions
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | 이벤트 구독을 식별할 수 있는 이름 |
-| enabled | Body | Boolean | O | 활성화 여부 |
-| notifyEmail | Body | Boolean | O | 이메일 발송 여부 |
-| notifySms | Body | Boolean | O | SMS 발송 여부 |
-| eventCodes | Body | Array | O | 구독할 이벤트 코드 목록 |
-| sources | Body | Array | O | 구독할 이벤트 소스 목록 |
-| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
-| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5806,17 +6111,25 @@ POST /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | Y | 활성화 여부 |
+| notifyEmail | Boolean | Y | 이메일 발송 여부 |
+| notifySms | Boolean | Y | SMS 발송 여부 |
+| eventCodes | Array | Y | 구독할 이벤트 코드 목록 |
+| sources | Array | Y | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5829,16 +6142,15 @@ POST /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
 
 ---
 
 ### 이벤트 구독 삭제하기
-
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
 
 #### 필요 권한
 
@@ -5848,11 +6160,19 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5862,10 +6182,6 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### 이벤트 구독 수정하기
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5874,22 +6190,20 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | 이벤트 구독을 식별할 수 있는 이름 |
-| enabled | Body | Boolean | X | 활성화 여부 |
-| notifyEmail | Body | Boolean | X | 이메일 발송 여부 |
-| notifySms | Body | Boolean | X | SMS 발송 여부 |
-| eventCodes | Body | Array | X | 구독할 이벤트 코드 목록 |
-| sources | Body | Array | X | 구독할 이벤트 소스 목록 |
-| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
-| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5909,8 +6223,20 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | N | 활성화 여부 |
+| notifyEmail | Boolean | N | 이메일 발송 여부 |
+| notifySms | Boolean | N | SMS 발송 여부 |
+| eventCodes | Array | N | 구독할 이벤트 코드 목록 |
+| sources | Array | N | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
@@ -5922,10 +6248,6 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### 가용성 영역 목록 보기
 
-```http
-GET /v4.0/availability-zones
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5934,19 +6256,18 @@ GET /v4.0/availability-zones
 
 #### 요청
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | 가용성 영역 목록 |
-| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
-| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
-| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5966,8 +6287,14 @@ GET /v4.0/availability-zones
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZones | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Boolean | 가용성 영역의 사용 가능 여부 |
 
 ---
 

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -109,6 +109,9 @@ GET /v4.0/project/members
     },
     "members": [
         {
+            "memberId": "memberId-example",
+            "memberName": "memberName-example",
+            "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
         }
     ]
@@ -150,6 +153,7 @@ GET /v4.0/project/regions
     },
     "regions": [
         {
+            "regionCode": "KR1",
             "isEnabled": false
         }
     ]
@@ -195,6 +199,9 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
+            "dbFlavorId": "dbFlavorId-example",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -223,7 +230,7 @@ GET /v4.0/network/subnets
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnets.subnetCidr | Body | String | 서브넷의 CIDR |
 | subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
@@ -241,6 +248,10 @@ GET /v4.0/network/subnets
     },
     "subnets": [
         {
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
+            "subnetCidr": "subnetCidr-example",
+            "usingGateway": false,
             "availableIpCount": 1
         }
     ]
@@ -285,6 +296,8 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
+            "dbVersion": "dbVersion-example",
+            "dbVersionName": "dbVersionName-example",
             "restorableFromObs": false
         }
     ]
@@ -392,6 +405,7 @@ GET /v4.0/jobs/{jobId}
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
+            "resourceType": "resourceType-example",
             "resourceId": "resourceId-example"
         }
     ],
@@ -439,6 +453,9 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "replicationType": "STANDALONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -491,6 +508,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
@@ -590,6 +609,16 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "dbPort": 1,
+            "dbInstanceType": "MASTER",
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "NONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -703,6 +732,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -832,6 +862,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1129,6 +1160,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1172,6 +1204,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1241,6 +1274,8 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1319,6 +1354,9 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
+            "fileName": "fileName-example",
+            "certificateType": "CA_FILE",
+            "fileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1426,6 +1464,9 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
+            "dbSchemaId": "dbSchemaId-example",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1568,6 +1609,14 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
+            "dbUserId": "dbUserId-example",
+            "dbUserName": "dbUserName-example",
+            "host": "host-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
             "tlsOption": "NONE"
         }
     ]
@@ -2082,6 +2131,9 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
     },
     "logFiles": [
         {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2243,6 +2295,19 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
     "totalCounts": 1,
     "maintenances": [
         {
+            "maintenanceId": "maintenanceId-example",
+            "dbInstanceId": "dbInstanceId-example",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
             "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2418,6 +2483,8 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     },
     "endPoints": [
         {
+            "domain": "domain-example",
+            "ipAddress": "ipAddress-example",
             "endPointType": "endPointType-example"
         }
     ]
@@ -2638,6 +2705,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -2781,6 +2849,23 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
     "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
     "restorableBackups": [
         {
+            "backup": {
+                "backupId": "backupId-example",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "dbInstanceId-example",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "ENUM_VALUE",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
             "restorableBinLogs": []
         }
     ]
@@ -2947,6 +3032,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3243,6 +3329,15 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
+            "backupId": "backupId-example",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "dbInstanceId-example",
+            "dbVersion": "ENUM_VALUE",
+            "utilVersion": "utilVersion-example",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3574,6 +3669,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3656,6 +3752,11 @@ GET /v4.0/db-security-groups
     "totalCounts": 1,
     "dbSecurityGroups": [
         {
+            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
+            "progressStatus": "NONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3698,6 +3799,14 @@ POST /v4.0/db-security-groups
     "description": "description-example",
     "rules": [
         {
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
+            },
+            "cidr": "cidr-example",
             "description": "description-example"
         }
     ]
@@ -3805,6 +3914,17 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
     "progressStatus": "NONE",
     "rules": [
         {
+            "ruleId": "ruleId-example",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "cidr-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ],
@@ -4062,6 +4182,13 @@ GET /v4.0/parameter-groups
     "totalCounts": 1,
     "parameterGroups": [
         {
+            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "parameterGroupType": "USER",
+            "parameterGroupStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4199,6 +4326,14 @@ GET /v4.0/parameter-groups/{parameterGroupId}
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
+            "parameterId": "parameterId-example",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
             "applyType": "BOTH"
         }
     ],
@@ -4319,6 +4454,7 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 {
     "modifiedParameters": [
         {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
             "value": "value-example"
         }
     ]
@@ -4390,6 +4526,9 @@ GET /v4.0/user-groups
     "totalCounts": 1,
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4600,6 +4739,12 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
+            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
+            "notifySms": false,
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4739,11 +4884,13 @@ GET /v4.0/notification-groups/{notificationGroupId}
     "isEnabled": false,
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -4846,6 +4993,7 @@ GET /v4.0/metrics
     },
     "metrics": [
         {
+            "measureName": "measureName-example",
             "unit": "unit-example"
         }
     ]
@@ -4902,6 +5050,7 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
+            "eventCode": "ENUM_VALUE",
             "eventCategoryType": "ALL"
         }
     ]
@@ -4951,6 +5100,16 @@ GET /v4.0/events
     "totalCounts": 1,
     "events": [
         {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "sourceId-example",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
             "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -5006,6 +5165,20 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
+            "eventSubscriptionId": "eventSubscriptionId-example",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
+            "notifySms": false,
+            "eventCodes": [],
+            "sources": [
+                {
+                    "sourceId": "sourceId-example",
+                    "eventCategoryType": "ALL"
+                }
+            ],
+            "userGroupIds": [],
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -5051,6 +5224,7 @@ POST /v4.0/event-subscriptions
     "eventCodes": [],
     "sources": [
         {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL"
         }
     ],
@@ -5141,6 +5315,7 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
     "eventCodes": [],
     "sources": [
         {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL"
         }
     ],
@@ -5190,6 +5365,7 @@ GET /v4.0/availability-zones
     },
     "availabilityZones": [
         {
+            "availabilityZoneName": "availabilityZoneName-example",
             "zoneState": {
                 "available": false
             }

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -99,7 +99,7 @@ GET /v4.0/project/members
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | members.memberName | Body | String | 프로젝트 멤버의 이름 |
 | members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
 | members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
@@ -116,7 +116,7 @@ GET /v4.0/project/members
     },
     "members": [
         {
-            "memberId": "memberId-example",
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
             "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
@@ -201,7 +201,7 @@ GET /v4.0/db-flavors
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
 | dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
 | dbFlavors.ram | Body | Number | 메모리 용량(MB) |
 | dbFlavors.vcpus | Body | Number | CPU 코어 수 |
@@ -218,7 +218,7 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "dbFlavorId-example",
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
             "dbFlavorName": "dbFlavorName-example",
             "ram": 1,
             "vcpus": 1
@@ -327,7 +327,7 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "dbVersion-example",
+            "dbVersion": "MYSQL_V8036",
             "dbVersionName": "dbVersionName-example",
             "restorableFromObs": false
         }
@@ -426,7 +426,7 @@ GET /v4.0/jobs/{jobId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 | jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
 | resourceRelations | Body | Array | 연관 리소스 목록 |
 | resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
@@ -444,7 +444,7 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
@@ -485,7 +485,7 @@ GET /v4.0/db-instance-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
 | dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
@@ -502,7 +502,7 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
@@ -540,10 +540,10 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | createdYmdt | Body | DateTime | 생성 일시 |
@@ -559,11 +559,11 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
@@ -646,8 +646,8 @@ GET /v4.0/db-instances
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstances | Body | Array | DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
@@ -670,11 +670,11 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "MYSQL_V8036",
             "dbPort": 1,
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE",
@@ -765,7 +765,7 @@ POST /v4.0/db-instances
     "dbInstanceName": "dbInstanceName",
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "dbPort": 1,
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
@@ -782,10 +782,10 @@ POST /v4.0/db-instances
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -912,11 +912,11 @@ POST /v4.0/db-instances/restore-from-obs
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "dbPort": 1,
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "useHighAvailability": false,
     "pingInterval": 3,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -925,7 +925,7 @@ POST /v4.0/db-instances/restore-from-obs
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -1064,8 +1064,8 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 유형 |
@@ -1073,8 +1073,8 @@ GET /v4.0/db-instances/{dbInstanceId}
 | dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
 | dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
 | notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
 | useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
@@ -1096,17 +1096,17 @@ GET /v4.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "dbInstanceId-example",
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceName": "dbInstanceName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "dbPort": 1,
     "dbInstanceType": "MASTER",
     "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "dbFlavorId-example",
-    "parameterGroupId": "parameterGroupId-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupIds": [],
     "notificationGroupIds": [],
     "useDeletionProtection": false,
@@ -1168,7 +1168,7 @@ PUT /v4.0/db-instances/{dbInstanceId}
     "dbPort": 1,
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "useSlowQueryAnalysis": false,
     "useDummy": false,
     "dbSecurityGroupIds": [],
@@ -1580,7 +1580,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbSchemas | Body | Array | DB 스키마 목록 |
-| dbSchemas.dbSchemaId | Body | String | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaId | Body | UUID | DB 스키마의 식별자 |
 | dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
 | dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
 | dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
@@ -1597,7 +1597,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
-            "dbSchemaId": "dbSchemaId-example",
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
             "dbSchemaName": "dbSchemaName-example",
             "dbSchemaStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00"
@@ -1738,7 +1738,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
 | dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
 | dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
 | dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
@@ -1760,7 +1760,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
-            "dbUserId": "dbUserId-example",
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
             "host": "host-example",
             "authorityType": "CUSTOM",
@@ -2509,8 +2509,8 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 유지 관리 목록 갯수 |
 | maintenances | Body | Array | 유지 관리 목록 |
-| maintenances.maintenanceId | Body | String | 유지 관리 아이디 |
-| maintenances.dbInstanceId | Body | String | DB 인스턴스 아이디 |
+| maintenances.maintenanceId | Body | UUID | 유지 관리 아이디 |
+| maintenances.dbInstanceId | Body | UUID | DB 인스턴스 아이디 |
 | maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
 | maintenances.description | Body | String | 유지 관리 설명 |
 | maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
@@ -2536,8 +2536,8 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
     "totalCounts": 1,
     "maintenances": [
         {
-            "maintenanceId": "maintenanceId-example",
-            "dbInstanceId": "dbInstanceId-example",
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "category": "USER",
             "description": "description-example",
             "type": "UPDATE_DB_INSTANCE",
@@ -2722,7 +2722,7 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 |-----|-----|-----|-----|
 | availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
 | subnet | Body | Object | 서브넷 객체 |
-| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnet.subnetCidr | Body | String | 서브넷의 CIDR |
 | endPoints | Body | Array | 접속 정보 목록 |
@@ -2740,9 +2740,9 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "availabilityZone-example",
+    "availabilityZone": "kr-pub-a",
     "subnet": {
-        "subnetId": "subnetId-example",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
         "subnetCidr": "subnetCidr-example"
     },
@@ -2977,10 +2977,10 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
     "useSlowQueryAnalysis": true,
     "network": {
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -3120,10 +3120,10 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 | latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
 | restorableBackups | Body | Array | 복원 가능한 백업 목록 |
 | restorableBackups.backup | Body | Object | 백업 정보 객체 |
-| restorableBackups.backup.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backup.backupId | Body | UUID | 백업의 식별자 |
 | restorableBackups.backup.backupName | Body | String | 백업 이름 |
 | restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
 | restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
 | restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
@@ -3151,12 +3151,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
     "restorableBackups": [
         {
             "backup": {
-                "backupId": "backupId-example",
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
                 "backupName": "backupName-example",
                 "backupStatus": "BACKING_UP",
-                "dbInstanceId": "dbInstanceId-example",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
                 "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "ENUM_VALUE",
+                "dbVersion": "MYSQL_V8036",
                 "backupType": "AUTO",
                 "backupSize": 1,
                 "useBackupLock": false,
@@ -3326,7 +3326,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
     "useHighAvailability": false,
     "pingInterval": 3,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -3335,7 +3335,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -3528,7 +3528,7 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "storageType-example",
+    "storageType": "General SSD",
     "storageSize": 1,
     "storageStatus": "DELETED",
     "storageAutoscale": {
@@ -3648,10 +3648,10 @@ GET /v4.0/backups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 백업 목록 수 |
 | backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupId | Body | UUID | 백업의 식별자 |
 | backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
 | backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | backups.dbVersion | Body | Enum | DB 엔진 유형 |
 | backups.utilVersion | Body | String | 유틸리티 버전 |
 | backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
@@ -3672,11 +3672,11 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "backupId-example",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
             "backupName": "backupName-example",
             "backupStatus": "BACKING_UP",
-            "dbInstanceId": "dbInstanceId-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
             "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
             "backupSize": 1,
@@ -3823,11 +3823,11 @@ GET /v4.0/backups/{backupId}
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | backup | Body | Object | 백업 상세 정보 |
-| backup.backupId | Body | String | 백업의 식별자 |
+| backup.backupId | Body | UUID | 백업의 식별자 |
 | backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
 | backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
 | backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
 | backup.dbVersion | Body | Enum | DB 엔진 버전 |
 | backup.utilVersion | Body | String | 유틸리티 버전 |
@@ -3852,13 +3852,13 @@ GET /v4.0/backups/{backupId}
         "isSuccessful": true
     },
     "backup": {
-        "backupId": "backupId-example",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
         "regionCode": "KR1",
         "backupName": "backupName-example",
         "backupStatus": "BACKING_UP",
-        "dbInstanceId": "dbInstanceId-example",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
         "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "ENUM_VALUE",
+        "dbVersion": "MYSQL_V8036",
         "utilVersion": "utilVersion-example",
         "backupType": "AUTO",
         "backupMethodType": "FULL",
@@ -4025,10 +4025,10 @@ POST /v4.0/backups/{backupId}/restore
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -4111,7 +4111,7 @@ GET /v4.0/db-security-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
 | dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
 | dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
@@ -4131,7 +4131,7 @@ GET /v4.0/db-security-groups
     "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbSecurityGroupName": "dbSecurityGroupName-example",
             "description": "description-example",
             "progressStatus": "NONE",
@@ -4205,7 +4205,7 @@ POST /v4.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4217,7 +4217,7 @@ POST /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4276,12 +4276,12 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | description | Body | String | DB 보안 그룹에 대한 추가 정보 |
 | progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
 | rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
 | rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
 | rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
@@ -4305,13 +4305,13 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupName": "dbSecurityGroupName-example",
     "description": "description-example",
     "progressStatus": "NONE",
     "rules": [
         {
-            "ruleId": "ruleId-example",
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
             "description": "description-example",
             "direction": "INGRESS",
             "etherType": "IPV4",
@@ -4399,7 +4399,7 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4411,7 +4411,7 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4470,7 +4470,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4482,7 +4482,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4542,7 +4542,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4554,7 +4554,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4587,7 +4587,7 @@ GET /v4.0/parameter-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 파라미터 그룹 수 |
 | parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
@@ -4609,10 +4609,10 @@ GET /v4.0/parameter-groups
     "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "parameterGroupName": "parameterGroupName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "MYSQL_V8036",
             "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -4654,7 +4654,7 @@ POST /v4.0/parameter-groups
 {
     "parameterGroupName": "parameterGroupName",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -4665,7 +4665,7 @@ POST /v4.0/parameter-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4677,7 +4677,7 @@ POST /v4.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4736,13 +4736,13 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 유형 |
 | parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
 | parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterId | Body | UUID | 파라미터의 식별자 |
 | parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
 | parameters.parameterName | Body | String | 파라미터 이름 |
 | parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
@@ -4764,14 +4764,14 @@ GET /v4.0/parameter-groups/{parameterGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupName": "parameterGroupName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
-            "parameterId": "parameterId-example",
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
             "parameterFileGroup": "CLIENT",
             "parameterName": "parameterName-example",
             "fileParameterName": "fileParameterName-example",
@@ -4868,7 +4868,7 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4880,7 +4880,7 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4983,7 +4983,7 @@ GET /v4.0/user-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
 | userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroups.createdYmdt | Body | DateTime | 생성 일시 |
 | userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
@@ -5001,7 +5001,7 @@ GET /v4.0/user-groups
     "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
@@ -5053,7 +5053,7 @@ POST /v4.0/user-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5065,7 +5065,7 @@ POST /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example"
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5124,11 +5124,11 @@ GET /v4.0/user-groups/{userGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
 | members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
 
@@ -5142,12 +5142,12 @@ GET /v4.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example",
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "userGroupName": "userGroupName-example",
     "userGroupTypeCode": "ENTIRE",
     "members": [
         {
-            "memberId": "memberId-example"
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
         }
     ],
     "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -5224,7 +5224,7 @@ GET /v4.0/notification-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | notificationGroups | Body | Array | 알림 그룹 목록 |
-| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
 | notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
@@ -5244,7 +5244,7 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "notificationGroupName": "notificationGroupName-example",
             "notifyEmail": false,
             "notifySms": false,
@@ -5305,7 +5305,7 @@ POST /v4.0/notification-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5317,7 +5317,7 @@ POST /v4.0/notification-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5376,16 +5376,16 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notifyEmail | Body | Boolean | 이메일 알림 여부 |
 | notifySms | Body | Boolean | SMS 알림 여부 |
 | isEnabled | Body | Boolean | 활성화 여부 |
 | dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
@@ -5400,20 +5400,20 @@ GET /v4.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "notificationGroupName": "notificationGroupName-example",
     "notifyEmail": false,
     "notifySms": false,
     "isEnabled": false,
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -5698,7 +5698,7 @@ GET /v4.0/event-subscriptions
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
 | eventSubscriptions | Body | Array | 이벤트 구독 목록 |
-| eventSubscriptions.eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
 | eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
 | eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
@@ -5724,7 +5724,7 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "eventSubscriptionId-example",
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL",
             "eventSubscriptionName": "eventSubscriptionName-example",
             "enabled": false,
@@ -5804,7 +5804,7 @@ POST /v4.0/event-subscriptions
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5816,7 +5816,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "eventSubscriptionId-example"
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -2,36 +2,29 @@
 
 ## RDS for MariaDB API 공통 정보
 
-### API 엔드포인트
-
-| 리전        | 엔드포인트                                         |
-|-----------|-----------------------------------------------|
-| 한국(판교) 리전 | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
-
 ### 인증 및 권한
 
 RDS for MariaDB은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름                  | 종류     | 형식     | 필수 | 설명                                                          |
-|---------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public API로 발급 받은 Bearer 유형 토큰                              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | O | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
 
+또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
-또한 프로젝트 멤버 역할에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`로 구분하여 권한을 부여할 수 있습니다.
-
-* `RDS for MariaDB ADMIN` 권한은 모든 기능을 사용 가능합니다.
-* `RDS for MariaDB VIEWER` 권한은 정보를 조회하는 기능만 사용 가능합니다.
+* `RDS for MariaDB ADMIN` 역할은 API 실행에 필요한 모든 권한이 부여됩니다.
+* `RDS for MariaDB VIEWER` 역할은 정보를 조회하는 권한만 부여됩니다.
     * DB 인스턴스를 생성, 수정, 삭제하거나, DB 인스턴스를 대상으로 하는 어떠한 기능도 사용할 수 없습니다.
-    * 단, 알림 그룹 및 사용자 그룹 관련 기능은 사용 가능합니다.
+    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용할 수 있습니다.
 
 API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같은 오류가 발생합니다.
 
-| resultCode | resultMessage | 설명          |
-|------------|---------------|-------------|
-| 80401      | Unauthorized  | 인증에 실패했습니다. |
-| 80403      | Forbidden     | 권한이 없습니다.   |
+| resultCode | resultMessage | 설명 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 인증에 실패했습니다. |
+| 80403 | Forbidden | 권한이 없습니다. |
 
 ### 응답 공통 정보
 
@@ -49,43 +42,55 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 ```
 
 #### 필드
-| 이름            | 형식      | 설명                                      |
-|---------------|---------|-----------------------------------------|
-| resultCode    | Number  | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
-| resultMessage | String  | 결과 메시지                                  |
-| isSuccessful  | Boolean | 성공 여부                                   |
+| 이름 | 형식 | 설명 |
+|-----|-----|-----|
+| resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
+| resultMessage | String | 결과 메시지 |
+| isSuccessful | Boolean | 성공 여부 |
 
+### API 엔드포인트
+
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-mariadb.api.gov-nhncloudservice.com |
 
 ### DB 엔진 유형
 
-| DB 엔진 유형        | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+| DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
 
-* ENUM 타입의 dbVersion 필드에서 해당 값을 사용할 수 있습니다.
+* ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
-## 프로젝트 정보
+## DB 보안 그룹
 
-### 리전 목록 보기
+### DB 보안 그룹 진행 상태
+
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
+
+### DB 보안 그룹 목록 보기
 
 ```http
-GET /v4.0/project/regions
+GET /v4.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | 프로젝트 정보 조회 |
 
 #### 요청
 
@@ -93,11 +98,16 @@ GET /v4.0/project/regions
 
 #### 응답
 
-| 이름                 | 종류   | 형식      | 설명                                                                         |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | 리전 목록                                                                      |
-| regions.regionCode | Body | Enum    | 리전 코드<br/>- `KR1`: 한국(판교) 리전 |
-| regions.isEnabled  | Body | Boolean | 리전의 활성화 여부                                                                 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -109,61 +119,10 @@ GET /v4.0/project/regions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "regions": [
+    "totalCounts": 1,
+    "dbSecurityGroups": [
         {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | 프로젝트 정보 조회 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                   | 종류   | 형식     | 설명              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | 프로젝트 멤버 목록      |
-| members.memberId     | Body | UUID   | 프로젝트 멤버의 식별자    |
-| members.memberName   | Body | String | 프로젝트 멤버의 이름     |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber  | Body | String | 프로젝트 멤버의 전화번호   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "홍길동",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -174,50 +133,38 @@ GET /v4.0/project/members
 
 ---
 
-## DB 인스턴스 사양
-
-### DB 인스턴스 사양 목록 보기
+### DB 보안 그룹 생성하기
 
 ```http
-GET /v4.0/db-flavors
+POST /v4.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                                       | 설명               |
-|-------------------------------------------|------------------|
-| RDSforMariaDB:DbFlavor.List | DB 인스턴스 사양 목록 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                     | 종류   | 형식     | 설명              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DB 인스턴스 사양 목록   |
-| dbFlavors.dbFlavorId   | Body | UUID   | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름   |
-| dbFlavors.ram          | Body | Number | 메모리 용량(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU 코어 수        |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "description": "description-example"
         }
     ]
 }
@@ -226,36 +173,11 @@ GET /v4.0/db-flavors
 </p>
 </details>
 
----
-
-## 네트워크
-
-### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명        |
-|------------------------------------------|-----------|
-| RDSforMariaDB:Network.List | 서브넷 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
 #### 응답
 
-| 이름                       | 종류   | 형식      | 설명               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | 서브넷 목록           |
-| subnets.subnetId         | Body | UUID    | 서브넷의 식별자         |
-| subnets.subnetName       | Body | String  | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr       | Body | String  | 서브넷의 CIDR        |
-| subnets.usingGateway     | Body | Boolean | 게이트웨이 사용 여부      |
-| subnets.availableIpCount | Body | Number  | 사용 가능한 IP 수      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -267,15 +189,297 @@ GET /v4.0/network/subnets
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "subnets": [
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 상세 보기
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | 포트 객체 |
+| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | 최소 포트 범위 |
+| rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 생성 일시 |
+| rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
-    ]
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 규칙 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
 }
 ```
 
@@ -292,23 +496,17 @@ GET /v4.0/network/subnets
 GET /v4.0/db-versions
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명          |
-|--------------------------------------------|-------------|
-| RDSforMariaDB:DbVersion.List | DB 엔진 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 엔진 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 엔진 유형              |
-| dbVersions.dbVersionName     | Body | String  | DB 엔진 이름              |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | Body | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | Body | String | DB 엔진 이름 |
 | dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 <details><summary>예시</summary>
@@ -323,252 +521,9 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "restorableFromObs": false
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 데이터 스토리지
-
-### 데이터 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명                |
-|------------------------------------------|-------------------|
-| RDSforMariaDB:Storage.List | 데이터 스토리지 타입 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름           | 종류   | 형식    | 설명             |
-|--------------|------|-------|----------------|
-| storageTypes | Body | Array | 데이터 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 작업 정보
-
-### 작업 상태
-
-| 상태명                | 설명                   |
-|--------------------|----------------------|
-| `PREPARING`        | 작업이 준비 중인 경우         |
-| `READY`            | 작업이 준비 완료된 경우        |
-| `RUNNING`          | 작업이 진행 중인 경우         |
-| `COMPLETED`        | 작업이 완료된 경우           |
-| `REGISTERED`       | 작업이 등록된 경우           |
-| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
-| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
-| `CANCELED`         | 작업이 취소된 경우           |
-| `FAILED`           | 작업이 실패한 경우           |
-| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
-| `DELETED`          | 작업이 삭제된 경우           |
-| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
-
-### 작업 정보 상세 보기
-
-```http
-GET /v4.0/jobs/{jobId}
-```
-
-#### 필요 권한
-
-| 권한명                                 | 설명          |
-|-------------------------------------|-------------|
-| RDSforMariaDB:Job.Get | 작업 정보 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름    | 종류  | 형식   | 필수 | 설명      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 작업의 식별자 |
-
-#### 응답
-
-| 이름                             | 종류   | 형식       | 설명                                |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 작업의 식별자                           |
-| jobStatus                      | Body | Enum     | 작업의 현재 상태                         |
-| resourceRelations              | Body | Array    | 연관 리소스 목록                         |
-| resourceRelations.resourceType | Body | Enum     | 연관 리소스 유형                         |
-| resourceRelations.resourceId   | Body | UUID     | 연관 리소스의 식별자                       |
-| createdYmdt                    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명               |
-|--------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                                 | 종류   | 형식       | 설명                                                                       |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB 인스턴스 그룹 목록                                                            |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                          |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명               |
-|-------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| replicationType              | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성                                                              |
-| dbInstances                  | Body | Array    | DB 인스턴스 그룹에 속한 DB 인스턴스 목록                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
 }
 ```
 
@@ -601,8 +556,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 | `BACKING_UP`               | 백업 중         |
 | `CANCELING`                | 취소 중         |
 | `CREATING`                 | 생성 중         |
-| `CREATING_SCHEMA`          | DB 스키마 생성 중	 |
-| `CREATING_USER`            | 사용자 생성 중	    |
+| `CREATING_SCHEMA`          | DB 스키마 생성 중  |
+| `CREATING_USER`            | 사용자 생성 중     |
 | `DELETING`                 | 삭제 중         |
 | `DELETING_SCHEMA`          | DB 스키마 삭제 중  |
 | `DELETING_USER`            | 사용자 삭제 중     |
@@ -621,8 +576,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 | `STARTING`                 | 시작 중         |
 | `STOPPING`                 | 정지 중         |
 | `SYNCING_SCHEMA`           | DB 스키마 동기화 중 |
-| `SYNCING_USER`             | 사용자 동기화 중	   |
-| `UPDATING_USER`            | 사용자 수정 중	    |
+| `SYNCING_USER`             | 사용자 동기화 중    |
+| `UPDATING_USER`            | 사용자 수정 중     |
 
 ### DB 인스턴스 목록 보기
 
@@ -630,32 +585,26 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 GET /v4.0/db-instances
 ```
 
-#### 필요 권한
-
-| 권한명                                         | 설명            |
-|---------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.List | DB 인스턴스 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB 인스턴스 목록                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| dbInstances.description       | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB 인스턴스의 현재 진행 상태                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
+| dbInstances.dbPort | Body | Number | DB 포트 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -669,104 +618,9 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 상세 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                          | 종류   | 형식       | 설명                                                                                                                                    |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstanceGroupId           | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceName              | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| description                 | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbVersion                   | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbPort                      | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstanceStatus            | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| progressStatus              | Body | Enum     | DB 인스턴스의 현재 작업 진행 상태                                                                                                                  |
-| dbFlavorId                  | Body | UUID     | DB 인스턴스 사양의 식별자                                                                                                                       |
-| parameterGroupId            | Body | UUID     | DB 인스턴스에 적용된 파라미터 그룹의 식별자                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록                                                                                                         |
-| notificationGroupIds        | Body | Array    | DB 인스턴스에 적용된 알림 그룹의 식별자 목록                                                                                                            |
-| useDeletionProtection       | Body | Boolean  | DB 인스턴스 삭제 보호 여부                                                                                                                      |
-| useSlowQueryAnalysis        | Body | Boolean  | Slow query 분석 여부                                                                                                                      |
-| supportAuthenticationPlugin | Body | Boolean  | 인증 플러그인 지원 여부                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 최신 파라미터 그룹 적용 필요 여부                                                                                                                   |
-| needMigration               | Body | Boolean  | 마이그레이션 필요 여부                                                                                                                          |
-| supportDbVersionUpgrade     | Body | Boolean  | DB 버전 업그레이드 지원 여부                                                                                                                     |
-| createdYmdt                 | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
 }
 ```
 
@@ -781,86 +635,103 @@ GET /v4.0/db-instances/{dbInstanceId}
 POST /v4.0/db-instances
 ```
 
-#### 필요 권한
+#### 공통 요청
 
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| authenticationPlugin | Body | Enum | X | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 데이터 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
-#### 요청
+#### 고가용성 사용 시
 
-| 이름                      | 종류    | 형식      | 필수 | 설명                                                                  |
-|-------------------------|-------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName          | Body  | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName | Body  | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                         |
-| description             | Body  | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId              | Body  | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbVersion               | Body  | Enum    | O  | DB 엔진 유형                                                            |
-| dbPort                  | Body  | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| dbUserName              | Body  | String  | O  | DB 사용자 계정명                                                          |
-| dbPassword              | Body  | String  | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                    |
-| parameterGroupId        | Body  | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds      | Body  | Array   | X  | DB 보안 그룹의 식별자 목록                                                    |
-| userGroupIds            | Body  | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability     | Body  | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval            | Body  | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                | Body  | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification  | Body  | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection   | Body  | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         |
-| useSlowQueryAnalysis    | Body  | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                  |
-| authenticationPlugin                         | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                  |
-| network.subnetId                             | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                    |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                                                                                             |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                                                                                                    |
-| storage                                      | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                                                                                                  |    
-| storage.storageType                          | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                                                                                                         |
-| storage.storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                           |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                   |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                       |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                         |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                   |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                   |
-| backup                                       | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                    |
-| backup.backupPeriod                          | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                          |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                     |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
     "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
@@ -872,52 +743,140 @@ POST /v4.0/db-instances
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                      | 종류   | 형식      | 필수 | 설명                                          |
-|-------------------------|------|---------|----|---------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB 인스턴스의 식별자                                |
-| dbInstanceName          | Body | String  | X  | DB 인스턴스를 식별할 수 있는 마스터 이름                    |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                           |
-| dbPort                  | Body | Number  | X  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Slow query 분석 여부 |
-| dbFlavorId         | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                           |
-| parameterGroupId   | Body | UUID    | X  | 파라미터 그룹의 식별자                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                          |
-| executeBackup      | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| useOnlineFailover  | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| waitReplicationDelay  | Body | Boolean | X  | 복제 지연 해소 대기 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| useReadOnly  | Body | Boolean | X  | 읽기 전용으로 변경 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | O | DB 포트 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "ENUM_VALUE",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "tenantId-example",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
@@ -926,9 +885,26 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -938,218 +914,19 @@ PUT /v4.0/db-instances/{dbInstanceId}
 DELETE /v4.0/db-instances/{dbInstanceId}
 ```
 
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | DB 인스턴스 삭제하기 |
-
 #### 요청
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| deleteAutoBackup          | Body | Boolean  | X  | 자동 백업 삭제 여부<br/>- 기본값: `false` |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | DB 인스턴스 재시작하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| waitReplicationDelay     | Body | Boolean | X  | 복제 지연 해소 대기 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false`                                         |
-| useReadOnly     | Body | Boolean | X  | 읽기 전용으로 변경 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false`                                         |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-### DB 인스턴스 강제 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명               |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| deleteAutoBackup | Body | Boolean | X | 자동 백업 삭제 여부<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 인스턴스 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### 필요 권한
-
-| 권한명                                          | 설명           |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | DB 인스턴스 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 정지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 필요 권한
-
-| 권한명                                         | 설명           |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | DB 인스턴스 정지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 복제하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명           |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
-
-#### 요청
-
-| 이름                                           | 종류   | 형식      | 필수 | 설명                                                                        |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbInstanceName                               | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                      |
-| description                                  | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                         |
-| dbFlavorId                                   | Body | UUID    | X  | DB 인스턴스 사양의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                   |
-| dbPort                                       | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`        |
-| parameterGroupId                             | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                      |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB 보안 그룹의 식별자 목록<br/>- 기본값: 원본 DB 인스턴스 값                                  |
-| userGroupIds                                 | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                            |
-| useDefaultNotification                       | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                            |
-| useDeletionProtection                        | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                               |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                        |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: 원본 DB 인스턴스 값                                       |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                  |
-| storage                                      | Body | Object  | X  | 데이터 스토리지 정보 객체                                                            |    
-| storage.storageType                          | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 예시: `General SSD`                        |
-| storage.storageSize                          | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                         |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                             |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `50`<br/>- 최댓값: `95`                               |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최댓값: `4096`                                         |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                         |
-| backup                                       | Body | Object  | X  | 백업 정보 객체                                                                  |
-| backup.backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | 백업 시작 시각<br/>- 예시: `00:00:00`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간<br/>- 기본값: 원본 DB 인스턴스 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
+    "deleteAutoBackup": false
 }
 ```
 
@@ -1158,194 +935,9 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 승격하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | DB 인스턴스 승격하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재구축하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | DB 인스턴스 재구축하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 복원 정보 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                      | 종류   | 형식       | 설명                                                                                                                                                                           |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 가장 오래된 복원 가능한 시각                                                                                                                                                             |
-| latestRestorableYmdt                    | Body | DateTime | 가장 최신의 복원 가능한 시각                                                                                                                                                             |
-| restorableBackups                       | Body | Array    | 복원 가능한 백업 목록                                                                                                                                                                 |
-| restorableBackups.backup                | Body | Object   | 백업 정보 객체                                                                                                                                                                     |
-| restorableBackups.backup.backupId       | Body | UUID     | 백업의 식별자                                                                                                                                                                      |
-| restorableBackups.backup.backupName     | Body | String   | 백업 이름                                                                                                                                                                        |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | 테이블 잠금 사용 여부                                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | 백업 크기                                                                                                                                                                        |
-| restorableBackups.backup.backupType     | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`: 수동                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | 백업 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                                              |
-| restorableBackups.backup.dbInstanceName | Body | String   | 원본 DB 인스턴스의 이름                                                                                                                                                               |
-| restorableBackups.backup.dbVersion      | Body | String   | DB 엔진 유형                                                                                                                                                                     |
-| restorableBackups.backup.failoverCount  | Body | Number   | 장애 조치 횟수                                                                                                                                                                     |
-| restorableBackups.backup.binLogFileName | Body | String   | 바이너리 로그 파일명                                                                                                                                                                |
-| restorableBackups.backup.binLogPosition | Body | Number   | 바이너리 로그 파일 위치                                                                                                                                                                |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | 백업 생성 일시                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | 백업 갱신 일시                                                                                                                                                                     |
-| restorableBackups.restorableBinLogs     | Body | Array    | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록                                                                                                                                             |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 복원될 마지막 쿼리 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 공통 요청
-
-| 이름           | 종류    | 형식   | 필수 | 설명                                                                                                                          |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DB 인스턴스의 식별자                                                                                                                |
-| restoreType  | Query | Enum | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입 |
-
-#### restoreType이 `TIMESTAMP`인 경우
-
-| 이름          | 종류    | 형식       | 필수 | 설명                                        |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreType이 `BINLOG`인 경우
-
-| 이름             | 종류    | 형식     | 필수 | 설명                 |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| binLogFileName | Query | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| binLogPosition | Query | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-#### 응답
-
-| 이름           | 종류   | 형식       | 설명                                   |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 마지막 수행 쿼리                            |
 
 <details><summary>예시</summary>
 <p>
@@ -1357,8 +949,7 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -1367,633 +958,45 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 ---
 
-### 복원
+### DB 인스턴스 상세 보기
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
+GET /v4.0/db-instances/{dbInstanceId}
 ```
-
-#### 필요 권한
-
-| 권한명                                            | 설명           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원하기 |
-
-#### 공통 요청
-
-| 이름                                                  | 종류   | 형식      | 필수 | 설명                                                                                                                                                   |
-|-----------------------------------------------------|------|---------|----|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                         |
-| restore                                             | Body | Object  | O  | 복원 정보 객체                                                                                                                                             |
-| restore.restoreType                                 | Body | Enum    | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입<br/>- `BACKUP`: 기존에 생성한 백업을 이용한 스냅숏 복원 타입 |
-| dbInstanceName                                      | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                                                                                             |
-| dbInstanceCandidateName                             | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 고가용성 사용 시 필수                                                                                                       |
-| description                                         | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                    |
-| dbFlavorId                                          | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                                                                                                      |
-| dbPort                                              | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                                                                                   |
-| parameterGroupId                                    | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                 |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                                     |
-| userGroupIds                                        | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                       |
-| useHighAvailability                                 | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                                                                                                        |
-| pingInterval                                        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                                  |
-| pingType                                            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                  |
-| useDefaultNotification                              | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                       |
-| useDeletionProtection                               | Body | Boolean | X  | 삭제 보호 여부<br>기본값: `false`                                                                                                                             |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                                                                                                   |
-| network                                             | Body | Object  | X  | 네트워크 정보 객체                                                                                                                                           |
-| network.subnetId                                    | Body | UUID    | X  | 서브넷의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                     |
-| network.usePublicAccess                             | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                       |
-| network.availabilityZone                            | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: 랜덤 선택                                                                                            |
-| storage                                             | Body | Object  | X  | 데이터 스토리지 정보 객체                                                                                                                                       |
-| storage.storageType                                 | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                          |
-| storage.storageSize                                 | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                            |
-| storage.storageAutoscale                            | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                                                                                                    |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | 스토리지 자동 확장 여부                                                                                                                                        |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 자동 확장 조건(%)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `50`<br/>- 최댓값: `95`                                                                                  |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 자동 확장 최대 크기(GB) <br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최댓값: `4096`                                                                                           |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                                                                            |
-| backup                                              | Body | Object  | X  | 백업 정보 객체                                                                                                                                             |
-| backup.backupPeriod                                 | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                  |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                   |
-| backup.backupRetryCount                             | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                              |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | X | 예정된 자동 백업 목록<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름                  | 종류   | 형식       | 필수 | 설명                                                                                             |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다. |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름                            | 종류   | 형식     | 필수 | 설명                 |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| restore.binLog                | Body | Object | O  | 바이너리 로그 정보 객체      |
-| restore.binLog.binLogFileName | Body | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-* 바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그를 복원할 수 있습니다.
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름               | 종류   | 형식   | 필수                           | 설명              |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreType이 `BACKUP`인 경우) | 복원에 사용할 백업의 식별자 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-### 오브젝트 스토리지로부터 복원
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### 필요 권한
-
-| 권한명                                                   | 설명                      |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | DB 인스턴스 오브젝트 스토리지로부터 복원 |
-
-#### 요청
-
-| 이름                                                  | 종류   | 형식      | 필수 | 설명                                                                                     |
-|-----------------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O  | 복원 정보 객체                                                                               |
-| restore.tenantId                                    | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 테넌트 ID                                                              |
-| restore.username                                    | Body | String  | O  | NHN Cloud 계정 또는 IAM 계정 ID                                                              |
-| restore.password                                    | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 API 비밀번호                                                            |
-| restore.targetContainer                             | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 컨테이너                                                                |
-| restore.objectPath                                  | Body | String  | O  | 컨테이너에 저장된 백업의 경로                                                                       |
-| dbVersion                                           | Body | Enum    | O  | DB 엔진 유형                                                                               |
-| dbInstanceName                                      | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                               |
-| dbInstanceCandidateName                             | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                                            |
-| description                                         | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                      |
-| dbFlavorId                                          | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                        |
-| dbPort                                              | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                            |
-| parameterGroupId | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                           |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                       |
-| userGroupIds                                        | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                         |
-| useHighAvailability                                 | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                           |
-| pingInterval                                        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                                            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification                              | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                          |
-| useDeletionProtection                               | Body | Boolean | X  | 삭제 보호 여부<br>기본값: `false`                                                               |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                                     |
-| network                                             | Body | Object  | O  | 네트워크 정보 객체                                                                             |
-| network.subnetId                                    | Body | UUID    | O  | 서브넷의 식별자                                                                               |
-| network.usePublicAccess                             | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                          |
-| network.availabilityZone                            | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                |
-| storage                                             | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                         |
-| storage.storageType                                 | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                     |
-| storage.storageSize                                 | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                     |
-| storage.storageAutoscale                            | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                                      |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | 스토리지 자동 확장 여부                                                                          |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                                            |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                                      |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                                      |
-| backup                                              | Body | Object  | O  | 백업 정보 객체                                                                               |
-| backup.backupPeriod                                 | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                           |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                             | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-
-### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O  | 삭제 보호 여부     |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 고가용성 상태
-
-| 상태                               | 설명                              |
-|----------------------------------|---------------------------------|
-| `CREATED`                        | 고가용성이 생성된 경우                    |
-| `STABLE`                         | 고가용성이 정상인 경우                    |
-| `PAUSING`                        | 고가용성이 일시 중지 중인 경우               |
-| `PAUSED`                         | 고가용성이 일시 중지된 경우                 |
-| `PAUSED_DUE_TO_TASK`             | 작업으로 인해 고가용성이 일시 중지된 경우         |
-| `DISABLE_MASTER_IN_REPLICATION`  | 마스터 비정상 복제 감지로 고가용성이 중단된 경우     |
-| `DISABLE_MHA_PROCESS`            | 고가용성 프로세스가 중단된 경우               |
-| `DISABLE_REPLICATION_STOP`       | 복제 중단으로 인해 고가용성이 중단된 경우         |
-| `DISABLE_REPLICATION_DELAY`      | 복제 지연으로 인해 고가용성이 중단된 경우         |
-| `MASTER_FAILURE_DETECTION`       | 마스터 장애가 감지된 경우                  |
-| `FAILOVER_STARTED`               | 장애 조치가 시작된 경우                   |
-| `FAILOVER_FAILED`                | 장애 조치가 실패한 경우                   |
-| `FAILOVER_COMPLETED`             | 장애 조치가 완료된 경우                   |
-| `DELETED`                        | 고가용성이 삭제된 경우                    |
-
----
-
-### 고가용성 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명         |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                  | 종류   | 형식      | 설명                                                                                                                  |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | 고가용성 사용 여부                                                                                                          |
-| haStatus            | Body | Enum    | 고가용성 상태                                                                                                          |
-| pingInterval        | Body | Number  | Ping 간격(초)                                                                                                          |
-| pingType            | Body | Enum    | Ping 타입<br/>- `INSERT`<br/>- `SELECT`                                                                                |
-
-<details><summary>예시</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
-
----
-
-### 고가용성 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식      | 필수 | 설명                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB 인스턴스의 식별자                                         |
-| useHighAvailability | Body | Boolean | O  | 고가용성 사용 여부                                           |
-| pingInterval        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- `INSERT`<br/>- `SELECT` |
-| dbInstanceCandidateName        | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 고가용성 사용 시 필수값 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 다시 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명           |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | 고가용성 다시 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 일시 중지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명           |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | 고가용성 일시 중지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 복구하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | 고가용성 복구하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 분리하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명        |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | 고가용성 분리하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 데이터 스토리지 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식      | 설명                                                                                   |
-|--------------------------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | 데이터 스토리지 타입                                                                          |
-| storageSize                          | Body | Number  | 데이터 스토리지 크기(GB)                                                                      |
-| storageStatus                        | Body | Enum    | 데이터 스토리지의 현재 상태<br/>- `DETACHED`: 부착되지 않음<br/>- `ATTACHED`: 부착됨<br/>- `DELETED`: 삭제됨 |
-| storageAutoscale                     | Body | Object  | 데이터 스토리지 자동 확장 객체                                                                    |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부                                                                        |
-| storageAutoscale.threshold           | Body | Number  | 자동 확장 조건(%)                                                                          |
-| storageAutoscale.maxStorageSize      | Body | Number  | 자동 확장 최대 크기(GB)                                                                      |
-| storageAutoscale.cooldownTime        | Body | Number  | 자동 확장 쿨다운 시간(분)                                                                      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| dbPort | Body | Number | DB 포트 |
+| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
+| useSlowQueryAnalysis | Body | Boolean | Slow query 분석 여부 |
+| supportAuthenticationPlugin | Body | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Body | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2005,54 +1008,108 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
+    "dbInstanceId": "dbInstanceId-example",
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "NONE",
+    "dbFlavorId": "dbFlavorId-example",
+    "parameterGroupId": "parameterGroupId-example",
+    "dbSecurityGroupIds": [],
+    "notificationGroupIds": [],
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
 
-
 ---
 
-### 데이터 스토리지 정보 수정하기
+### DB 인스턴스 수정하기
 
 ```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+PUT /v4.0/db-instances/{dbInstanceId}
 ```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
 
 #### 요청
 
-| 이름                                   | 종류   | 형식      | 필수 | 설명                                                                        |
-|--------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: 현재값<br/>- 최댓값: `2048`                          |
-| useOnlineFailover                    | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                         |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                             |
-| storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                               |
-| storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                         |
-| storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부 |
+| useDummy | Body | Boolean | X | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -2062,32 +1119,26 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                                | 종류   | 형식      | 설명             |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | 백업 보관 기간(일)    |
-| ftwrlWaitTimeout                  | Body | Number  | 쿼리 지연 대기 시간(초) |
-| backupRetryCount                  | Body | Number  | 백업 재시도 횟수      |
-| replicationRegion                 | Body | Enum    | 백업 복제 리전       |
-| useBackupLock                     | Body | Boolean | 테이블 잠금 사용 여부   |
-| backupSchedules                   | Body | Array   | 예정된 자동 백업 목록   |
-| backupSchedules.backupWndBgnTime  | Body | String  | 백업 시작 시각       |
-| backupSchedules.backupWndDuration | Body | Enum    | 백업 Duration    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Body | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Body | Number | 백업 재시도 횟수 |
+| replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Body | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
 <p>
@@ -2100,14 +1151,13 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2115,7 +1165,6 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 </p>
 </details>
-
 
 ---
 
@@ -2125,36 +1174,33 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
 #### 요청
 
-| 이름                                    | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                          |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                |
-| backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부                                                                                                                                                                                                                |
-| backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
+| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2165,45 +1211,9 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 네트워크 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                     | 종류   | 형식     | 설명                                                                                                                                      |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DB 인스턴스를 생성할 가용성 영역                                                                                                                     |
-| subnet                 | Body | Object | 서브넷 객체                                                                                                                                  |
-| subnet.subnetId        | Body | UUID   | 서브넷의 식별자                                                                                                                                |
-| subnet.subnetName      | Body | UUID   | 서브넷을 식별할 수 있는 이름                                                                                                                        |
-| subnet.subnetCidr      | Body | UUID   | 서브넷의 CIDR                                                                                                                               |
-| endPoints              | Body | Array  | 접속 정보 목록                                                                                                                                |
-| endPoints.domain       | Body | String | 도메인                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP 주소                                                                                                                                   |
-| endPoints.endPointType | Body | Enum   | 접속 정보 타입<br>-`EXTERNAL`: 외부 접속 도메인<br>-`INTERNAL`: 내부 접속 도메인<br>-`PUBLIC`: (Deprecated) 외부 접속 도메인<br>-`PRIVATE`: (Deprecated) 내부 접속 도메인 |
 
 <details><summary>예시</summary>
 <p>
@@ -2215,19 +1225,7 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2236,509 +1234,28 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 ---
 
-### 네트워크 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식      | 필수 | 설명           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O  | 외부 접속 가능 여부 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명                  |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | DB 인스턴스 내 사용자 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB 사용자 목록                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DB 사용자의 식별자                                                                                                                 |
-| dbUsers.dbUserName           | Body | String   | DB 사용자 계정 이름                                                                                                                |
-| dbUsers.host                 | Body | String   | DB 사용자 계정의 호스트 이름                                                                                                           |
-| dbUsers.authorityType        | Body | Enum     | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/>            |
-| dbUsers.dbUserStatus         | Body | Enum     | DB 사용자의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `UPDATING`: 수정 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbUsers.authenticationPlugin         | Body | Enum    | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-| dbUsers.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 사용자 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | DB 인스턴스 내 사용자 생성하기 |
-
-#### 요청
-
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserName           | Body | String | O  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `32`                                                                  |
-| dbPassword           | Body | String | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| host                 | Body | String | O  | DB 사용자 계정의 호스트명<br/>- 예시: `1.1.1.%`                                                                              |
-| authorityType        | Body | Enum   | O  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | DB 인스턴스 내 사용자 수정하기 |
-
-#### 요청
-
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserId             | URL  | UUID   | O  | DB 사용자의 식별자                                                                                                      |
-| dbPassword           | Body | String | X  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| authorityType        | Body | Enum   | X  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | DB 인스턴스 내 사용자 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbUserId     | URL | UUID | O  | DB 사용자의 식별자  |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 스키마 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                  |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | DB 인스턴스 내 스키마 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                                                                                   |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB 스키마 목록                                                                                            |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB 스키마의 식별자                                                                                          |
-| dbSchemas.dbSchemaName   | Body | String   | DB 스키마 이름                                                                                            |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB 스키마의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbSchemas.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 스키마 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명                 |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | DB 인스턴스 내 스키마 생성하기 |
-
-#### 요청
-
-| 이름           | 종류   | 형식     | 필수 | 설명           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O  | DB 스키마 이름    |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 스키마 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명                 |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | DB 인스턴스 내 스키마 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbSchemaId   | URL | UUID | O  | DB 스키마의 식별자  |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 로그 파일 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명                    |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | DB 인스턴스 내 로그 파일 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류    | 형식    | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileTypes | Query | Array | X  | 로그 파일 타입 종류 목록<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### 응답
-
-| 이름                   | 종류   | 형식       | 설명                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | 로그 파일 목록                                                                                                                                                                                     |
-| logFiles.logFileName | Body | String   | 로그 파일명                                                                                                                                                                                     |
-| logFiles.logFileType | Body | Enum     | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | 로그 파일 크기(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 로그 파일 내용 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명                    |
-|-----------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.Get | DB 인스턴스 내 로그 파일 내용 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류    | 형식     | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileName  | URL   | String | O  | 로그 파일명                                                                                                                                                                                        |
-| logFileType  | Query | Enum   | O  | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### 응답
-
-| 이름      | 종류   | 형식     | 설명                        |
-|---------|------|--------|---------------------------|
-| content | Body | String | 로그 파일 내용(최대 65533 Bytes) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "..."
-}
-```
-
-</p>
-</details>
-
----
-
-### 로그 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명                   |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | DB 인스턴스 내 로그 파일 내보내기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                             |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                   |
-| logFileNames    | Body | Array  | O  | 로그 파일명 목록<br/>- 최소 크기: `1`   |
-| tenantId        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID      |
-| password        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 로그 파일의 경로            |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### BinLog 목록 보기
+### 바이너리 로그 목록 보기
 
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
 ```
 
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | BinLog 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식      | 필수 | 설명                                                                                   |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID    | O  | DB 인스턴스의 식별자                                                                         |
-| deletable    | Query | Boolean | X  | 삭제 가능한 BinLog만 조회할지 여부<br/>- `true`: 마지막 BinLog 제외<br/>- `false`: 전체<br/>- 기본값: `false` |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 
 #### 응답
 
-| 이름                     | 종류   | 형식       | 설명                                |
-|------------------------|------|----------|-----------------------------------|
-| binLogs                | Body | Array    | BinLog 파일 목록                      |
-| binLogs.binLogFileName | Body | String   | BinLog 파일명                      |
-| binLogs.binLogFileSize | Body | Number   | BinLog 파일 크기(Byte)                |
-| binLogs.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| binLogs | Body | Array | BinLog 파일 목록 |
+| binLogs.binLogFileName | Body | String | BinLog 파일 이름 |
+| binLogs.binLogFileSize | Body | Number | BinLog 파일 크기 (Byte) |
+| binLogs.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2752,9 +1269,7 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2765,24 +1280,18 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 ---
 
-### BinLog 삭제
+### 바이너리 로그 삭제
 
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```
 
-#### 필요 권한
-
-| 권한명                                                | 설명        |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | BinLog 삭제 |
-
 #### 요청
 
-| 이름                 | 종류   | 형식     | 필수 | 설명                                     |
-|--------------------|------|--------|----|----------------------------------------|
-| dbInstanceId       | URL  | UUID   | O  | DB 인스턴스의 식별자                           |
-| lastBinLogFileName | Body | String | O  | 삭제할 마지막 BinLog 파일명(해당 파일 직전까지 삭제됩니다) |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| lastBinLogFileName | Body | String | O | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
 
 <details><summary>예시</summary>
 <p>
@@ -2800,22 +1309,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
 ### 인증서 파일 목록 보기
@@ -2824,29 +1317,23 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```
 
-#### 필요 권한
-
-| 권한명                                                    | 설명           |
-|--------------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceCertificate.List | 인증서 파일 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                           |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
-| certificates                 | Body | Array    | 인증서 파일 목록                                                                    |
-| certificates.fileName        | Body | String   | 인증서 파일명                                                                    |
-| certificates.certificateType | Body | Enum     | 인증서 타입<br/>- `CA_FILE`: CA 인증서<br/>- `CERT_FILE`: 인증서<br/>- `KEY_FILE`: 비밀 키 |
-| certificates.fileSize        | Body | Number   | 인증서 파일 크기(Byte)                                                              |
-| certificates.createdYmdt     | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                            |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| certificates | Body | Array | 인증서 파일 목록 |
+| certificates.fileName | Body | String | 인증서 파일 이름 |
+| certificates.certificateType | Body | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Body | Number | 인증서 파일 크기(Byte) |
+| certificates.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2860,10 +1347,7 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
-            "fileName": "ca.pem",
-            "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2880,35 +1364,29 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명          |
-|----------------------------------------------------------|-------------|
-| RDSforMariaDB:DbInstanceCertificate.Export | 인증서 파일 내보내기 |
-
 #### 요청
 
-| 이름               | 종류   | 형식     | 필수 | 설명                                                                           |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
-| dbInstanceId     | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                 |
-| certificateTypes | Body | Array  | O  | 업로드할 인증서 타입<br/>- `CA_FILE`: CA 인증서<br/>- `CERT_FILE`: 인증서<br/>- `KEY_FILE`: 비밀 키 |
-| tenantId         | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID                                                |
-| username         | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID                                                    |
-| password         | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호                                              |
-| targetContainer  | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너                                                  |
-| objectPath       | Body | String | O  | 컨테이너에 저장될 인증서 파일의 경로                                                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| certificateTypes | Body | Array | O | 업로드할 인증서 타입 목록 |
+| tenantId | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 인증서 파일의 경로 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
+    "certificateTypes": [],
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -2917,9 +1395,2159 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | Body | String | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 생성하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbSchemaName | Body | String | O | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbSchemaId | URL | UUID | O | DB 스키마의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
+| dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Body | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Body | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 생성하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | Body | String | O | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "host-example",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+| dbPassword | Body | String | X | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Body | Enum | X | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 삭제 보호 설정 변경
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 강제 재시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 고가용성 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
+| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Body | Number | Ping 간격(초) |
+| pingType | Body | String | Ping 방식 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 일시 중지하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 복구하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 다시 시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 분리하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | 로그 파일 목록 |
+| logFiles.logFileName | Body | String | 로그 파일 이름 |
+| logFiles.logFileType | Body | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | Body | DateTime | 생성 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 내보내기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | 로그 파일 이름 목록 |
+| tenantId | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 로그 파일의 경로 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 내용 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| logFileName | URL | UUID | O | 로그 파일 이름 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| content | Body | String | 로그 파일 내용 (최대 65533 bytes) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 유지 관리 목록 갯수 |
+| maintenances | Body | Array | 유지 관리 목록 |
+| maintenances.maintenanceId | Body | String | 유지 관리 아이디 |
+| maintenances.dbInstanceId | Body | String | DB 인스턴스 아이디 |
+| maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| maintenances.description | Body | String | 유지 관리 설명 |
+| maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| maintenances.payload | Body | Object | 유지 관리 타입에 따른 Payload |
+| maintenances.required | Body | Boolean | 유지 관리 필수 여부 |
+| maintenances.deadlineYmdt | Body | DateTime | 유지 관리 강제 적용 일시 |
+| maintenances.status | Body | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
+| maintenances.addedYmdt | Body | DateTime | 유지 관리 스케줄 등록 일시 |
+| maintenances.executionStartedYmdt | Body | DateTime | 유지 관리 시작 일시 |
+| maintenances.executionCompletedYmdt | Body | DateTime | 유지 관리 종료 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 즉시 실행하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| configId | Body | String | O | 설정 아이디 |
+| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | Body | String | X | 유지 관리 설명 |
+| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 예약하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| configId | Body | String | O | 설정 아이디 |
+| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | Body | String | X | 유지 관리 설명 |
+| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 유지 관리 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| maintenanceId | URL | UUID | O | 유지 관리 아이디 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 네트워크 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Body | Object | 서브넷 객체 |
+| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
+| endPoints | Body | Array | 접속 정보 목록 |
+| endPoints.domain | Body | String | 도메인 |
+| endPoints.ipAddress | Body | String | IP 주소 |
+| endPoints.endPointType | Body | String | 접속 정보 타입 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "availabilityZone-example",
+    "subnet": {
+        "subnetId": "subnetId-example",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "subnetCidr-example"
+    },
+    "endPoints": [
+        {
+            "endPointType": "endPointType-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 네트워크 정보 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 승격하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 재구축하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복제하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부 |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | X | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | X | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 재시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원 정보 조회
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backup | Body | Object | 백업 정보 객체 |
+| restorableBackups.backup.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backup.backupName | Body | String | 백업 이름 |
+| restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
+| restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | 백업 크기 |
+| restorableBackups.backup.useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
+| restorableBackups.backup.failoverCount | Body | Number | 장애 조치 횟수 |
+| restorableBackups.backup.binLogFileName | Body | String | 바이너리 로그 파일 이름 |
+| restorableBackups.backup.binLogPosition | Body | Object | 바이너리 로그 파일 위치 |
+| restorableBackups.backup.createdYmdt | Body | DateTime | 백업 생성 일시 |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
+| restorableBackups.restorableBinLogs | Body | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "restorableBinLogs": []
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 복원될 마지막 쿼리 조회
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | 쿼리 수행 일시 |
+| lastQuery | Body | String | 마지막 수행 쿼리 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
+| dbPort | Body | Number | X | DB 포트 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Body | Object | X | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
+| storage.storageType | Body | Enum | X | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Body | Object | X | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
+| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
+| backup | Body | Object | X | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
+| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | Body | String | X | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Body | Object | X | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Body | Object | X | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 정지하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 스토리지 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageType | Body | String | 데이터 스토리지 타입 |
+| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+| storageAutoscale | Body | Object | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부 |
+| storageAutoscale.threshold | Body | Number | 자동 확장 조건(%) |
+| storageAutoscale.maxStorageSize | Body | Number | 자동 확장 최대 크기(GB) |
+| storageAutoscale.cooldownTime | Body | Number | 자동 확장 쿨다운 시간(분) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "storageType-example",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
+    }
+}
+```
+
+</p>
+</details>
+
+---
+
+### 스토리지 정보 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+| storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부 |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 그룹 상세 보기
+
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
+        {
+            "dbInstanceStatus": "BEFORE_CREATE"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 사양
+
+### DB 인스턴스 사양 목록 보기
+
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbFlavors": [
+        {
+            "vcpus": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 가용성 영역
+
+### 가용성 영역 목록 보기
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZones": [
+        {
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 네트워크
+
+### 서브넷 목록 보기
+
+```http
+GET /v4.0/network/subnets
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | 서브넷 목록 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 데이터 스토리지
+
+### 스토리지 타입 목록 보기
+
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 타입 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 모니터링
+
+### 통계 정보 조회
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### Metric 목록 보기
+
+```http
+GET /v4.0/metrics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric 목록 |
+| metrics.measureName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "metrics": [
+        {
+            "unit": "unit-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -2935,123 +3563,32 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 | `DELETED`    | 백업이 삭제된 경우   |
 | `ERROR`      | 오류가 발생한 경우   |
 
-### 백업 상세 보기
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명       |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | 백업 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름                      | 종류   | 형식       | 설명              |
-|-------------------------|------|----------|-----------------|
-| backup                  | Body | Object   | 백업 상세 정보        |
-| backup.backupId         | Body | UUID     | 백업의 식별자         |
-| backup.regionCode       | Body | Enum     | 리전 코드           |
-| backup.backupName       | Body | String   | 백업을 식별할 수 있는 이름 |
-| backup.backupStatus     | Body | Enum     | 백업의 현재 상태       |
-| backup.dbInstanceId     | Body | UUID     | 원본 DB 인스턴스의 식별자 |
-| backup.dbInstanceName   | Body | String   | 원본 DB 인스턴스의 이름  |
-| backup.dbVersion        | Body | Enum     | DB 엔진 버전        |
-| backup.backupType       | Body | Enum     | 백업 유형                             |
-| backup.backupMethodType | Body | Enum     | 백업 방식                             |
-| backup.backupFileType   | Body | Enum     | 백업 파일 유형                          |
-| backup.backupSize       | Body | Number   | 백업의 크기(Byte)                      |
-| backup.isReplicable     | Body | Boolean  | 복제 가능 여부                          |
-| backup.binLogFileName   | Body | String   | 바이너리 로그 파일명                       |
-| backup.binLogPosition   | Body | Number   | 바이너리 로그 위치                        |
-| backup.createdYmdt      | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt      | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
 ### 백업 목록 조회
 
 ```http
 GET /v4.0/backups
 ```
 
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Backup.List | 백업 목록 조회 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-| backupType   | Query | Enum   | X  | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동<br/>- 기본값: 전체 |
-| dbInstanceId | Query | UUID   | X  | 원본 DB 인스턴스의 식별자                                          |
-| dbVersion    | Query | Enum   | X  | DB 엔진 유형                                                 |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 전체 백업 목록 수                        |
-| backups              | Body | Array    | 백업 목록                             |
-| backups.backupId     | Body | UUID     | 백업의 식별자                           |
-| backups.backupName   | Body | String   | 백업을 식별할 수 있는 이름                   |
-| backups.backupStatus | Body | Enum     | 백업의 현재 상태                         |
-| backups.dbInstanceId | Body | UUID     | 원본 DB 인스턴스의 식별자                   |
-| backups.dbVersion    | Body | Enum     | DB 엔진 유형                          |
-| backups.backupType   | Body | Enum     | 백업 유형                             |
-| backups.backupSize   | Body | Number   | 백업의 크기(Byte)                      |
-| createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 백업 목록 수 |
+| backups | Body | Array | 백업 목록 |
+| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | Body | Enum | DB 엔진 유형 |
+| backups.utilVersion | Body | String | 유틸리티 버전 |
+| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | Body | DateTime | 생성 일시 |
+| backups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -3066,15 +3603,7 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3091,89 +3620,166 @@ GET /v4.0/backups
 POST /v4.0/backups
 ```
 
-#### 필요 권한
+#### 요청
 
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Create | 백업 생성하기 |
-
-#### 공통 요청
-
-| 이름               | 종류   | 형식     | 필수 | 설명                                                                                   |
-|------------------|------|--------|----|--------------------------------------------------------------------------------------|
-| backupName       | Body | String | O  | 백업을 식별할 수 있는 이름                                                                      |
-| backupMethodType | Body | Enum   | O  | 백업 방식 타입 종류<br/>- `FULL`: 전체 백업<br/>- `INCREMENTAL`: 증분 백업 <br/>- `SNAPSHOT`: 스냅숏 백업 |
-
-#### 전체 백업(backupMethodType이 `FULL`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB 인스턴스의 식별자 |
-
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| baseBackupId | Body | UUID | X | 원본 백업의 식별자 |
+| dbInstanceId | Body | UUID | X | DB 인스턴스의 식별자 |
+| backupMethodType | Body | Enum | O | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-#### 증분 백업(backupMethodType이 `INCREMENTAL`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명         |
-|--------------|------|------|----|------------|
-| baseBackupId | Body | UUID | O  | 기준 백업의 식별자 |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-#### 스냅숏 백업(backupMethodType이 `SNAPSHOT`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB 인스턴스의 식별자 |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 백업 삭제하기
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 백업 단건 조회
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| backup | Body | Object | 백업 상세 정보 |
+| backup.backupId | Body | String | 백업의 식별자 |
+| backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
+| backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
+| backup.dbVersion | Body | Enum | DB 엔진 버전 |
+| backup.utilVersion | Body | String | 유틸리티 버전 |
+| backup.backupType | Body | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | 백업의 크기(Byte) |
+| backup.isReplicable | Body | Boolean | 복제 가능 여부 |
+| backup.binLogFileName | Body | String | 바이너리 로그 파일명 |
+| backup.binLogPosition | Body | Object | 바이너리 로그 위치 |
+| backup.createdYmdt | Body | DateTime | 생성 일시 |
+| backup.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "backupId-example",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "dbInstanceId-example",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "ENUM_VALUE",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3183,33 +3789,27 @@ POST /v4.0/backups
 POST /v4.0/backups/{backupId}/export
 ```
 
-#### 필요 권한
-
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Export | 백업 내보내기 |
-
 #### 요청
 
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | 백업의 식별자                     |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3218,12 +3818,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
-> [주의]
-> 수동 백업의 경우 백업이 수행된 DB 인스턴스가 존재하지 않으면, 백업을 오브젝트 스토리지로 내보낼 수 없습니다.
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3233,75 +3847,93 @@ POST /v4.0/backups/{backupId}/export
 POST /v4.0/backups/{backupId}/restore
 ```
 
-#### 필요 권한
+#### 공통 요청
 
-| 권한명                                        | 설명      |
-|--------------------------------------------|---------|
-| RDSforMariaDB:Backup.Restore | 백업 복원하기 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbPort | Body | Number | X | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Body | Object | X | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
+| storage | Body | Object | X | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageType | Body | Enum | X | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | X | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
-#### 요청
+#### 고가용성 사용 시
 
-| 이름                                           | 종류   | 형식      | 필수 | 설명                                                                  |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O  | 백업의 식별자                                                             |
-| dbInstanceName                               | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName                      | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                         |
-| description                                  | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId                                   | Body | UUID    | X  | DB 인스턴스 사양의 식별자          <br/> - 기본값: 원본 DB 인스턴스 값                                           |
-| dbPort                                       | Body | Integer | X  | DB 포트 <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId                             | Body | UUID    | X  | 파라미터 그룹의 식별자    <br/> - 기본값: 원본 DB 인스턴스 값                                                          |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds                                 | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability                          | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval                                 | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                                     | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification                       | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         | 
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                  |
-| network                                      | Body | Object  | X  | 네트워크 정보 객체                                                          |
-| network.subnetId                             | Body | UUID    | X  | 서브넷의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                            |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: 랜덤 선택                            |
-| storage                                      | Body | Object  | X  | 데이터 스토리지 정보 객체                                                      |
-| storage.storageType                          | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`<br/>- 기본값: 원본 DB 인스턴스 값                                 |
-| storage.storageSize                          | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                   |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부    <br/> - 기본값: 원본 DB 인스턴스 값                                                         |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `50`<br/>- 최댓값: `95`                         |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최댓값: `4096`                                   |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `10`<br/>- 최댓값: `1440`                   |
-| backup                                       | Body | Object  | X  | 백업 정보 객체                                                            |
-| backup.backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
     "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3314,84 +3946,10 @@ POST /v4.0/backups/{backupId}/restore
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
----
-
-### 백업 삭제하기
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
-
-#### 필요 권한
-
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | 백업 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-## DB 보안 그룹
-
-### DB 보안 그룹 진행 상태
-
-| 상태              | 설명           |
-|-----------------|--------------|
-| `NONE`          | 진행 중인 작업이 없음 |
-| `CREATING_RULE` | 규칙 정책 생성 중   |
-| `UPDATING_RULE` | 규칙 정책 수정 중   |
-| `DELETING_RULE` | 규칙 정책 삭제 중   |
-
-### DB 보안 그룹 목록 보기
-
-```http
-GET /v4.0/db-security-groups
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명             |
-|--------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식       | 설명                                |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB 보안 그룹 목록                       |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                     |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름             |
-| dbSecurityGroups.description         | Body | String   | DB 보안 그룹에 대한 추가 정보                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
 <details><summary>예시</summary>
 <p>
 
@@ -3402,827 +3960,7 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 상세 보기
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명             |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-| 이름                  | 종류   | 형식       | 설명                                                                                                                 |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                                                                                                      |
-| dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                              |
-| description         | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                 |
-| progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                                                                                                 |
-| rules               | Body | Array    | DB 보안 그룹 규칙 목록                                                                                                     |
-| rules.ruleId        | Body | UUID     | DB 보안 그룹 규칙의 식별자                                                                                                   |
-| rules.description   | Body | String   | DB 보안 그룹 규칙에 대한 추가 정보                                                                                              |
-| rules.direction     | Body | Enum     | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                       |
-| rules.etherType     | Body | Enum     | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | 포트 객체                                                                                                              |
-| rules.port.portType | Body | Enum     | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number   | 최소 포트 범위                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 최대 포트 범위                                                                                                           |
-| rules.cidr          | Body | String   | 허용할 트래픽의 원격 소스                                                                                                     |
-| rules.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 생성하기
-
-```http
-POST /v4.0/db-security-groups
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                    |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB 보안 그룹 규칙 목록                                                                                                                                                                           |
-| rules.description   | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| rules.port.maxPort  | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                | 종류   | 형식   | 설명            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
----
-
-### DB 보안 그룹 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB 보안 그룹의 식별자         |
-| dbSecurityGroupName | Body | String | X  | DB 보안 그룹을 식별할 수 있는 이름 |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB 보안 그룹 규칙의 식별자                                                                                                                                                                         |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식    | 필수 | 설명                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB 보안 그룹의 식별자       |
-| ruleIds           | Query | Array | O  | DB 보안 그룹 규칙의 식별자 목록 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명            |
-|-------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.List | 파라미터 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름        | 종류    | 형식   | 필수 | 설명       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB 엔진 유형 |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식       | 설명                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | 파라미터 그룹 목록                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | 파라미터 그룹의 식별자                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                              |
-| parameterGroups.description          | Body | String   | 파라미터 그룹에 대한 추가 정보                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB 엔진 유형                                                          |
-| parameterGroups.parameterGroupStatus | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요 |
-| parameterGroups.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
----
-
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | 파라미터 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-| 이름                            | 종류   | 형식       | 설명                                                                                                     |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | 파라미터 그룹의 식별자                                                                                           |
-| parameterGroupName            | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                                                                   |
-| description                   | Body | String   | 파라미터 그룹에 대한 추가 정보                                                                                      |
-| dbVersion                     | Body | Enum     | DB 엔진 유형                                                                                               |
-| parameterGroupStatus          | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요                                      |
-| parameters                    | Body | Array    | 파라미터 목록                                                                                                |
-| parameters.parameterId        | Body | UUID     | 파라미터 식별자                                                                                               |
-| parameters.parameterFileGroup | Body | Enum     | 파라미터 파일 그룹 타입<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | 파라미터 이름                                                                                                |
-| parameters.fileParameterName  | Body | String   | 파라미터 파일명                                                                                             |
-| parameters.value              | Body | String   | 현재 설정된 값                                                                                               |
-| parameters.defaultValue       | Body | String   | 기본값                                                                                                    |
-| parameters.allowedValue       | Body | String   | 허용된 값                                                                                                  |
-| parameters.updateType         | Body | Enum     | 수정 타입<br/>- `VARIABLE`: 언제든 수정 가능<br/>- `CONSTANT`: 수정 불가능<br/>- `INIT_VARIABLE`: DB 인스턴스 생성 시에만 수정 가능 |
-| parameters.applyType          | Body | Enum     | 적용 타입<br/>- `SESSION`: 세션 적용<br/>- `FILE`: 설정 파일 적용(재시작 필요)<br/>- `BOTH`: 전체(재시작 필요)                   |
-| createdYmdt                   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Create | 파라미터 그룹 생성하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-| dbVersion          | Body | Enum   | O  | DB 엔진 유형             |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명           |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | X  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                             | 종류   | 형식     | 필수 | 설명           |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | 파라미터 그룹의 식별자 |
-| modifiedParameters             | Body | Array  | O  | 변경할 파라미터 목록  |
-| modifiedParameters.parameterId | Body | UUID   | O  | 파라미터의 식별자    |
-| modifiedParameters.value       | Body | String | O  | 변경할 파라미터 값   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명            |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
-
-#### 요청
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4239,25 +3977,20 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 GET /v4.0/user-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명           |
-|--------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.List | 사용자 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId   | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| userGroups.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
+| userGroups | Body | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4269,74 +4002,12 @@ GET /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 사용자 그룹 상세 보기
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                       | 설명           |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | 사용자 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
-
-#### 응답
-
-| 이름                | 종류   | 형식       | 설명                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | 사용자 그룹의 식별자                                                                                               |
-| userGroupName     | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                                                                       |
-| userGroupTypeCode | Body | Enum     | 사용자 그룹 종류    <br /> `ENTIRE`: 프로젝트 멤버 전체를 포함하는 사용자 그룹 <br /> `INDIVIDUAL_MEMBER`: 특정 프로젝트 멤버를 포함하는 사용자 그룹 |
-| members           | Body | Array    | 프로젝트 멤버 목록                                                                                                |
-| members.memberId  | Body | UUID     | 프로젝트 멤버의 식별자                                                                                              |
-| createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4351,36 +4022,22 @@ GET /v4.0/user-groups/{userGroupId}
 POST /v4.0/user-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Create | 사용자 그룹 생성하기 |
-
 #### 요청
 
-| 이름            | 종류   | 형식      | 필수 | 설명                                                        |
-|---------------|------|---------|----|-----------------------------------------------------------|
-| userGroupName | Body | String  | O  | 사용자 그룹을 식별할 수 있는 이름                                       |
-| memberIds     | Body | Array   | O  | 프로젝트 멤버의 식별자 목록 <br /> `selectAll`이 true인 경우 해당 필드 값은 무시됩니다 |
-| selectAll     | Body | Boolean | X  | 프로젝트 멤버 전체 여부 <br /> true인 경우 해당 그룹은 전체 멤버를 대상으로 설정됩니다        |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4389,52 +4046,9 @@ POST /v4.0/user-groups
 
 #### 응답
 
-| 이름          | 종류   | 형식   | 설명          |
-|-------------|------|------|-------------|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
----
-
-### 사용자 그룹 수정하기
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | 사용자 그룹 수정하기 |
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | 사용자 그룹의 식별자                                        |
-| userGroupName | Body | String  | X  | 사용자 그룹을 식별할 수 있는 이름                                |
-| memberIds     | Body | Array   | X  | 프로젝트 멤버의 식별자 목록                                    |
-| selectAll     | Body | Boolean | X  | 프로젝트 멤버 전체 여부 <br /> true인 경우 해당 그룹은 전체 멤버를 대상으로 설정됩니다 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4445,7 +4059,8 @@ PUT /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "userGroupId-example"
 }
 ```
 
@@ -4460,21 +4075,45 @@ PUT /v4.0/user-groups/{userGroupId}
 DELETE /v4.0/user-groups/{userGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Delete | 사용자 그룹 삭제하기 |
-
 #### 요청
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 사용자 그룹 상세 보기
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4485,12 +4124,57 @@ DELETE /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "userGroupId-example",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "memberId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
+
+---
+
+### 사용자 그룹 수정하기
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4502,28 +4186,22 @@ DELETE /v4.0/user-groups/{userGroupId}
 GET /v4.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                                | 설명          |
-|----------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.List | 알림 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                       | 종류   | 형식       | 설명                                |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 알림 그룹 목록                          |
-| notificationGroups.notificationGroupId   | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroups.notificationGroupName | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notificationGroups.notifyEmail           | Body | Boolean  | 이메일 알림 여부                         |
-| notificationGroups.notifySms             | Body | Boolean  | SMS 알림 여부                         |
-| notificationGroups.isEnabled             | Body | Boolean  | 활성화 여부                            |
-| notificationGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4537,90 +4215,9 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 알림 그룹 상세 보기
-
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명          |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | 알림 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
-
-#### 응답
-
-| 이름                         | 종류   | 형식       | 설명                                |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroupName      | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notifyEmail                | Body | Boolean  | 이메일 알림 여부                         |
-| notifySms                  | Body | Boolean  | SMS 알림 여부                         |
-| isEnabled                  | Body | Boolean  | 활성화 여부                            |
-| dbInstances                | Body | Array    | 감시 대상 DB 인스턴스 목록                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DB 인스턴스의 식별자                      |
-| dbInstances.dbInstanceName | Body | String   | DB 인스턴스를 식별할 수 있는 이름              |
-| userGroups                 | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId     | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName   | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| createdYmdt                | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
 }
 ```
 
@@ -4635,85 +4232,28 @@ GET /v4.0/notification-groups/{notificationGroupId}
 POST /v4.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Create | 알림 그룹 생성하기 |
-
 #### 요청
 
-| 이름                    | 종류   | 형식      | 필수 | 설명                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 알림 그룹을 식별할 수 있는 이름          |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled             | Body | Boolean | X  | 활성화 여부<br/>- 기본값: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 감시 대상 DB 인스턴스의 식별자 목록       |
-| userGroupIds          | Body | Array   | O  | 사용자 그룹의 식별자 목록              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                  | 종류   | 형식   | 설명         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
----
-
-### 알림 그룹 수정하기
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | 알림 그룹 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 알림 그룹의 식별자            |
-| notificationGroupName | Body | String  | X  | 알림 그룹을 식별할 수 있는 이름    |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부             |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부             |
-| isEnabled             | Body | Boolean | X  | 활성화 여부                |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
+    "notificationGroupName": "notificationGroupName",
     "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
@@ -4722,7 +4262,9 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### 응답
 
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4733,7 +4275,8 @@ PUT /v4.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "notificationGroupId-example"
 }
 ```
 
@@ -4748,67 +4291,51 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 DELETE /v4.0/notification-groups/{notificationGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Delete | 알림 그룹 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-## 모니터링
-
-### Metric 목록 보기
+### 알림 그룹 상세 보기
 
 ```http
-GET /v4.0/metrics
+GET /v4.0/notification-groups/{notificationGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
 #### 응답
 
-| 이름                  | 종류   | 형식     | 설명        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metric 목록 |
-| metrics.measureName | Body | Enum   | 조회 지표 유형  |
-| metrics.unit        | Body | String | 측정값 단위    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notifySms | Body | Boolean | SMS 알림 여부 |
+| isEnabled | Body | Boolean | 활성화 여부 |
+| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Body | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4820,12 +4347,23 @@ GET /v4.0/metrics
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "metrics": [
+    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
+            "dbInstanceName": "dbInstanceName-example"
         }
-    ]
+    ],
+    "userGroups": [
+        {
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4834,69 +4372,44 @@ GET /v4.0/metrics
 
 ---
 
-### 통계 정보 조회
+### 알림 그룹 수정하기
 
 ```http
-GET /v4.0/metric-statistics
+PUT /v4.0/notification-groups/{notificationGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
-| 이름           | 종류    | 형식       | 필수 | 설명                                |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB 인스턴스의 식별자                      |
-| measureNames | Query | Array    | O  | 조회 지표 목록<br/>- 최소 크기: `1`         |
-| from         | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 조회 간격                             |
-
-#### 응답
-
-| 이름                                | 종류   | 형식        | 설명       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 통계 정보 목록 |
-| metricStatistics.measureName      | Body | Enum      | 측정 항목 유형 |
-| metricStatistics.unit             | Body | String    | 측정값 단위   |
-| metricStatistics.values           | Body | Array     | 측정값 목록   |
-| metricStatistics.values.timestamp | Body | Timestamp | 측정 시간    |
-| metricStatistics.values.value     | Body | Object    | 측정값      |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Body | Array | X | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
 </p>
 </details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4915,117 +4428,23 @@ GET /v4.0/metric-statistics
 | TENANT      | 테넌트     |
 | MONITORING  | 모니터링    |
 
-### 이벤트 목록 조회
-
-```http
-GET /v4.0/events
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명        |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | 이벤트 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-| from              | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 조회할 이벤트 카테고리 유형<br/>- `ALL`: 전체<br/>- `INSTANCE`: DB 인스턴스<br/>- `BACKUP`: 백업<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `TENANT`: 테넌트 |
-| sourceId          | Query | String   | X  | 이벤트가 발생한 대상 리소스의 식별자                                                                                                                 |
-| keyword           | Query | String   | X  | 이벤트 메시지에 포함된 문자열 검색어                                                                                                                 |
-| ascendingOrder    | Query | Enum     | X  | 이벤트 메시지 정렬 순서<br/>- `ASC`: 오름차순<br/>- `DESC`: 내림차순<br/>- 기본값: `DESC`                                                                 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                    |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 전체 이벤트 목록 수                           |
-| events                   | Body | Array    | 이벤트 목록                                |
-| events.eventCategoryType | Body | Enum     | 이벤트 카테고리 유형                           |
-| events.eventCode         | Body | Enum     | 발생한 이벤트의 유형                           |
-| events.sourceId          | Body | String   | 이벤트 소스의 식별자                           |
-| events.sourceName        | Body | String   | 이벤트 소스를 식별할 수 있는 이름                   |
-| events.messages          | Body | Array    | 이벤트 메시지 목록                            |
-| events.messages.langCode | Body | String   | 언어 코드                                 |
-| events.messages.message  | Body | String   | 이벤트 메시지                               |
-| events.eventYmdt         | Body | DateTime | 이벤트 발생 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
 ### 구독 가능한 이벤트 코드 목록 보기
 
 ```http
 GET /v4.0/event-codes
 ```
 
-#### 필요 권한
-
-| 권한명                                    | 설명        |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | 이벤트 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식    | 설명          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | 이벤트 코드 목록   |
-| eventCodes.eventCode         | Body | Enum  | 이벤트 코드      |
-| eventCodes.eventCategoryType | Body | Enum  | 이벤트 카테고리 유형 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>예시</summary>
 <p>
@@ -5039,8 +4458,56 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 이벤트 목록 조회
+
+```http
+GET /v4.0/events
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 이벤트 목록 수 |
+| events | Body | Array | 이벤트 목록 |
+| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Body | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | 이벤트 메세지 |
+| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5059,40 +4526,28 @@ GET /v4.0/event-codes
 GET /v4.0/event-subscriptions
 ```
 
-#### 필요 권한
-
-| 권한명                                                    | 설명            |
-|---------------------------------------------------------|---------------|
-| RDSforMariaDB:EventSubscription.List | 이벤트 구독 목록 조회 |
-
 #### 요청
 
-| 이름                | 종류    | 형식       | 필수 | 설명                                       |
-|-------------------|-------|----------|----|------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1` |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20             |
-| eventSubscriptionId    | Query | UUID   | X  | 이벤트 구독의 식별자                              |
-| eventSubscriptionName  | Query | String | X  | 이벤트 구독을 식별할 수 있는 이름                      |
-| userGroupId            | Query | UUID   | X  | 사용자 그룹의 식별자                              |
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                            | 종류   | 형식       | 설명                       |
-|-----------------------------------------------|------|----------|--------------------------|
-| totalCounts                                   | Body | Number   | 전체 이벤트 구독 목록 수           |
-| eventSubscriptions                            | Body | Array    | 이벤트 구독 목록                |
-| eventSubscriptions.eventSubscriptionId        | Body | UUID     | 이벤트의 구독 식별자              |
-| eventSubscriptions.eventCategoryType          | Body | Enum     | 이벤트 카테고리 유형              |
-| eventSubscriptions.eventSubscriptionName      | Body | String   | 이벤트 구독을 식별할 수 있는 이름      |
-| eventSubscriptions.enabled                    | Body | Boolean  | 활성화 여부                   |
-| eventSubscriptions.notifyEmail                | Body | Boolean  | 이메일 발송 여부                |
-| eventSubscriptions.notifySms                  | Body | Boolean  | SMS 발송 여부                |
-| eventSubscriptions.eventCodes                 | Body | Array    | 구독할 이벤트 코드 목록            |
-| eventSubscriptions.sources                    | Body | Array    | 구독할 이벤트 소스 목록            |
-| eventSubscriptions.sources.sourceId           | Body | UUID     | 이벤트 소스의 식별자              |
-| eventSubscriptions.sources.eventCategoryType  | Body | Enum     | 이벤트 카테고리 유형              |
-| eventSubscriptions.userGroupIds               | Body | Array    | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
-| eventSubscriptions.createdYmdt                | Body | DateTime | 생성 일시                    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Body | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Body | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -5107,25 +4562,7 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
-            "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
-            "sources": [
-                {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
-                }
-            ],
-            "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
-            ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5142,49 +4579,38 @@ GET /v4.0/event-subscriptions
 POST /v4.0/event-subscriptions
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Create | 이벤트 구독 생성하기 |
-
 #### 요청
 
-| 이름                           | 종류   | 형식      | 필수 | 설명                                    |
-|------------------------------|------|---------|----|-----------------------------------------|
-| eventCategoryType            | Body | Enum    | O  | 이벤트 카테고리 유형                          |
-| eventSubscriptionName        | Body | String  | O  | 이벤트 구독을 식별할 수 있는 이름<br/>- 최대 길이: `100` |
-| enabled                      | Body | Boolean | O  | 활성화 여부                                |
-| notifyEmail                  | Body | Boolean | O  | 이메일 발송 여부                             |
-| notifySms                    | Body | Boolean | O  | SMS 발송 여부                             |
-| eventCodes                   | Body | Array   | O  | 구독할 이벤트 코드 목록                        |
-| sources                      | Body | Array   | O  | 구독할 이벤트 소스 목록                        |
-| sources.sourceId             | Body | UUID    | O  | 이벤트 소스의 식별자                          |
-| sources.eventCategoryType    | Body | Enum    | O  | 이벤트 카테고리 유형                          |
-| userGroupIds                 | Body | Array   | O  | 이벤트 구독할 사용자 그룹의 식별자 목록              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Body | Boolean | O | 활성화 여부 |
+| notifyEmail | Body | Boolean | O | 이메일 발송 여부 |
+| notifySms | Body | Boolean | O | SMS 발송 여부 |
+| eventCodes | Body | Array | O | 구독할 이벤트 코드 목록 |
+| sources | Body | Array | O | 구독할 이벤트 소스 목록 |
+| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | O | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5193,9 +4619,9 @@ POST /v4.0/event-subscriptions
 
 #### 응답
 
-| 이름                    | 종류   | 형식   | 설명          |
-|-----------------------|------|------|-------------|
-| eventSubscriptionId   | Body | UUID | 이벤트 구독의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5207,86 +4633,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### 이벤트 구독 수정하기
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | 이벤트 구독 수정하기 |
-
-#### 요청
-
-| 이름                           | 종류   | 형식      | 필수 | 설명                              |
-|------------------------------|------|---------|----|-----------------------------------|
-| eventSubscriptionId          | URL  | UUID    | O  | 이벤트 구독의 식별자                    |
-| eventCategoryType            | Body | Enum    | X  | 이벤트 카테고리 유형                    |
-| eventSubscriptionName        | Body | String  | X  | 이벤트 구독을 식별할 수 있는 이름           |
-| enabled                      | Body | Boolean | X  | 활성화 여부                          |
-| notifyEmail                  | Body | Boolean | X  | 이메일 발송 여부                       |
-| notifySms                    | Body | Boolean | X  | SMS 발송 여부                       |
-| eventCodes                   | Body | Array   | X  | 구독할 이벤트 코드 목록                  |
-| sources                      | Body | Array   | X  | 구독할 이벤트 소스 목록                  |
-| sources.sourceId             | Body | UUID    | X  | 이벤트 소스의 식별자                    |
-| sources.eventCategoryType    | Body | Enum    | X  | 이벤트 카테고리 유형                    |
-| userGroupIds                 | Body | Array   | X  | 이벤트 구독할 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "eventSubscriptionId-example"
 }
 ```
 
@@ -5301,21 +4648,115 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Delete | 이벤트 구독 삭제하기 |
-
 #### 요청
 
-| 이름                    | 종류  | 형식   | 필수 | 설명          |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId   | URL | UUID | O  | 이벤트 구독의 식별자 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 이벤트 구독 수정하기
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Body | Boolean | X | 활성화 여부 |
+| notifyEmail | Body | Boolean | X | 이메일 발송 여부 |
+| notifySms | Body | Boolean | X | SMS 발송 여부 |
+| eventCodes | Body | Array | X | 구독할 이벤트 코드 목록 |
+| sources | Body | Array | X | 구독할 이벤트 소스 목록 |
+| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v4.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -5326,7 +4767,16 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -5334,3 +4784,422 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 </details>
 
 ---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
+
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v4.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 상세 보기
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 목록 |
+| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## 프로젝트 정보
+
+### 프로젝트 멤버 목록 보기
+
+```http
+GET /v4.0/project/members
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberName | Body | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "phoneNumber": "phoneNumber-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 리전 목록 보기
+
+```http
+GET /v4.0/project/regions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 목록 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
+        {
+            "isEnabled": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+

--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -75,21 +75,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
-## DB 보안 그룹
+## 프로젝트 정보
 
-### DB 보안 그룹 진행 상태
-
-| 상태              | 설명           |
-|-----------------|--------------|
-| `NONE`          | 진행 중인 작업이 없음 |
-| `CREATING_RULE` | 규칙 정책 생성 중   |
-| `UPDATING_RULE` | 규칙 정책 수정 중   |
-| `DELETING_RULE` | 규칙 정책 삭제 중   |
-
-### DB 보안 그룹 목록 보기
+### 프로젝트 멤버 목록 보기
 
 ```http
-GET /v4.0/db-security-groups
+GET /v4.0/project/members
 ```
 
 #### 요청
@@ -100,14 +91,11 @@ GET /v4.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberName | Body | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
 
 <details><summary>예시</summary>
 <p>
@@ -119,10 +107,9 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
+    "members": [
         {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            "phoneNumber": "phoneNumber-example"
         }
     ]
 }
@@ -133,38 +120,37 @@ GET /v4.0/db-security-groups
 
 ---
 
-### DB 보안 그룹 생성하기
+### 리전 목록 보기
 
 ```http
-POST /v4.0/db-security-groups
+GET /v4.0/project/regions
 ```
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 목록 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
         {
-            "description": "description-example"
+            "isEnabled": false
         }
     ]
 }
@@ -173,11 +159,29 @@ POST /v4.0/db-security-groups
 </p>
 </details>
 
+---
+
+## DB 인스턴스 사양
+
+### DB 인스턴스 사양 목록 보기
+
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
 
 <details><summary>예시</summary>
 <p>
@@ -189,93 +193,11 @@ POST /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 상세 보기
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
-| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | 포트 객체 |
-| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | 최소 포트 범위 |
-| rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 생성 일시 |
-| rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "dbSecurityGroupId-example",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
+    "dbFlavors": [
         {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            "vcpus": 1
         }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    ]
 }
 ```
 
@@ -284,59 +206,28 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ---
 
-### DB 보안 그룹 수정하기
+## 네트워크
+
+### 서브넷 목록 보기
 
 ```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+GET /v4.0/network/subnets
 ```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
-
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| subnets | Body | Array | 서브넷 목록 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
 
 <details><summary>예시</summary>
 <p>
@@ -348,138 +239,11 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "jobId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "jobId-example"
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
 }
 ```
 
@@ -524,6 +288,214 @@ GET /v4.0/db-versions
             "restorableFromObs": false
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 데이터 스토리지
+
+### 스토리지 타입 목록 보기
+
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 타입 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v4.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 그룹 상세 보기
+
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
+        {
+            "dbInstanceStatus": "BEFORE_CREATE"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -3219,338 +3191,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 
 ---
 
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## DB 인스턴스 사양
-
-### DB 인스턴스 사양 목록 보기
-
-```http
-GET /v4.0/db-flavors
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "vcpus": 1
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 가용성 영역
-
-### 가용성 영역 목록 보기
-
-```http
-GET /v4.0/availability-zones
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | 가용성 영역 목록 |
-| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
-| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
-| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 네트워크
-
-### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "availableIpCount": 1
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 데이터 스토리지
-
-### 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": []
-}
-```
-
-</p>
-</details>
-
----
-
-## 모니터링
-
-### 통계 정보 조회
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### Metric 목록 보기
-
-```http
-GET /v4.0/metrics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.measureName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "unit": "unit-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
 ## 백업
 
 ### 백업 상태
@@ -3966,6 +3606,751 @@ POST /v4.0/backups/{backupId}/restore
 
 </p>
 </details>
+
+---
+
+## DB 보안 그룹
+
+### DB 보안 그룹 진행 상태
+
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
+
+### DB 보안 그룹 목록 보기
+
+```http
+GET /v4.0/db-security-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "dbSecurityGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 생성하기
+
+```http
+POST /v4.0/db-security-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
+        {
+            "description": "description-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 상세 보기
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | 포트 객체 |
+| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | 최소 포트 범위 |
+| rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 생성 일시 |
+| rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 규칙 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
+
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v4.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 상세 보기
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 목록 |
+| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4413,6 +4798,65 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
+## 모니터링
+
+### 통계 정보 조회
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### Metric 목록 보기
+
+```http
+GET /v4.0/metrics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric 목록 |
+| metrics.measureName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "metrics": [
+        {
+            "unit": "unit-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
 ## 이벤트
 
 ### 이벤트 카테고리
@@ -4713,50 +5157,26 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ---
 
-## 작업 정보
+## 가용성 영역
 
-### 작업 상태
-
-| 상태명                | 설명                   |
-|--------------------|----------------------|
-| `PREPARING`        | 작업이 준비 중인 경우         |
-| `READY`            | 작업이 준비 완료된 경우        |
-| `RUNNING`          | 작업이 진행 중인 경우         |
-| `COMPLETED`        | 작업이 완료된 경우           |
-| `REGISTERED`       | 작업이 등록된 경우           |
-| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
-| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
-| `CANCELED`         | 작업이 취소된 경우           |
-| `FAILED`           | 작업이 실패한 경우           |
-| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
-| `DELETED`          | 작업이 삭제된 경우           |
-| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
-
-### 작업 정보 상세 보기
+### 가용성 영역 목록 보기
 
 ```http
-GET /v4.0/jobs/{jobId}
+GET /v4.0/availability-zones
 ```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
-
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
+| availabilityZones | Body | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
 
 <details><summary>예시</summary>
 <p>
@@ -4768,431 +5188,11 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
+    "availabilityZones": [
         {
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | String | 파라미터의 식별자 |
-| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "value": "value-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-## 프로젝트 정보
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
-| members.memberName | Body | String | 프로젝트 멤버의 이름 |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "phoneNumber": "phoneNumber-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 리전 목록 보기
-
-```http
-GET /v4.0/project/regions
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| regions | Body | Array | 리전 목록 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "isEnabled": false
+            "zoneState": {
+                "available": false
+            }
         }
     ]
 }

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -84,6 +84,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 GET /v4.0/project/members
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | 프로젝트 멤버 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -130,6 +136,12 @@ GET /v4.0/project/members
 GET /v4.0/project/regions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Project.Get | 리전 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -173,6 +185,12 @@ GET /v4.0/project/regions
 ```http
 GET /v4.0/db-flavors
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbFlavor.List | DB 인스턴스 사양 목록 보기 |
 
 #### 요청
 
@@ -221,6 +239,12 @@ GET /v4.0/db-flavors
 ```http
 GET /v4.0/network/subnets
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Network.List | 서브넷 목록 보기 |
 
 #### 요청
 
@@ -272,6 +296,12 @@ GET /v4.0/network/subnets
 GET /v4.0/db-versions
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbVersion.List | DB 엔진 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -317,6 +347,12 @@ GET /v4.0/db-versions
 ```http
 GET /v4.0/storage-types
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Storage.List | 스토리지 타입 목록 보기 |
 
 #### 요청
 
@@ -371,6 +407,12 @@ GET /v4.0/storage-types
 ```http
 GET /v4.0/jobs/{jobId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Job.Get | 작업 정보 상세 보기 |
 
 #### 요청
 
@@ -428,6 +470,12 @@ GET /v4.0/jobs/{jobId}
 GET /v4.0/db-instance-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -473,6 +521,12 @@ GET /v4.0/db-instance-groups
 ```http
 GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
 
 #### 요청
 
@@ -577,6 +631,12 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 GET /v4.0/db-instances
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.List | DB 인스턴스 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -636,6 +696,12 @@ GET /v4.0/db-instances
 ```http
 POST /v4.0/db-instances
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
 
 #### 공통 요청
 
@@ -774,6 +840,12 @@ POST /v4.0/db-instances
 ```http
 POST /v4.0/db-instances/restore-from-obs
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.RestoreFromObs | 오브젝트 스토리지를 이용한 DB 인스턴스 복원 |
 
 #### 공통 요청
 
@@ -918,6 +990,12 @@ POST /v4.0/db-instances/restore-from-obs
 DELETE /v4.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Delete | DB 인스턴스 삭제하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -967,6 +1045,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
 
 #### 요청
 
@@ -1047,6 +1131,12 @@ GET /v4.0/db-instances/{dbInstanceId}
 PUT /v4.0/db-instances/{dbInstanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1123,6 +1213,12 @@ PUT /v4.0/db-instances/{dbInstanceId}
 GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 백업 정보 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1178,6 +1274,12 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 백업 정보 수정하기 |
 
 #### 요청
 
@@ -1246,6 +1348,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.List | 바이너리 로그 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1294,6 +1402,12 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceBinLog.Purge | 바이너리 로그 삭제 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1324,6 +1438,12 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.List | 인증서 파일 목록 보기 |
 
 #### 요청
 
@@ -1374,6 +1494,12 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceCertificate.Export | 인증서 파일 내보내기 |
 
 #### 요청
 
@@ -1435,6 +1561,12 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.List | DB 스키마 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1484,6 +1616,12 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Create | DB 스키마 생성하기 |
 
 #### 요청
 
@@ -1535,6 +1673,12 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceSchema.Delete | DB 스키마 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1574,6 +1718,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/db-users
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.List | DB 사용자 목록 보기 |
 
 #### 요청
 
@@ -1635,6 +1785,12 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 POST /v4.0/db-instances/{dbInstanceId}/db-users
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Create | DB 사용자 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1695,6 +1851,12 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Delete | DB 사용자 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1734,6 +1896,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceUser.Modify | DB 사용자 수정하기 |
 
 #### 요청
 
@@ -1792,6 +1960,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 삭제 보호 설정 변경 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -1823,6 +1997,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 POST /v4.0/db-instances/{dbInstanceId}/force-restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1842,6 +2022,12 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/high-availability
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 고가용성 정보 보기 |
 
 #### 요청
 
@@ -1887,6 +2073,12 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
 
 #### 공통 요청
 
@@ -1946,6 +2138,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Pause | 고가용성 일시 중지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -1984,6 +2182,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Repair | 고가용성 복구하기 |
 
 #### 요청
 
@@ -2024,6 +2228,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Resume | 고가용성 다시 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2063,6 +2273,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:HighAvailability.Split | 고가용성 분리하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2101,6 +2317,12 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/log-files
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.List | 로그 파일 목록 보기 |
 
 #### 요청
 
@@ -2151,6 +2373,12 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Export | 로그 파일 내보내기 |
 
 #### 요청
 
@@ -2212,6 +2440,12 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstanceLog.Get | 로그 파일 내용 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2251,6 +2485,12 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/maintenances
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.List | DB 인스턴스 유지 관리 목록 보기 |
 
 #### 요청
 
@@ -2326,6 +2566,12 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Execute | DB 인스턴스 유지 관리 즉시 실행하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2384,6 +2630,12 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Update | DB 인스턴스 유지 관리 예약하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2423,6 +2675,12 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Maintenance.Delete | DB 인스턴스 유지 관리 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2443,6 +2701,12 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/network-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 네트워크 정보 보기 |
 
 #### 요청
 
@@ -2503,6 +2767,12 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 PUT /v4.0/db-instances/{dbInstanceId}/network-info
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 네트워크 정보 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2553,6 +2823,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 POST /v4.0/db-instances/{dbInstanceId}/promote
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Promote | DB 인스턴스 승격하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2592,6 +2868,12 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 POST /v4.0/db-instances/{dbInstanceId}/rebuild
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Rebuild | DB 인스턴스 재구축하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2630,6 +2912,12 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/replicate
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
 
 #### 공통 요청
 
@@ -2748,6 +3036,12 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 POST /v4.0/db-instances/{dbInstanceId}/restart
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restart | DB 인스턴스 재시작하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -2803,6 +3097,12 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | DB 인스턴스 복원 정보 조회 |
 
 #### 요청
 
@@ -2884,6 +3184,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 복원될 마지막 쿼리 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -2924,6 +3230,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원 |
 
 #### 공통 요청
 
@@ -3089,6 +3401,12 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 POST /v4.0/db-instances/{dbInstanceId}/start
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Start | DB 인스턴스 시작하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3128,6 +3446,12 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 POST /v4.0/db-instances/{dbInstanceId}/stop
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Stop | DB 인스턴스 정지하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3166,6 +3490,12 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Get | 스토리지 정보 보기 |
 
 #### 요청
 
@@ -3220,6 +3550,12 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 ```http
 PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbInstance.Modify | 스토리지 정보 수정하기 |
 
 #### 공통 요청
 
@@ -3296,6 +3632,12 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 GET /v4.0/backups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.List | 백업 목록 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3356,6 +3698,12 @@ GET /v4.0/backups
 POST /v4.0/backups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Create | 백업 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3411,6 +3759,12 @@ POST /v4.0/backups
 DELETE /v4.0/backups/{backupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Delete | 백업 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3449,6 +3803,12 @@ DELETE /v4.0/backups/{backupId}
 ```http
 GET /v4.0/backups/{backupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Get | 백업 단건 조회 |
 
 #### 요청
 
@@ -3525,6 +3885,12 @@ GET /v4.0/backups/{backupId}
 POST /v4.0/backups/{backupId}/export
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Export | 백업 내보내기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3582,6 +3948,12 @@ POST /v4.0/backups/{backupId}/export
 ```http
 POST /v4.0/backups/{backupId}/restore
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Backup.Restore | 백업 복원하기 |
 
 #### 공통 요청
 
@@ -3723,6 +4095,12 @@ POST /v4.0/backups/{backupId}/restore
 GET /v4.0/db-security-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3774,6 +4152,12 @@ GET /v4.0/db-security-groups
 ```http
 POST /v4.0/db-security-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
 
 #### 요청
 
@@ -3848,6 +4232,12 @@ POST /v4.0/db-security-groups
 DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -3867,6 +4257,12 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 ```http
 GET /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
 
 #### 요청
 
@@ -3945,6 +4341,12 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -3977,6 +4379,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 ```http
 DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Delete | DB 보안 그룹 규칙 삭제하기 |
 
 #### 요청
 
@@ -4017,6 +4425,12 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
 
 #### 요청
 
@@ -4082,6 +4496,12 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 ```http
 PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
 
 #### 요청
 
@@ -4151,6 +4571,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 GET /v4.0/parameter-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.List | 파라미터 그룹 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4207,6 +4633,12 @@ GET /v4.0/parameter-groups
 POST /v4.0/parameter-groups
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Create | 파라미터 그룹 생성하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4260,6 +4692,12 @@ POST /v4.0/parameter-groups
 DELETE /v4.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4279,6 +4717,12 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 ```http
 GET /v4.0/parameter-groups/{parameterGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Get | 파라미터 그룹 상세 보기 |
 
 #### 요청
 
@@ -4354,6 +4798,12 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 PUT /v4.0/parameter-groups/{parameterGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4386,6 +4836,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 ```http
 POST /v4.0/parameter-groups/{parameterGroupId}/copy
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
 
 #### 요청
 
@@ -4439,6 +4895,12 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Modify | 파라미터 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4477,6 +4939,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4498,6 +4966,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 ```http
 GET /v4.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.List | 사용자 그룹 목록 보기 |
 
 #### 요청
 
@@ -4546,6 +5020,12 @@ GET /v4.0/user-groups
 ```http
 POST /v4.0/user-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Create | 사용자 그룹 생성하기 |
 
 #### 요청
 
@@ -4600,6 +5080,12 @@ POST /v4.0/user-groups
 DELETE /v4.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Delete | 사용자 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4619,6 +5105,12 @@ DELETE /v4.0/user-groups/{userGroupId}
 ```http
 GET /v4.0/user-groups/{userGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Get | 사용자 그룹 상세 보기 |
 
 #### 요청
 
@@ -4674,6 +5166,12 @@ GET /v4.0/user-groups/{userGroupId}
 PUT /v4.0/user-groups/{userGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:UserGroup.Modify | 사용자 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4710,6 +5208,12 @@ PUT /v4.0/user-groups/{userGroupId}
 ```http
 GET /v4.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.List | 알림 그룹 목록 보기 |
 
 #### 요청
 
@@ -4762,6 +5266,12 @@ GET /v4.0/notification-groups
 ```http
 POST /v4.0/notification-groups
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Create | 알림 그룹 생성하기 |
 
 #### 요청
 
@@ -4822,6 +5332,12 @@ POST /v4.0/notification-groups
 DELETE /v4.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Delete | 알림 그룹 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4841,6 +5357,12 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 ```http
 GET /v4.0/notification-groups/{notificationGroupId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Get | 알림 그룹 상세 보기 |
 
 #### 요청
 
@@ -4911,6 +5433,12 @@ GET /v4.0/notification-groups/{notificationGroupId}
 PUT /v4.0/notification-groups/{notificationGroupId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:NotificationGroup.Modify | 알림 그룹 수정하기 |
+
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -4954,6 +5482,12 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 GET /v4.0/metric-statistics
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | 통계 정보 조회 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -4969,6 +5503,12 @@ GET /v4.0/metric-statistics
 ```http
 GET /v4.0/metrics
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Metric.List | Metric 목록 보기 |
 
 #### 요청
 
@@ -5027,6 +5567,12 @@ GET /v4.0/metrics
 GET /v4.0/event-codes
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 구독 가능한 이벤트 코드 목록 보기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5068,6 +5614,12 @@ GET /v4.0/event-codes
 ```http
 GET /v4.0/events
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:Event.List | 이벤트 목록 조회 |
 
 #### 요청
 
@@ -5129,6 +5681,12 @@ GET /v4.0/events
 ```http
 GET /v4.0/event-subscriptions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.List | 이벤트 구독 목록 조회 |
 
 #### 요청
 
@@ -5196,6 +5754,12 @@ GET /v4.0/event-subscriptions
 ```http
 POST /v4.0/event-subscriptions
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Create | 이벤트 구독 생성하기 |
 
 #### 요청
 
@@ -5267,6 +5831,12 @@ POST /v4.0/event-subscriptions
 DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
 
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Delete | 이벤트 구독 삭제하기 |
+
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
@@ -5286,6 +5856,12 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```http
 PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:EventSubscription.Modify | 이벤트 구독 수정하기 |
 
 #### 요청
 
@@ -5340,6 +5916,12 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 ```http
 GET /v4.0/availability-zones
 ```
+
+#### 필요 권한
+
+| 권한명 | 설명 |
+|-----|-----|
+| RDSforMariaDB:AvailabilityZone.List | 가용성 영역 목록 보기 |
 
 #### 요청
 

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -1,6 +1,13 @@
-## Database > RDS for MariaDB > API 가이드
+## Database > RDS for MariaDB > API v4.0 가이드
 
 ## RDS for MariaDB API 공통 정보
+
+### API 엔드포인트
+
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-mariadb.api.nhncloudservice.com |
+
 
 ### 인증 및 권한
 
@@ -47,12 +54,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
 | isSuccessful | Boolean | 성공 여부 |
-
-### API 엔드포인트
-
-| 리전 | 엔드포인트 |
-|------|----------|
-| 한국(판교) 리전 | https://kr1-rds-mariadb.api.nhncloudservice.com |
 
 ### DB 엔진 유형
 

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -118,8 +118,8 @@ GET /v4.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -275,7 +275,7 @@ GET /v4.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -743,7 +743,7 @@ POST /v4.0/db-instances
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -802,7 +802,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -877,7 +877,7 @@ POST /v4.0/db-instances/restore-from-obs
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -938,7 +938,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1244,7 +1244,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
@@ -1264,7 +1264,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1299,7 +1299,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1314,7 +1314,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2751,13 +2751,13 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example"
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2956,7 +2956,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 스토리지 자동 확장 사용 시
@@ -3001,7 +3001,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3271,7 +3271,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
@@ -3352,7 +3352,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3995,7 +3995,7 @@ POST /v4.0/backups/{backupId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -4049,7 +4049,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4198,7 +4198,7 @@ POST /v4.0/db-security-groups
                 "minPort": 3306,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4327,7 +4327,7 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
@@ -4465,7 +4465,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4537,7 +4537,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -374,7 +374,10 @@ GET /v4.0/storage-types
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageTypes": []
+    "storageTypes": [
+        "General SSD",
+        "General HDD"
+    ]
 }
 ```
 
@@ -1107,8 +1110,12 @@ GET /v4.0/db-instances/{dbInstanceId}
     "progressStatus": "NONE",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbSecurityGroupIds": [],
-    "notificationGroupIds": [],
+    "dbSecurityGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
+    "notificationGroupIds": [
+        "550e8400-e29b-41d4-a716-446655440000"
+    ],
     "useDeletionProtection": false,
     "useSlowQueryAnalysis": false,
     "supportAuthenticationPlugin": false,
@@ -5737,7 +5744,9 @@ GET /v4.0/event-subscriptions
                     "eventCategoryType": "ALL"
                 }
             ],
-            "userGroupIds": [],
+            "userGroupIds": [
+                "550e8400-e29b-41d4-a716-446655440000"
+            ],
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -944,7 +944,7 @@ POST /v4.0/db-instances/restore-from-obs
         ]
     },
     "restore": {
-        "tenantId": "tenantId-example",
+        "tenantId": "0123456789abcdef0123456789abcdef",
         "username": "username-example",
         "password": "password-example",
         "targetContainer": "targetContainer-example",
@@ -1526,7 +1526,7 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```json
 {
     "certificateTypes": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -1769,7 +1769,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
         {
             "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
-            "host": "host-example",
+            "host": "192.168.0.1",
             "authorityType": "CUSTOM",
             "dbUserStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -1817,7 +1817,7 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 {
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
-    "host": "host-example",
+    "host": "192.168.0.1",
     "authorityType": "CUSTOM",
     "authenticationPlugin": "NATIVE",
     "tlsOption": "NONE"
@@ -2405,7 +2405,7 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```json
 {
     "logFileNames": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -3914,7 +3914,7 @@ POST /v4.0/backups/{backupId}/export
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -5640,7 +5640,7 @@ GET /v4.0/events
 | events | Body | Array | 이벤트 목록 |
 | events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
 | events.messages | Body | Array | 이벤트 메세지 목록 |
 | events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
@@ -5662,7 +5662,7 @@ GET /v4.0/events
         {
             "eventCategoryType": "ALL",
             "eventCode": "ENUM_VALUE",
-            "sourceId": "sourceId-example",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "sourceName": "sourceName-example",
             "messages": [
                 {
@@ -5713,7 +5713,7 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
 | eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
 | eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
@@ -5740,7 +5740,7 @@ GET /v4.0/event-subscriptions
             "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "sourceId-example",
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
                     "eventCategoryType": "ALL"
                 }
             ],

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -1,4 +1,6 @@
-## Database > RDS for MariaDB > API v4.0 가이드
+## RDS for MariaDB API 가이드
+
+**Database > RDS for MariaDB > API v4.0 가이드**
 
 ## RDS for MariaDB API 공통 정보
 
@@ -14,10 +16,10 @@
 RDS for MariaDB은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| X-TC-APP-KEY | Header | String | O | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
+| X-TC-APP-KEY | Header | String | Y | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | Y | Public API로 발급 받은 Bearer 유형 토큰 |
 
 또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
@@ -37,7 +39,9 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 
 모든 API 요청에 '200 OK'로 응답합니다. 자세한 응답 결과는 응답 본문의 헤더를 참고합니다.
 
-#### 응답 본문
+<details>
+  <summary><strong>성공 응답</strong></summary>
+
 ```json
 {
     "header": {
@@ -48,13 +52,28 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 }
 ```
 
-#### 필드
-| 이름 | 형식 | 설명 |
+</details>
+
+<details>
+  <summary><strong>실패 응답</strong></summary>
+
+```json
+{
+    "header": {
+        "resultCode": -1,
+        "resultMessage": "FAIL",
+        "isSuccessful": false
+    }
+}
+```
+
+</details>
+
+| 이름 | 타입 | 설명 |
 |-----|-----|-----|
 | resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
 | resultMessage | String | 결과 메시지 |
 | isSuccessful | Boolean | 성공 여부 |
-
 ### DB 엔진 유형
 
 | DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
@@ -69,9 +88,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 | MARIADB_V101108 | O | O | NATIVE, ED25519 |
 | MARIADB_V101113 | O | O | NATIVE, ED25519 |
 | MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V101118 | O | O | NATIVE, ED25519 |
 | MARIADB_V11407 | O | O | NATIVE, ED25519 |
 | MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11412 | O | O | NATIVE, ED25519 |
 | MARIADB_V11806 | O | O | NATIVE, ED25519 |
+| MARIADB_V11808 | O | O | NATIVE, ED25519 |
 
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
@@ -79,10 +101,6 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 ## 프로젝트 정보
 
 ### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
 
 #### 필요 권한
 
@@ -92,20 +110,18 @@ GET /v4.0/project/members
 
 #### 요청
 
+```http
+GET /v4.0/project/members
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| members.memberName | Body | String | 프로젝트 멤버의 이름 |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -125,16 +141,19 @@ GET /v4.0/project/members
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| members.memberName | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | String | 프로젝트 멤버의 전화번호 |
 
 ---
 
 ### 리전 목록 보기
-
-```http
-GET /v4.0/project/regions
-```
 
 #### 필요 권한
 
@@ -144,18 +163,18 @@ GET /v4.0/project/regions
 
 #### 요청
 
+```http
+GET /v4.0/project/regions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| regions | Body | Array | 리전 목록 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -173,18 +192,19 @@ GET /v4.0/project/regions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| regions | Array | 리전 목록 |
+| regions.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Boolean | 리전의 활성화 여부 |
 
 ---
 
 ## DB 인스턴스 사양
 
 ### DB 인스턴스 사양 목록 보기
-
-```http
-GET /v4.0/db-flavors
-```
 
 #### 필요 권한
 
@@ -194,20 +214,18 @@ GET /v4.0/db-flavors
 
 #### 요청
 
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -227,18 +245,21 @@ GET /v4.0/db-flavors
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbFlavors | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Number | CPU 코어 수 |
 
 ---
 
 ## 네트워크
 
 ### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
 
 #### 필요 권한
 
@@ -248,21 +269,18 @@ GET /v4.0/network/subnets
 
 #### 요청
 
+```http
+GET /v4.0/network/subnets
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -283,18 +301,22 @@ GET /v4.0/network/subnets
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| subnets | Array | 서브넷 목록 |
+| subnets.subnetId | UUID | 서브넷의 식별자 |
+| subnets.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | String | 서브넷의 CIDR |
+| subnets.usingGateway | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Number | 사용 가능한 IP 수 |
 
 ---
 
 ## DB 엔진
 
 ### DB 엔진 목록 보기
-
-```http
-GET /v4.0/db-versions
-```
 
 #### 필요 권한
 
@@ -304,19 +326,18 @@ GET /v4.0/db-versions
 
 #### 요청
 
+```http
+GET /v4.0/db-versions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbVersions | Body | Array | DB 엔진 목록 |
-| dbVersions.dbVersion | Body | String | DB 엔진 유형 |
-| dbVersions.dbVersionName | Body | String | DB 엔진 이름 |
-| dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -335,18 +356,20 @@ GET /v4.0/db-versions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbVersions | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | String | DB 엔진 이름 |
+| dbVersions.restorableFromObs | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 ---
 
 ## 데이터 스토리지
 
 ### 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
 
 #### 필요 권한
 
@@ -356,16 +379,18 @@ GET /v4.0/storage-types
 
 #### 요청
 
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -381,8 +406,11 @@ GET /v4.0/storage-types
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageTypes | Array | 스토리지 타입 목록 |
 
 ---
 
@@ -407,10 +435,6 @@ GET /v4.0/storage-types
 
 ### 작업 정보 상세 보기
 
-```http
-GET /v4.0/jobs/{jobId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -419,26 +443,24 @@ GET /v4.0/jobs/{jobId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/jobs/{jobId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
+| jobId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -460,18 +482,23 @@ GET /v4.0/jobs/{jobId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
+| jobStatus | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- COMPLETED_WITH_ERROR<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | String | 연관 리소스의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ## DB 인스턴스 그룹
 
 ### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
 
 #### 필요 권한
 
@@ -481,20 +508,18 @@ GET /v4.0/db-instance-groups
 
 #### 요청
 
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -514,16 +539,19 @@ GET /v4.0/db-instance-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroups | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
 
 #### 필요 권한
 
@@ -533,27 +561,24 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
+| dbInstanceGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -576,8 +601,18 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| replicationType | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
@@ -630,10 +665,6 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 ### DB 인스턴스 목록 보기
 
-```http
-GET /v4.0/db-instances
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -642,27 +673,18 @@ GET /v4.0/db-instances
 
 #### 요청
 
+```http
+GET /v4.0/db-instances
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstances | Body | Array | DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
-| dbInstances.dbPort | Body | Number | DB 포트 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| dbInstances.progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -689,16 +711,26 @@ GET /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstances | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | String | DB 엔진 유형 |
+| dbInstances.dbPort | Number | DB 포트 |
+| dbInstances.dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 생성하기
-
-```http
-POST /v4.0/db-instances
-```
 
 #### 필요 권한
 
@@ -706,62 +738,16 @@ POST /v4.0/db-instances
 |-----|-----|
 | RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
-| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| authenticationPlugin | Body | Enum | X | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 데이터 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+POST /v4.0/db-instances
+```
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -810,17 +796,64 @@ POST /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| dbPort | Number | Y | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| authenticationPlugin | Enum | N | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 데이터 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -833,16 +866,15 @@ POST /v4.0/db-instances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
 
 #### 필요 권한
 
@@ -850,64 +882,16 @@ POST /v4.0/db-instances/restore-from-obs
 |-----|-----|
 | RDSforMariaDB:DbInstance.RestoreFromObs | 오브젝트 스토리지를 이용한 DB 인스턴스 복원 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | O | DB 포트 |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| storage | Body | Object | O | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | O | 스토리지 타입 |
-| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| backup | Body | Object | O | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
-| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
-| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
-| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
-| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -959,17 +943,66 @@ POST /v4.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | Y | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | Y | DB 포트 |
+| dbVersion | String | Y | DB 엔진 유형 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | Y | 스토리지 정보 객체 |
+| storage.storageType | Enum | Y | 스토리지 타입 |
+| storage.storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.subnetId | UUID | Y | 서브넷의 식별자 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Object | Y | 백업 정보 객체 |
+| backup.backupPeriod | Number | Y | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | Y | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.tenantId | String | Y | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | String | Y | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | String | Y | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | String | Y | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | String | Y | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | UUID | Y | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -982,16 +1015,15 @@ POST /v4.0/db-instances/restore-from-obs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1001,13 +1033,20 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| deleteAutoBackup | Body | Boolean | X | 자동 백업 삭제 여부<br/>- 기본값: `false` |
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1015,17 +1054,16 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| deleteAutoBackup | Boolean | N | 자동 백업 삭제 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1038,16 +1076,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 상세 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1057,40 +1094,24 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
-| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| description | Body | String | DB 인스턴스에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| dbPort | Body | Number | DB 포트 |
-| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
-| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
-| useSlowQueryAnalysis | Body | Boolean | Slow query 분석 여부 |
-| supportAuthenticationPlugin | Body | Boolean | 인증 plugin 지원 여부 |
-| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
-| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
-| supportDbVersionUpgrade | Body | Boolean | DB 버전 업그레이드 지원 여부 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1127,16 +1148,35 @@ GET /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | UUID | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| dbPort | Number | DB 포트 |
+| dbInstanceType | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | DB 인스턴스 삭제 보호 여부 |
+| useSlowQueryAnalysis | Boolean | Slow query 분석 여부 |
+| supportAuthenticationPlugin | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 인스턴스 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
 
 #### 필요 권한
 
@@ -1146,26 +1186,20 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부 |
-| useDummy | Body | Boolean | X | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
-| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
-| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
-| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1186,17 +1220,29 @@ PUT /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | N | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | String | N | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbVersion | String | N | DB 엔진 버전 코드 |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부 |
+| useDummy | Boolean | N | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1209,16 +1255,15 @@ PUT /v4.0/db-instances/{dbInstanceId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1228,27 +1273,24 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| backupPeriod | Body | Number | 백업 보관 기간(일) |
-| ftwrlWaitTimeout | Body | Number | 쿼리 지연 대기 시간(초) |
-| backupRetryCount | Body | Number | 백업 재시도 횟수 |
-| replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
-| backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1271,16 +1313,22 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backupPeriod | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Number | 백업 재시도 횟수 |
+| replicationRegion | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 ---
 
 ### 백업 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/backup-info
-```
 
 #### 필요 권한
 
@@ -1290,20 +1338,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
-| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/backup-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1321,17 +1369,23 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1344,16 +1398,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 바이너리 로그 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/binlogs
-```
 
 #### 필요 권한
 
@@ -1363,23 +1416,24 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/binlogs
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| binLogs | Body | Array | BinLog 파일 목록 |
-| binLogs.binLogFileName | Body | String | BinLog 파일 이름 |
-| binLogs.binLogFileSize | Body | Number | BinLog 파일 크기 (Byte) |
-| binLogs.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1398,16 +1452,18 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| binLogs | Array | BinLog 파일 목록 |
+| binLogs.binLogFileName | String | BinLog 파일 이름 |
+| binLogs.binLogFileSize | Number | BinLog 파일 크기 (Byte) |
+| binLogs.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 바이너리 로그 삭제
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
-```
 
 #### 필요 권한
 
@@ -1417,13 +1473,20 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| lastBinLogFileName | Body | String | O | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1431,8 +1494,11 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| lastBinLogFileName | String | Y | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
 
 #### 응답
 
@@ -1442,10 +1508,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 ### 인증서 파일 목록 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/certificates
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -1454,24 +1516,24 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/certificates
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| certificates | Body | Array | 인증서 파일 목록 |
-| certificates.fileName | Body | String | 인증서 파일 이름 |
-| certificates.certificateType | Body | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
-| certificates.fileSize | Body | Number | 인증서 파일 크기(Byte) |
-| certificates.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1491,16 +1553,19 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| certificates | Array | 인증서 파일 목록 |
+| certificates.fileName | String | 인증서 파일 이름 |
+| certificates.certificateType | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Number | 인증서 파일 크기(Byte) |
+| certificates.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 인증서 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
-```
 
 #### 필요 권한
 
@@ -1510,18 +1575,20 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| certificateTypes | Body | Array | O | 업로드할 인증서 타입 목록 |
-| tenantId | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
-| password | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 인증서 파일의 경로 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1534,17 +1601,21 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| certificateTypes | Array | Y | 업로드할 인증서 타입 목록 |
+| tenantId | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 인증서 파일의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1557,16 +1628,15 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 스키마 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
 
 #### 필요 권한
 
@@ -1576,24 +1646,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSchemas | Body | Array | DB 스키마 목록 |
-| dbSchemas.dbSchemaId | Body | UUID | DB 스키마의 식별자 |
-| dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
-| dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1613,16 +1683,19 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSchemas | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | UUID | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### DB 스키마 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
 
 #### 필요 권한
 
@@ -1632,13 +1705,20 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1646,17 +1726,16 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemaName | String | Y | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1669,16 +1748,15 @@ POST /v4.0/db-instances/{dbInstanceId}/db-schemas
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 스키마 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
 
 #### 필요 권한
 
@@ -1688,21 +1766,25 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbSchemaId | URL | UUID | O | DB 스키마의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbSchemaId | URL | UUID | Y | DB 스키마의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1715,16 +1797,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -1734,29 +1815,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
-| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
-| dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
-| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
-| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
-| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
-| dbUsers.authenticationPlugin | Body | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| dbUsers.tlsOption | Body | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1781,16 +1857,24 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbUsers | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | UUID | DB 사용자의 식별자 |
+| dbUsers.dbUserName | String | DB 사용자 계정 이름 |
+| dbUsers.host | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 ---
 
 ### DB 사용자 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
 
 #### 필요 권한
 
@@ -1800,18 +1884,20 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
-| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| host | Body | String | O | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
-| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1824,17 +1910,21 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbUserName | String | Y | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | String | Y | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | String | Y | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Enum | Y | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1847,16 +1937,15 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -1866,21 +1955,25 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | DB 사용자의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1893,16 +1986,15 @@ DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 사용자 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
 
 #### 필요 권한
 
@@ -1912,17 +2004,21 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
-| dbPassword | Body | String | X | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
-| authorityType | Body | Enum | X | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
-| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
-| tlsOption | Body | Enum | X | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | Y | DB 사용자의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1933,17 +2029,19 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbPassword | String | N | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Enum | N | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Enum | N | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Enum | N | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1956,16 +2054,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 삭제 보호 설정 변경
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
 
 #### 필요 권한
 
@@ -1975,13 +2072,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -1989,8 +2093,11 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useDeletionProtection | Boolean | Y | 삭제 보호 여부 |
 
 #### 응답
 
@@ -2000,10 +2107,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
 
 ### DB 인스턴스 강제 재시작하기
 
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2012,11 +2115,19 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2026,10 +2137,6 @@ POST /v4.0/db-instances/{dbInstanceId}/force-restart
 
 ### 고가용성 정보 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2038,23 +2145,24 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| useHighAvailability | Body | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
-| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
-| pingInterval | Body | Number | Ping 간격(초) |
-| pingType | Body | String | Ping 방식 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2070,16 +2178,18 @@ GET /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| useHighAvailability | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
+| haStatus | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Number | Ping 간격(초) |
+| pingType | String | Ping 방식 |
 
 ---
 
 ### 고가용성 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
 
 #### 필요 권한
 
@@ -2087,22 +2197,22 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 |-----|-----|
 | RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2111,17 +2221,23 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Boolean | Y | 고가용성 사용 여부 |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2134,16 +2250,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/high-availability
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 일시 중지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
 
 #### 필요 권한
 
@@ -2153,20 +2268,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2179,16 +2298,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 복구하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
 
 #### 필요 권한
 
@@ -2198,20 +2316,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2224,16 +2346,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 다시 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
 
 #### 필요 권한
 
@@ -2243,20 +2364,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2269,16 +2394,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 고가용성 분리하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
 
 #### 필요 권한
 
@@ -2288,20 +2412,24 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2314,16 +2442,15 @@ POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 로그 파일 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
 
 #### 필요 권한
 
@@ -2333,24 +2460,24 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| logFiles | Body | Array | 로그 파일 목록 |
-| logFiles.logFileName | Body | String | 로그 파일 이름 |
-| logFiles.logFileType | Body | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
-| logFiles.logFileSize | Body | Number | 로그 파일 크기(Byte) |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2370,16 +2497,19 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| logFiles | Array | 로그 파일 목록 |
+| logFiles.logFileName | String | 로그 파일 이름 |
+| logFiles.logFileType | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 로그 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
 
 #### 필요 권한
 
@@ -2389,18 +2519,20 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O |  |
-| logFileNames | Body | Array | O | 로그 파일 이름 목록 |
-| tenantId | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
-| password | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 로그 파일의 경로 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2413,17 +2545,21 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| logFileNames | Array | Y | 로그 파일 이름 목록 |
+| tenantId | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 로그 파일의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2436,16 +2572,15 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 로그 파일 내용 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
 
 #### 필요 권한
 
@@ -2455,21 +2590,25 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| logFileName | URL | UUID | O | 로그 파일 이름 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| logFileName | URL | UUID | Y | 로그 파일 이름 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| content | Body | String | 로그 파일 내용 (최대 65533 bytes) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2482,16 +2621,15 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| content | String | 로그 파일 내용 (최대 65533 bytes) |
 
 ---
 
 ### DB 인스턴스 유지 관리 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/maintenances
-```
 
 #### 필요 권한
 
@@ -2501,37 +2639,27 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| type | Query | String | X |  |
-| statuses | Query | String | X |  |
-| category | Query | String | X |  |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| type | Query | String | N |  |
+| statuses | Query | String | N |  |
+| category | Query | String | N |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 유지 관리 목록 갯수 |
-| maintenances | Body | Array | 유지 관리 목록 |
-| maintenances.maintenanceId | Body | UUID | 유지 관리 아이디 |
-| maintenances.dbInstanceId | Body | UUID | DB 인스턴스 아이디 |
-| maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| maintenances.description | Body | String | 유지 관리 설명 |
-| maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| maintenances.payload | Body | Object | 유지 관리 타입에 따른 Payload |
-| maintenances.required | Body | Boolean | 유지 관리 필수 여부 |
-| maintenances.deadlineYmdt | Body | DateTime | 유지 관리 강제 적용 일시 |
-| maintenances.status | Body | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
-| maintenances.executionType | Body | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
-| maintenances.addedYmdt | Body | DateTime | 유지 관리 스케줄 등록 일시 |
-| maintenances.executionStartedYmdt | Body | DateTime | 유지 관리 시작 일시 |
-| maintenances.executionCompletedYmdt | Body | DateTime | 유지 관리 종료 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2562,16 +2690,29 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 유지 관리 목록 갯수 |
+| maintenances | Array | 유지 관리 목록 |
+| maintenances.maintenanceId | UUID | 유지 관리 아이디 |
+| maintenances.dbInstanceId | UUID | DB 인스턴스 아이디 |
+| maintenances.category | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| maintenances.description | String | 유지 관리 설명 |
+| maintenances.type | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| maintenances.payload | Object | 유지 관리 타입에 따른 Payload |
+| maintenances.required | Boolean | 유지 관리 필수 여부 |
+| maintenances.deadlineYmdt | DateTime | 유지 관리 강제 적용 일시 |
+| maintenances.status | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
+| maintenances.executionType | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
+| maintenances.addedYmdt | DateTime | 유지 관리 스케줄 등록 일시 |
+| maintenances.executionStartedYmdt | DateTime | 유지 관리 시작 일시 |
+| maintenances.executionCompletedYmdt | DateTime | 유지 관리 종료 일시 |
 
 ---
 
 ### DB 인스턴스 유지 관리 즉시 실행하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
-```
 
 #### 필요 권한
 
@@ -2581,17 +2722,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| configId | Body | String | O | 설정 아이디 |
-| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| description | Body | String | X | 유지 관리 설명 |
-| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2603,17 +2747,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| configId | String | Y | 설정 아이디 |
+| category | Enum | Y | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | String | N | 유지 관리 설명 |
+| type | Enum | Y | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | String | Y | 유지 관리 타입에 따른 Payload |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2626,16 +2773,15 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 유지 관리 예약하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
-```
 
 #### 필요 권한
 
@@ -2645,17 +2791,20 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| configId | Body | String | O | 설정 아이디 |
-| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
-| description | Body | String | X | 유지 관리 설명 |
-| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
-| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2667,8 +2816,15 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| configId | String | Y | 설정 아이디 |
+| category | Enum | Y | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | String | N | 유지 관리 설명 |
+| type | Enum | Y | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | String | Y | 유지 관리 타입에 따른 Payload |
 
 #### 응답
 
@@ -2678,10 +2834,6 @@ POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
 
 ### DB 인스턴스 유지 관리 삭제하기
 
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2690,12 +2842,20 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| maintenanceId | URL | UUID | O | 유지 관리 아이디 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+| maintenanceId | URL | UUID | Y | 유지 관리 아이디 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -2705,10 +2865,6 @@ DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
 
 ### 네트워크 정보 보기
 
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -2717,28 +2873,24 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
-| subnet | Body | Object | 서브넷 객체 |
-| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
-| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
-| endPoints | Body | Array | 접속 정보 목록 |
-| endPoints.domain | Body | String | 도메인 |
-| endPoints.ipAddress | Body | String | IP 주소 |
-| endPoints.endPointType | Body | String | 접속 정보 타입 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2763,16 +2915,23 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZone | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Object | 서브넷 객체 |
+| subnet.subnetId | UUID | 서브넷의 식별자 |
+| subnet.subnetName | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | String | 서브넷의 CIDR |
+| endPoints | Array | 접속 정보 목록 |
+| endPoints.domain | String | 도메인 |
+| endPoints.ipAddress | String | IP 주소 |
+| endPoints.endPointType | String | 접속 정보 타입 |
 
 ---
 
 ### 네트워크 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
 
 #### 필요 권한
 
@@ -2782,13 +2941,20 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2796,17 +2962,16 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| usePublicAccess | Boolean | Y | 외부 접속 가능 여부 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2819,16 +2984,15 @@ PUT /v4.0/db-instances/{dbInstanceId}/network-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 승격하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
 
 #### 필요 권한
 
@@ -2838,20 +3002,24 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2864,16 +3032,15 @@ POST /v4.0/db-instances/{dbInstanceId}/promote
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 재구축하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
 
 #### 필요 권한
 
@@ -2883,20 +3050,24 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -2909,16 +3080,15 @@ POST /v4.0/db-instances/{dbInstanceId}/rebuild
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 복제하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
 
 #### 필요 권한
 
@@ -2926,49 +3096,22 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 |-----|-----|
 | RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
-| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| network | Body | Object | O | 네트워크 정보 객체 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부 |
-| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
-| storage | Body | Object | X | 스토리지 정보 객체 |
-| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | X | 백업 정보 객체 |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 스토리지 자동 확장 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3009,17 +3152,50 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자 |
+| dbPort | Number | N | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Object | Y | 네트워크 정보 객체 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부 |
+| network.availabilityZone | Enum | Y | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Object | N | 스토리지 정보 객체 |
+| storage.storageType | Enum | N | 데이터 스토리지 타입 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | N | 백업 정보 객체 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3032,16 +3208,15 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
 
 #### 필요 권한
 
@@ -3051,16 +3226,20 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
-| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
-| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
-| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3071,17 +3250,19 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| useOnlineFailover | Boolean | N | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Boolean | N | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Boolean | N | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Boolean | N | 쓰기 부하 차단<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3094,16 +3275,15 @@ POST /v4.0/db-instances/{dbInstanceId}/restart
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 복원 정보 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
 
 #### 필요 권한
 
@@ -3113,38 +3293,24 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
-| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
-| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
-| restorableBackups.backup | Body | Object | 백업 정보 객체 |
-| restorableBackups.backup.backupId | Body | UUID | 백업의 식별자 |
-| restorableBackups.backup.backupName | Body | String | 백업 이름 |
-| restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
-| restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
-| restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| restorableBackups.backup.backupSize | Body | Number | 백업 크기 |
-| restorableBackups.backup.useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
-| restorableBackups.backup.failoverCount | Body | Number | 장애 조치 횟수 |
-| restorableBackups.backup.binLogFileName | Body | String | 바이너리 로그 파일 이름 |
-| restorableBackups.backup.binLogPosition | Body | Object | 바이너리 로그 파일 위치 |
-| restorableBackups.backup.createdYmdt | Body | DateTime | 백업 생성 일시 |
-| restorableBackups.backup.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
-| restorableBackups.restorableBinLogs | Body | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3180,16 +3346,33 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| oldestRestorableYmdt | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backup | Object | 백업 정보 객체 |
+| restorableBackups.backup.backupId | UUID | 백업의 식별자 |
+| restorableBackups.backup.backupName | String | 백업 이름 |
+| restorableBackups.backup.backupStatus | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.backup.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.backup.dbVersion | String | DB 엔진 유형 |
+| restorableBackups.backup.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Number | 백업 크기 |
+| restorableBackups.backup.useBackupLock | Boolean | 테이블 잠금 사용 여부 |
+| restorableBackups.backup.failoverCount | Number | 장애 조치 횟수 |
+| restorableBackups.backup.binLogFileName | String | 바이너리 로그 파일 이름 |
+| restorableBackups.backup.binLogPosition | Object | 바이너리 로그 파일 위치 |
+| restorableBackups.backup.createdYmdt | DateTime | 백업 생성 일시 |
+| restorableBackups.backup.updatedYmdt | DateTime | 백업 갱신 일시 |
+| restorableBackups.restorableBinLogs | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
 
 ---
 
 ### 복원될 마지막 쿼리 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
 
 #### 필요 권한
 
@@ -3199,21 +3382,24 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시 |
-| lastQuery | Body | String | 마지막 수행 쿼리 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3227,16 +3413,16 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| executedYmdt | DateTime | 쿼리 수행 일시 |
+| lastQuery | String | 마지막 수행 쿼리 |
 
 ---
 
 ### DB 인스턴스 복원
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
-```
 
 #### 필요 권한
 
@@ -3244,85 +3430,22 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 |-----|-----|
 | RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
-| dbPort | Body | Number | X | DB 포트 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| storage | Body | Object | X | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
-| storage.storageType | Body | Enum | X | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| network | Body | Object | X | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
-| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
-| backup | Body | Object | X | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
-| restore | Body | Object | O | 복원 정보 객체 |
-| restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
-| restore.binLog.binLogFileName | Body | String | X | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Object | X | 복원에 사용할 바이너리 로그 위치 |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
-| restore.binLog | Body | Object | X | 복원에 사용할 바이너리 로그 정보 객체 |
-
-바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3374,17 +3497,86 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
+| dbPort | Number | N | DB 포트 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Object | N | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
+| storage.storageType | Enum | N | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Object | N | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
+| network.subnetId | UUID | N | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
+| backup | Object | N | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
+| backup.backupSchedules.backupWndBgnTime | Time | N | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | N | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Object | Y | 복원 정보 객체 |
+| restore.restoreType | Enum | Y | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | String | N | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Object | N | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.restoreYmdt | DateTime | N | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Object | N | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| restore.backupId | UUID | N | 복원에 사용할 백업의 식별자 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3397,16 +3589,15 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
 
 #### 필요 권한
 
@@ -3416,20 +3607,24 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3442,16 +3637,15 @@ POST /v4.0/db-instances/{dbInstanceId}/start
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### DB 인스턴스 정지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
 
 #### 필요 권한
 
@@ -3461,20 +3655,24 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3487,16 +3685,15 @@ POST /v4.0/db-instances/{dbInstanceId}/stop
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 스토리지 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3506,27 +3703,24 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageType | Body | String | 데이터 스토리지 타입 |
-| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
-| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
-| storageAutoscale | Body | Object | 데이터 스토리지 자동 확장 객체 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부 |
-| storageAutoscale.threshold | Body | Number | 자동 확장 조건(%) |
-| storageAutoscale.maxStorageSize | Body | Number | 자동 확장 최대 크기(GB) |
-| storageAutoscale.cooldownTime | Body | Number | 자동 확장 쿨다운 시간(분) |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3547,16 +3741,22 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| storageType | String | 데이터 스토리지 타입 |
+| storageSize | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+| storageAutoscale | Object | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Boolean | 스토리지 자동 확장 여부 |
+| storageAutoscale.threshold | Number | 자동 확장 조건(%) |
+| storageAutoscale.maxStorageSize | Number | 자동 확장 최대 크기(GB) |
+| storageAutoscale.cooldownTime | Number | 자동 확장 쿨다운 시간(분) |
 
 ---
 
 ### 스토리지 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
-```
 
 #### 필요 권한
 
@@ -3564,25 +3764,22 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 |-----|-----|
 | RDSforMariaDB:DbInstance.Modify | 스토리지 정보 수정하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
-| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
-| storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부 |
+| dbInstanceId | URL | UUID | Y | DB 인스턴스의 식별자 |
 
-#### 스토리지 자동 확장 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3593,17 +3790,26 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageSize | Number | Y | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+| storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부 |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3616,8 +3822,11 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -3635,10 +3844,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 
 ### 백업 목록 조회
 
-```http
-GET /v4.0/backups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -3647,27 +3852,18 @@ GET /v4.0/backups
 
 #### 요청
 
+```http
+GET /v4.0/backups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 백업 목록 수 |
-| backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | UUID | 백업의 식별자 |
-| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
-| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| backups.dbVersion | Body | Enum | DB 엔진 유형 |
-| backups.utilVersion | Body | String | 유틸리티 버전 |
-| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
-| backups.backupSize | Body | Number | 백업의 크기(Byte) |
-| backups.createdYmdt | Body | DateTime | 생성 일시 |
-| backups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3694,16 +3890,26 @@ GET /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 백업 목록 수 |
+| backups | Array | 백업 목록 |
+| backups.backupId | UUID | 백업의 식별자 |
+| backups.backupName | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | String | DB 엔진 유형 |
+| backups.utilVersion | String | 유틸리티 버전 |
+| backups.backupType | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | DateTime | 생성 일시 |
+| backups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 백업 생성하기
-
-```http
-POST /v4.0/backups
-```
 
 #### 필요 권한
 
@@ -3713,15 +3919,14 @@ POST /v4.0/backups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupName | Body | String | O | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| baseBackupId | Body | UUID | X | 원본 백업의 식별자 |
-| dbInstanceId | Body | UUID | X | DB 인스턴스의 식별자 |
-| backupMethodType | Body | Enum | O | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
+```http
+POST /v4.0/backups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3732,17 +3937,19 @@ POST /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| backupName | String | Y | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| baseBackupId | UUID | N | 원본 백업의 식별자 |
+| dbInstanceId | UUID | N | DB 인스턴스의 식별자 |
+| backupMethodType | Enum | Y | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3755,16 +3962,15 @@ POST /v4.0/backups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 삭제하기
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
 
 #### 필요 권한
 
@@ -3774,20 +3980,24 @@ DELETE /v4.0/backups/{backupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/backups/{backupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3800,16 +4010,15 @@ DELETE /v4.0/backups/{backupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 단건 조회
-
-```http
-GET /v4.0/backups/{backupId}
-```
 
 #### 필요 권한
 
@@ -3819,37 +4028,24 @@ GET /v4.0/backups/{backupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/backups/{backupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| backup | Body | Object | 백업 상세 정보 |
-| backup.backupId | Body | UUID | 백업의 식별자 |
-| backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
-| backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
-| backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
-| backup.dbVersion | Body | Enum | DB 엔진 버전 |
-| backup.utilVersion | Body | String | 유틸리티 버전 |
-| backup.backupType | Body | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
-| backup.backupMethodType | Body | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
-| backup.backupFileType | Body | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
-| backup.backupSize | Body | Number | 백업의 크기(Byte) |
-| backup.isReplicable | Body | Boolean | 복제 가능 여부 |
-| backup.binLogFileName | Body | String | 바이너리 로그 파일명 |
-| backup.binLogPosition | Body | Object | 바이너리 로그 위치 |
-| backup.createdYmdt | Body | DateTime | 생성 일시 |
-| backup.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3881,16 +4077,32 @@ GET /v4.0/backups/{backupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| backup | Object | 백업 상세 정보 |
+| backup.backupId | UUID | 백업의 식별자 |
+| backup.regionCode | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| backup.backupName | String | 백업을 식별할 수 있는 이름 |
+| backup.backupStatus | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backup.dbInstanceId | UUID | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceName | String | 원본 DB 인스턴스의 이름 |
+| backup.dbVersion | String | DB 엔진 버전 |
+| backup.utilVersion | String | 유틸리티 버전 |
+| backup.backupType | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Number | 백업의 크기(Byte) |
+| backup.isReplicable | Boolean | 복제 가능 여부 |
+| backup.binLogFileName | String | 바이너리 로그 파일명 |
+| backup.binLogPosition | Object | 바이너리 로그 위치 |
+| backup.createdYmdt | DateTime | 생성 일시 |
+| backup.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 백업 내보내기
-
-```http
-POST /v4.0/backups/{backupId}/export
-```
 
 #### 필요 권한
 
@@ -3900,17 +4112,20 @@ POST /v4.0/backups/{backupId}/export
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
-| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
-| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
-| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
+```http
+POST /v4.0/backups/{backupId}/export
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3922,17 +4137,20 @@ POST /v4.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| tenantId | String | Y | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | String | Y | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | String | Y | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | String | Y | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | String | Y | 컨테이너에 저장될 백업의 경로 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -3945,16 +4163,15 @@ POST /v4.0/backups/{backupId}/export
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
 ### 백업 복원하기
-
-```http
-POST /v4.0/backups/{backupId}/restore
-```
 
 #### 필요 권한
 
@@ -3962,58 +4179,22 @@ POST /v4.0/backups/{backupId}/restore
 |-----|-----|
 | RDSforMariaDB:Backup.Restore | 백업 복원하기 |
 
-#### 공통 요청
+#### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+```http
+POST /v4.0/backups/{backupId}/restore
+```
+
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| backupId | URL | UUID | O |  |
-| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| dbPort | Body | Number | X | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
-| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
-| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
-| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
-| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
-| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
-| network | Body | Object | X | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
-| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
-| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
-| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
-| storage | Body | Object | X | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageType | Body | Enum | X | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
-| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
-| backup | Body | Object | X | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
-| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
-| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
-| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
-| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| backupId | URL | UUID | Y |  |
 
-#### 고가용성 사용 시
+#### 요청 본문
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-
-#### 스토리지 자동 확장 사용 시
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
-| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
-| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4057,17 +4238,59 @@ POST /v4.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceName | String | Y | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | UUID | N | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbPort | Number | N | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | UUID | N | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbSecurityGroupIds | Array | N | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Boolean | N | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Number | N | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Boolean | N | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Boolean | N | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Boolean | N | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Object | N | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| network.subnetId | UUID | N | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Boolean | N | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Enum | N | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
+| storage | Object | N | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageType | Enum | N | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageSize | Number | N | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Object | N | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageAutoscale.useStorageAutoscale | Boolean | N | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Object | N | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
+| backup.backupPeriod | Number | N | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Number | N | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Number | N | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Enum | N | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Boolean | N | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules | Array | N | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules.backupWndBgnTime | Time | Y | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Enum | Y | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 고가용성 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceCandidateName | String | Y | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Number | Y | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Number | Y | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Number | Y | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4080,8 +4303,11 @@ POST /v4.0/backups/{backupId}/restore
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 요청한 작업의 식별자 |
 
 ---
 
@@ -4098,10 +4324,6 @@ POST /v4.0/backups/{backupId}/restore
 
 ### DB 보안 그룹 목록 보기
 
-```http
-GET /v4.0/db-security-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4110,23 +4332,18 @@ GET /v4.0/db-security-groups
 
 #### 요청
 
+```http
+GET /v4.0/db-security-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4149,16 +4366,22 @@ GET /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 생성하기
-
-```http
-POST /v4.0/db-security-groups
-```
 
 #### 필요 권한
 
@@ -4168,22 +4391,14 @@ POST /v4.0/db-security-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+```http
+POST /v4.0/db-security-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4205,17 +4420,26 @@ POST /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | Y | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Array | Y | DB 보안 그룹 규칙 목록 |
+| rules.direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | Y | 포트 객체 |
+| rules.port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | String | Y | CIDR |
+| rules.description | String | N | 보안 그룹 규칙에 대한 추가 정보 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4228,16 +4452,15 @@ POST /v4.0/db-security-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
 
 ---
 
 ### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4247,11 +4470,19 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4261,10 +4492,6 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 상세 보기
 
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4273,37 +4500,24 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
-| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | 포트 객체 |
-| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | 최소 포트 범위 |
-| rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 생성 일시 |
-| rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4337,16 +4551,32 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| dbSecurityGroupId | UUID | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | UUID | DB 보안 그룹 규칙의 식별자 |
+| rules.description | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Object | 포트 객체 |
+| rules.port.portType | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Number | 최소 포트 범위 |
+| rules.port.maxPort | Number | 최대 포트 범위 |
+| rules.cidr | String | CIDR |
+| rules.createdYmdt | DateTime | 생성 일시 |
+| rules.updatedYmdt | DateTime | 수정 일시 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### DB 보안 그룹 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
 
 #### 필요 권한
 
@@ -4356,14 +4586,20 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4372,8 +4608,12 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupName | String | N | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
@@ -4383,10 +4623,6 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ### DB 보안 그룹 규칙 삭제하기
 
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4395,21 +4631,25 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleIds | Query | String | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4422,16 +4662,15 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
 
 #### 필요 권한
 
@@ -4441,20 +4680,20 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4470,17 +4709,23 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4493,16 +4738,15 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
 
 #### 필요 권한
 
@@ -4512,21 +4756,21 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | Y |  |
+| ruleId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4542,17 +4786,23 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| direction | Enum | Y | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Enum | Y | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Object | Y | 포트 객체 |
+| port.portType | Enum | Y | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Number | N | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Number | N | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | String | Y | CIDR |
+| description | String | N | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | UUID | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4565,18 +4815,17 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| jobId | UUID | 작업의 식별자 |
 
 ---
 
 ## 파라미터 그룹
 
 ### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4586,25 +4835,18 @@ GET /v4.0/parameter-groups
 
 #### 요청
 
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4629,16 +4871,24 @@ GET /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | String | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
 
 #### 필요 권한
 
@@ -4648,14 +4898,14 @@ POST /v4.0/parameter-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
+```http
+POST /v4.0/parameter-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4665,17 +4915,18 @@ POST /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | String | Y | DB 엔진 유형 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4688,16 +4939,15 @@ POST /v4.0/parameter-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4707,11 +4957,19 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4721,10 +4979,6 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 상세 보기
 
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4733,36 +4987,24 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | UUID | 파라미터의 식별자 |
-| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4794,16 +5036,31 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
+| parameterGroupName | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | String | DB 엔진 유형 |
+| parameterGroupStatus | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Array | 파라미터 목록 |
+| parameters.parameterId | UUID | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | String | 파라미터 이름 |
+| parameters.fileParameterName | String | 파라미터 파일 이름 |
+| parameters.value | String | 현재 설정된 값 |
+| parameters.defaultValue | String | 기본값 |
+| parameters.allowedValue | String | 허용된 값 |
+| parameters.updateType | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
 
 #### 필요 권한
 
@@ -4813,14 +5070,20 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4829,8 +5092,12 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | N | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
@@ -4840,10 +5107,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}
 
 ### 파라미터 그룹 복사하기
 
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4852,14 +5115,20 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4868,17 +5137,17 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupName | String | Y | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | String | N | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4891,16 +5160,15 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| parameterGroupId | UUID | 파라미터 그룹의 식별자 |
 
 ---
 
 ### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
 
 #### 필요 권한
 
@@ -4910,15 +5178,20 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -4931,8 +5204,13 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| modifiedParameters | Array | Y | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | UUID | Y | 파라미터의 식별자 |
+| modifiedParameters.value | String | Y | 변경할 파라미터 값 |
 
 #### 응답
 
@@ -4942,10 +5220,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 
 ### 파라미터 그룹 재설정하기
 
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4954,11 +5228,19 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
+| parameterGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -4970,10 +5252,6 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/reset
 
 ### 사용자 그룹 목록 보기
 
-```http
-GET /v4.0/user-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -4982,21 +5260,18 @@ GET /v4.0/user-groups
 
 #### 요청
 
+```http
+GET /v4.0/user-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
-| userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5017,16 +5292,20 @@ GET /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 사용자 그룹 목록 수 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 생성하기
-
-```http
-POST /v4.0/user-groups
-```
 
 #### 필요 권한
 
@@ -5036,14 +5315,14 @@ POST /v4.0/user-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
-| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+```http
+POST /v4.0/user-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5053,17 +5332,18 @@ POST /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | Y | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5076,16 +5356,15 @@ POST /v4.0/user-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
 
 ---
 
 ### 사용자 그룹 삭제하기
-
-```http
-DELETE /v4.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -5095,11 +5374,19 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5109,10 +5396,6 @@ DELETE /v4.0/user-groups/{userGroupId}
 
 ### 사용자 그룹 상세 보기
 
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5121,26 +5404,24 @@ GET /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5162,16 +5443,21 @@ GET /v4.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Array | 프로젝트 멤버 목록 |
+| members.memberId | UUID | 프로젝트 멤버의 식별자 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 사용자 그룹 수정하기
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
 
 #### 필요 권한
 
@@ -5181,15 +5467,20 @@ PUT /v4.0/user-groups/{userGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| userGroupId | URL | UUID | O |  |
-| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
-| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
-| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5199,8 +5490,13 @@ PUT /v4.0/user-groups/{userGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| userGroupName | String | Y | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Array | N | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Boolean | N | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 #### 응답
 
@@ -5212,10 +5508,6 @@ PUT /v4.0/user-groups/{userGroupId}
 
 ### 알림 그룹 목록 보기
 
-```http
-GET /v4.0/notification-groups
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5224,23 +5516,18 @@ GET /v4.0/notification-groups
 
 #### 요청
 
+```http
+GET /v4.0/notification-groups
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroups | Body | Array | 알림 그룹 목록 |
-| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
-| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
-| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5263,16 +5550,22 @@ GET /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroups | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 생성하기
-
-```http
-POST /v4.0/notification-groups
-```
 
 #### 필요 권한
 
@@ -5282,17 +5575,14 @@ POST /v4.0/notification-groups
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
-| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
+```http
+POST /v4.0/notification-groups
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5305,17 +5595,21 @@ POST /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | Y | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Array | Y | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | Y | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5328,16 +5622,15 @@ POST /v4.0/notification-groups
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
 
 ---
 
 ### 알림 그룹 삭제하기
-
-```http
-DELETE /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5347,11 +5640,19 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5361,10 +5662,6 @@ DELETE /v4.0/notification-groups/{notificationGroupId}
 
 ### 알림 그룹 상세 보기
 
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5373,32 +5670,24 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+GET /v4.0/notification-groups/{notificationGroupId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | 이메일 알림 여부 |
-| notifySms | Body | Boolean | SMS 알림 여부 |
-| isEnabled | Body | Boolean | 활성화 여부 |
-| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
-| userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5429,16 +5718,27 @@ GET /v4.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| notificationGroupId | UUID | 알림 그룹의 식별자 |
+| notificationGroupName | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | 이메일 알림 여부 |
+| notifySms | Boolean | SMS 알림 여부 |
+| isEnabled | Boolean | 활성화 여부 |
+| dbInstances | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | UUID | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | DateTime | 생성 일시 |
+| updatedYmdt | DateTime | 수정 일시 |
 
 ---
 
 ### 알림 그룹 수정하기
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
 
 #### 필요 권한
 
@@ -5448,18 +5748,20 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| notificationGroupId | URL | UUID | O |  |
-| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
-| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
-| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
-| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
-| dbInstanceIds | Body | Array | X | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+```http
+PUT /v4.0/notification-groups/{notificationGroupId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5472,8 +5774,16 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupName | String | N | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Boolean | N | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Boolean | N | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Boolean | N | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Array | N | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Array | N | 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
@@ -5485,10 +5795,6 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 ### 통계 정보 조회
 
-```http
-GET /v4.0/metric-statistics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5496,6 +5802,12 @@ GET /v4.0/metric-statistics
 | RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청 본문
 
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -5507,10 +5819,6 @@ GET /v4.0/metric-statistics
 
 ### Metric 목록 보기
 
-```http
-GET /v4.0/metrics
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5519,18 +5827,18 @@ GET /v4.0/metrics
 
 #### 요청
 
+```http
+GET /v4.0/metrics
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.measureName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5548,8 +5856,13 @@ GET /v4.0/metrics
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| metrics | Array | Metric 목록 |
+| metrics.measureName | String | 조회 지표 유형 |
+| metrics.unit | String | 측정값 단위 |
 
 ---
 
@@ -5570,10 +5883,6 @@ GET /v4.0/metrics
 
 ### 구독 가능한 이벤트 코드 목록 보기
 
-```http
-GET /v4.0/event-codes
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5582,18 +5891,18 @@ GET /v4.0/event-codes
 
 #### 요청
 
+```http
+GET /v4.0/event-codes
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventCodes | Body | Array | 이벤트 코드 목록 |
-| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
-| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5611,16 +5920,17 @@ GET /v4.0/event-codes
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventCodes | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 ---
 
 ### 이벤트 목록 조회
-
-```http
-GET /v4.0/events
-```
 
 #### 필요 권한
 
@@ -5630,25 +5940,18 @@ GET /v4.0/events
 
 #### 요청
 
+```http
+GET /v4.0/events
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 목록 수 |
-| events | Body | Array | 이벤트 목록 |
-| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
-| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
-| events.messages | Body | Array | 이벤트 메세지 목록 |
-| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
-| events.messages.message | Body | String | 이벤트 메세지 |
-| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5676,18 +5979,26 @@ GET /v4.0/events
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 목록 수 |
+| events | Array | 이벤트 목록 |
+| events.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | UUID | 이벤트 소스의 식별자 |
+| events.sourceName | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | String | 이벤트 메세지 |
+| events.eventYmdt | DateTime | 이벤트 발생 일시 |
 
 ---
 
 ## 이벤트 구독
 
 ### 이벤트 구독 목록 조회
-
-```http
-GET /v4.0/event-subscriptions
-```
 
 #### 필요 권한
 
@@ -5697,29 +6008,18 @@ GET /v4.0/event-subscriptions
 
 #### 요청
 
+```http
+GET /v4.0/event-subscriptions
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
-| eventSubscriptions | Body | Array | 이벤트 구독 목록 |
-| eventSubscriptions.eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
-| eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
-| eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
-| eventSubscriptions.notifyEmail | Body | Boolean | 이메일 발송 여부 |
-| eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
-| eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
-| eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
-| eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
-| eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5753,16 +6053,28 @@ GET /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| totalCounts | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | UUID | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | DateTime | 생성 일시 |
 
 ---
 
 ### 이벤트 구독 생성하기
-
-```http
-POST /v4.0/event-subscriptions
-```
 
 #### 필요 권한
 
@@ -5772,21 +6084,14 @@ POST /v4.0/event-subscriptions
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | O | 이벤트 구독을 식별할 수 있는 이름 |
-| enabled | Body | Boolean | O | 활성화 여부 |
-| notifyEmail | Body | Boolean | O | 이메일 발송 여부 |
-| notifySms | Body | Boolean | O | SMS 발송 여부 |
-| eventCodes | Body | Array | O | 구독할 이벤트 코드 목록 |
-| sources | Body | Array | O | 구독할 이벤트 소스 목록 |
-| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
-| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | O | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+```http
+POST /v4.0/event-subscriptions
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5806,17 +6111,25 @@ POST /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | Y | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | Y | 활성화 여부 |
+| notifyEmail | Boolean | Y | 이메일 발송 여부 |
+| notifySms | Boolean | Y | SMS 발송 여부 |
+| eventCodes | Array | Y | 구독할 이벤트 코드 목록 |
+| sources | Array | Y | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | Y | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5829,16 +6142,15 @@ POST /v4.0/event-subscriptions
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| eventSubscriptionId | UUID | 이벤트 구독의 식별자 |
 
 ---
 
 ### 이벤트 구독 삭제하기
-
-```http
-DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
-```
 
 #### 필요 권한
 
@@ -5848,11 +6160,19 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
+```http
+DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
 |-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
@@ -5862,10 +6182,6 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### 이벤트 구독 수정하기
 
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5874,22 +6190,20 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| eventSubscriptionId | URL | UUID | O |  |
-| eventCategoryType | Body | Enum | X | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| eventSubscriptionName | Body | String | X | 이벤트 구독을 식별할 수 있는 이름 |
-| enabled | Body | Boolean | X | 활성화 여부 |
-| notifyEmail | Body | Boolean | X | 이메일 발송 여부 |
-| notifySms | Body | Boolean | X | SMS 발송 여부 |
-| eventCodes | Body | Array | X | 구독할 이벤트 코드 목록 |
-| sources | Body | Array | X | 구독할 이벤트 소스 목록 |
-| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
-| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
-| userGroupIds | Body | Array | X | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
 
-<details><summary>예시</summary>
-<p>
+#### 요청 파라미터
+
+| 이름 | 구분 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | Y |  |
+
+#### 요청 본문
+
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5909,8 +6223,20 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 필수 | 설명 |
+|-----|-----|-----|-----|
+| eventCategoryType | Enum | N | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | String | N | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Boolean | N | 활성화 여부 |
+| notifyEmail | Boolean | N | 이메일 발송 여부 |
+| notifySms | Boolean | N | SMS 발송 여부 |
+| eventCodes | Array | N | 구독할 이벤트 코드 목록 |
+| sources | Array | N | 구독할 이벤트 소스 목록 |
+| sources.sourceId | UUID | Y | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Enum | Y | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Array | N | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 #### 응답
 
@@ -5922,10 +6248,6 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ### 가용성 영역 목록 보기
 
-```http
-GET /v4.0/availability-zones
-```
-
 #### 필요 권한
 
 | 권한명 | 설명 |
@@ -5934,19 +6256,18 @@ GET /v4.0/availability-zones
 
 #### 요청
 
+```http
+GET /v4.0/availability-zones
+```
+
+#### 요청 본문
+
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | 가용성 영역 목록 |
-| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
-| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
-| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
+<details>
+  <summary><strong>예시 코드</strong></summary>
 
 ```json
 {
@@ -5966,8 +6287,14 @@ GET /v4.0/availability-zones
 }
 ```
 
-</p>
 </details>
+
+| 이름 | 타입 | 설명 |
+|-----|-----|-----|
+| availabilityZones | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Boolean | 가용성 영역의 사용 가능 여부 |
 
 ---
 

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -109,6 +109,9 @@ GET /v4.0/project/members
     },
     "members": [
         {
+            "memberId": "memberId-example",
+            "memberName": "memberName-example",
+            "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
         }
     ]
@@ -150,6 +153,7 @@ GET /v4.0/project/regions
     },
     "regions": [
         {
+            "regionCode": "KR1",
             "isEnabled": false
         }
     ]
@@ -195,6 +199,9 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
+            "dbFlavorId": "dbFlavorId-example",
+            "dbFlavorName": "dbFlavorName-example",
+            "ram": 1,
             "vcpus": 1
         }
     ]
@@ -223,7 +230,7 @@ GET /v4.0/network/subnets
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnets.subnetCidr | Body | String | 서브넷의 CIDR |
 | subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
@@ -241,6 +248,10 @@ GET /v4.0/network/subnets
     },
     "subnets": [
         {
+            "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+            "subnetName": "subnetName-example",
+            "subnetCidr": "subnetCidr-example",
+            "usingGateway": false,
             "availableIpCount": 1
         }
     ]
@@ -285,6 +296,8 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
+            "dbVersion": "dbVersion-example",
+            "dbVersionName": "dbVersionName-example",
             "restorableFromObs": false
         }
     ]
@@ -392,6 +405,7 @@ GET /v4.0/jobs/{jobId}
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
+            "resourceType": "resourceType-example",
             "resourceId": "resourceId-example"
         }
     ],
@@ -439,6 +453,9 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "replicationType": "STANDALONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -491,6 +508,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
     ],
@@ -590,6 +609,16 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceName": "dbInstanceName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "dbPort": 1,
+            "dbInstanceType": "MASTER",
+            "dbInstanceStatus": "BEFORE_CREATE",
+            "progressStatus": "NONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -703,6 +732,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -832,6 +862,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1129,6 +1160,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1172,6 +1204,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
+            "backupWndBgnTime": "backupWndBgnTime-example",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1241,6 +1274,8 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
+            "binLogFileName": "binLogFileName-example",
+            "binLogFileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1319,6 +1354,9 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
+            "fileName": "fileName-example",
+            "certificateType": "CA_FILE",
+            "fileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1426,6 +1464,9 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
+            "dbSchemaId": "dbSchemaId-example",
+            "dbSchemaName": "dbSchemaName-example",
+            "dbSchemaStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -1568,6 +1609,14 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
+            "dbUserId": "dbUserId-example",
+            "dbUserName": "dbUserName-example",
+            "host": "host-example",
+            "authorityType": "CUSTOM",
+            "dbUserStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
+            "updatedYmdt": "2023-12-31T15:00:00+09:00",
+            "authenticationPlugin": "NATIVE",
             "tlsOption": "NONE"
         }
     ]
@@ -2082,6 +2131,9 @@ GET /v4.0/db-instances/{dbInstanceId}/log-files
     },
     "logFiles": [
         {
+            "logFileName": "logFileName-example",
+            "logFileType": "ERROR",
+            "logFileSize": 1,
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2243,6 +2295,19 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
     "totalCounts": 1,
     "maintenances": [
         {
+            "maintenanceId": "maintenanceId-example",
+            "dbInstanceId": "dbInstanceId-example",
+            "category": "USER",
+            "description": "description-example",
+            "type": "UPDATE_DB_INSTANCE",
+            "payload": {
+            },
+            "required": false,
+            "deadlineYmdt": "2023-12-31T15:00:00+09:00",
+            "status": "PENDING",
+            "executionType": "SCHEDULED",
+            "addedYmdt": "2023-12-31T15:00:00+09:00",
+            "executionStartedYmdt": "2023-12-31T15:00:00+09:00",
             "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -2418,6 +2483,8 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     },
     "endPoints": [
         {
+            "domain": "domain-example",
+            "ipAddress": "ipAddress-example",
             "endPointType": "endPointType-example"
         }
     ]
@@ -2638,6 +2705,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -2781,6 +2849,23 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
     "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
     "restorableBackups": [
         {
+            "backup": {
+                "backupId": "backupId-example",
+                "backupName": "backupName-example",
+                "backupStatus": "BACKING_UP",
+                "dbInstanceId": "dbInstanceId-example",
+                "dbInstanceName": "dbInstanceName-example",
+                "dbVersion": "ENUM_VALUE",
+                "backupType": "AUTO",
+                "backupSize": 1,
+                "useBackupLock": false,
+                "failoverCount": 1,
+                "binLogFileName": "binLogFileName-example",
+                "binLogPosition": {
+                },
+                "createdYmdt": "2023-12-31T15:00:00+09:00",
+                "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            },
             "restorableBinLogs": []
         }
     ]
@@ -2947,6 +3032,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3243,6 +3329,15 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
+            "backupId": "backupId-example",
+            "backupName": "backupName-example",
+            "backupStatus": "BACKING_UP",
+            "dbInstanceId": "dbInstanceId-example",
+            "dbVersion": "ENUM_VALUE",
+            "utilVersion": "utilVersion-example",
+            "backupType": "AUTO",
+            "backupSize": 1,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3574,6 +3669,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
+                "backupWndBgnTime": "backupWndBgnTime-example",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3656,6 +3752,11 @@ GET /v4.0/db-security-groups
     "totalCounts": 1,
     "dbSecurityGroups": [
         {
+            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupName": "dbSecurityGroupName-example",
+            "description": "description-example",
+            "progressStatus": "NONE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -3698,6 +3799,14 @@ POST /v4.0/db-security-groups
     "description": "description-example",
     "rules": [
         {
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 3306,
+                "maxPort": 1
+            },
+            "cidr": "cidr-example",
             "description": "description-example"
         }
     ]
@@ -3805,6 +3914,17 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
     "progressStatus": "NONE",
     "rules": [
         {
+            "ruleId": "ruleId-example",
+            "description": "description-example",
+            "direction": "INGRESS",
+            "etherType": "IPV4",
+            "port": {
+                "portType": "ALL",
+                "minPort": 1,
+                "maxPort": 1
+            },
+            "cidr": "cidr-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ],
@@ -4062,6 +4182,13 @@ GET /v4.0/parameter-groups
     "totalCounts": 1,
     "parameterGroups": [
         {
+            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupName": "parameterGroupName-example",
+            "description": "description-example",
+            "dbVersion": "ENUM_VALUE",
+            "parameterGroupType": "USER",
+            "parameterGroupStatus": "STABLE",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4199,6 +4326,14 @@ GET /v4.0/parameter-groups/{parameterGroupId}
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
+            "parameterId": "parameterId-example",
+            "parameterFileGroup": "CLIENT",
+            "parameterName": "parameterName-example",
+            "fileParameterName": "fileParameterName-example",
+            "value": "value-example",
+            "defaultValue": "defaultValue-example",
+            "allowedValue": "allowedValue-example",
+            "updateType": "VARIABLE",
             "applyType": "BOTH"
         }
     ],
@@ -4319,6 +4454,7 @@ PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
 {
     "modifiedParameters": [
         {
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
             "value": "value-example"
         }
     ]
@@ -4390,6 +4526,9 @@ GET /v4.0/user-groups
     "totalCounts": 1,
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
+            "userGroupName": "userGroupName-example",
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4600,6 +4739,12 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
+            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupName": "notificationGroupName-example",
+            "notifyEmail": false,
+            "notifySms": false,
+            "isEnabled": false,
+            "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -4739,11 +4884,13 @@ GET /v4.0/notification-groups/{notificationGroupId}
     "isEnabled": false,
     "dbInstances": [
         {
+            "dbInstanceId": "dbInstanceId-example",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
+            "userGroupId": "userGroupId-example",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -4846,6 +4993,7 @@ GET /v4.0/metrics
     },
     "metrics": [
         {
+            "measureName": "measureName-example",
             "unit": "unit-example"
         }
     ]
@@ -4902,6 +5050,7 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
+            "eventCode": "ENUM_VALUE",
             "eventCategoryType": "ALL"
         }
     ]
@@ -4951,6 +5100,16 @@ GET /v4.0/events
     "totalCounts": 1,
     "events": [
         {
+            "eventCategoryType": "ALL",
+            "eventCode": "ENUM_VALUE",
+            "sourceId": "sourceId-example",
+            "sourceName": "sourceName-example",
+            "messages": [
+                {
+                    "langCode": "KO",
+                    "message": "message-example"
+                }
+            ],
             "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -5006,6 +5165,20 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
+            "eventSubscriptionId": "eventSubscriptionId-example",
+            "eventCategoryType": "ALL",
+            "eventSubscriptionName": "eventSubscriptionName-example",
+            "enabled": false,
+            "notifyEmail": false,
+            "notifySms": false,
+            "eventCodes": [],
+            "sources": [
+                {
+                    "sourceId": "sourceId-example",
+                    "eventCategoryType": "ALL"
+                }
+            ],
+            "userGroupIds": [],
             "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
@@ -5051,6 +5224,7 @@ POST /v4.0/event-subscriptions
     "eventCodes": [],
     "sources": [
         {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL"
         }
     ],
@@ -5141,6 +5315,7 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
     "eventCodes": [],
     "sources": [
         {
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL"
         }
     ],
@@ -5190,6 +5365,7 @@ GET /v4.0/availability-zones
     },
     "availabilityZones": [
         {
+            "availabilityZoneName": "availabilityZoneName-example",
             "zoneState": {
                 "available": false
             }

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -99,7 +99,7 @@ GET /v4.0/project/members
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | members.memberName | Body | String | 프로젝트 멤버의 이름 |
 | members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
 | members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
@@ -116,7 +116,7 @@ GET /v4.0/project/members
     },
     "members": [
         {
-            "memberId": "memberId-example",
+            "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
             "emailAddress": "emailAddress-example",
             "phoneNumber": "phoneNumber-example"
@@ -201,7 +201,7 @@ GET /v4.0/db-flavors
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
 | dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
 | dbFlavors.ram | Body | Number | 메모리 용량(MB) |
 | dbFlavors.vcpus | Body | Number | CPU 코어 수 |
@@ -218,7 +218,7 @@ GET /v4.0/db-flavors
     },
     "dbFlavors": [
         {
-            "dbFlavorId": "dbFlavorId-example",
+            "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
             "dbFlavorName": "dbFlavorName-example",
             "ram": 1,
             "vcpus": 1
@@ -327,7 +327,7 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "dbVersion-example",
+            "dbVersion": "MYSQL_V8036",
             "dbVersionName": "dbVersionName-example",
             "restorableFromObs": false
         }
@@ -426,7 +426,7 @@ GET /v4.0/jobs/{jobId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 | jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
 | resourceRelations | Body | Array | 연관 리소스 목록 |
 | resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
@@ -444,7 +444,7 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
     "jobStatus": "DELETED",
     "resourceRelations": [
         {
@@ -485,7 +485,7 @@ GET /v4.0/db-instance-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
 | dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
@@ -502,7 +502,7 @@ GET /v4.0/db-instance-groups
     },
     "dbInstanceGroups": [
         {
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "replicationType": "STANDALONE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
@@ -540,10 +540,10 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
 | dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | createdYmdt | Body | DateTime | 생성 일시 |
@@ -559,11 +559,11 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "replicationType": "STANDALONE",
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE"
         }
@@ -646,8 +646,8 @@ GET /v4.0/db-instances
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbInstances | Body | Array | DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
@@ -670,11 +670,11 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
-            "dbInstanceGroupId": "dbInstanceGroupId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "MYSQL_V8036",
             "dbPort": 1,
             "dbInstanceType": "MASTER",
             "dbInstanceStatus": "BEFORE_CREATE",
@@ -765,7 +765,7 @@ POST /v4.0/db-instances
     "dbInstanceName": "dbInstanceName",
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "dbPort": 1,
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
@@ -782,10 +782,10 @@ POST /v4.0/db-instances
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -912,11 +912,11 @@ POST /v4.0/db-instances/restore-from-obs
     "description": "description-example",
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "dbPort": 1,
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "useHighAvailability": false,
     "pingInterval": 3,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -925,7 +925,7 @@ POST /v4.0/db-instances/restore-from-obs
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -1064,8 +1064,8 @@ GET /v4.0/db-instances/{dbInstanceId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | UUID | DB 인스턴스 그룹의 식별자 |
 | dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | description | Body | String | DB 인스턴스에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 유형 |
@@ -1073,8 +1073,8 @@ GET /v4.0/db-instances/{dbInstanceId}
 | dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
 | dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
 | progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
-| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbFlavorId | Body | UUID | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
 | dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
 | notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
 | useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
@@ -1096,17 +1096,17 @@ GET /v4.0/db-instances/{dbInstanceId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbInstanceId": "dbInstanceId-example",
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbInstanceName": "dbInstanceName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "dbPort": 1,
     "dbInstanceType": "MASTER",
     "dbInstanceStatus": "BEFORE_CREATE",
     "progressStatus": "NONE",
-    "dbFlavorId": "dbFlavorId-example",
-    "parameterGroupId": "parameterGroupId-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupIds": [],
     "notificationGroupIds": [],
     "useDeletionProtection": false,
@@ -1168,7 +1168,7 @@ PUT /v4.0/db-instances/{dbInstanceId}
     "dbPort": 1,
     "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "useSlowQueryAnalysis": false,
     "useDummy": false,
     "dbSecurityGroupIds": [],
@@ -1580,7 +1580,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbSchemas | Body | Array | DB 스키마 목록 |
-| dbSchemas.dbSchemaId | Body | String | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaId | Body | UUID | DB 스키마의 식별자 |
 | dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
 | dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
 | dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
@@ -1597,7 +1597,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-schemas
     },
     "dbSchemas": [
         {
-            "dbSchemaId": "dbSchemaId-example",
+            "dbSchemaId": "550e8400-e29b-41d4-a716-446655440000",
             "dbSchemaName": "dbSchemaName-example",
             "dbSchemaStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00"
@@ -1738,7 +1738,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | dbUsers | Body | Array | DB 사용자 목록 |
-| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserId | Body | UUID | DB 사용자의 식별자 |
 | dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
 | dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
 | dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
@@ -1760,7 +1760,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
     },
     "dbUsers": [
         {
-            "dbUserId": "dbUserId-example",
+            "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
             "host": "host-example",
             "authorityType": "CUSTOM",
@@ -2509,8 +2509,8 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 유지 관리 목록 갯수 |
 | maintenances | Body | Array | 유지 관리 목록 |
-| maintenances.maintenanceId | Body | String | 유지 관리 아이디 |
-| maintenances.dbInstanceId | Body | String | DB 인스턴스 아이디 |
+| maintenances.maintenanceId | Body | UUID | 유지 관리 아이디 |
+| maintenances.dbInstanceId | Body | UUID | DB 인스턴스 아이디 |
 | maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
 | maintenances.description | Body | String | 유지 관리 설명 |
 | maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
@@ -2536,8 +2536,8 @@ GET /v4.0/db-instances/{dbInstanceId}/maintenances
     "totalCounts": 1,
     "maintenances": [
         {
-            "maintenanceId": "maintenanceId-example",
-            "dbInstanceId": "dbInstanceId-example",
+            "maintenanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "category": "USER",
             "description": "description-example",
             "type": "UPDATE_DB_INSTANCE",
@@ -2722,7 +2722,7 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 |-----|-----|-----|-----|
 | availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
 | subnet | Body | Object | 서브넷 객체 |
-| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetId | Body | UUID | 서브넷의 식별자 |
 | subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
 | subnet.subnetCidr | Body | String | 서브넷의 CIDR |
 | endPoints | Body | Array | 접속 정보 목록 |
@@ -2740,9 +2740,9 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "availabilityZone-example",
+    "availabilityZone": "kr-pub-a",
     "subnet": {
-        "subnetId": "subnetId-example",
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
         "subnetCidr": "subnetCidr-example"
     },
@@ -2977,10 +2977,10 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
     "useSlowQueryAnalysis": true,
     "network": {
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -3120,10 +3120,10 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
 | latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
 | restorableBackups | Body | Array | 복원 가능한 백업 목록 |
 | restorableBackups.backup | Body | Object | 백업 정보 객체 |
-| restorableBackups.backup.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backup.backupId | Body | UUID | 백업의 식별자 |
 | restorableBackups.backup.backupName | Body | String | 백업 이름 |
 | restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| restorableBackups.backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
 | restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
 | restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
@@ -3151,12 +3151,12 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info
     "restorableBackups": [
         {
             "backup": {
-                "backupId": "backupId-example",
+                "backupId": "550e8400-e29b-41d4-a716-446655440000",
                 "backupName": "backupName-example",
                 "backupStatus": "BACKING_UP",
-                "dbInstanceId": "dbInstanceId-example",
+                "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
                 "dbInstanceName": "dbInstanceName-example",
-                "dbVersion": "ENUM_VALUE",
+                "dbVersion": "MYSQL_V8036",
                 "backupType": "AUTO",
                 "backupSize": 1,
                 "useBackupLock": false,
@@ -3326,7 +3326,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
     "useHighAvailability": false,
     "pingInterval": 3,
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -3335,7 +3335,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "backup": {
         "backupPeriod": 0,
@@ -3528,7 +3528,7 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "storageType-example",
+    "storageType": "General SSD",
     "storageSize": 1,
     "storageStatus": "DELETED",
     "storageAutoscale": {
@@ -3648,10 +3648,10 @@ GET /v4.0/backups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 백업 목록 수 |
 | backups | Body | Array | 백업 목록 |
-| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupId | Body | UUID | 백업의 식별자 |
 | backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
 | backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | backups.dbVersion | Body | Enum | DB 엔진 유형 |
 | backups.utilVersion | Body | String | 유틸리티 버전 |
 | backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
@@ -3672,11 +3672,11 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "backupId-example",
+            "backupId": "550e8400-e29b-41d4-a716-446655440000",
             "backupName": "backupName-example",
             "backupStatus": "BACKING_UP",
-            "dbInstanceId": "dbInstanceId-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+            "dbVersion": "MYSQL_V8036",
             "utilVersion": "utilVersion-example",
             "backupType": "AUTO",
             "backupSize": 1,
@@ -3823,11 +3823,11 @@ GET /v4.0/backups/{backupId}
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | backup | Body | Object | 백업 상세 정보 |
-| backup.backupId | Body | String | 백업의 식별자 |
+| backup.backupId | Body | UUID | 백업의 식별자 |
 | backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
 | backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
 | backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
-| backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceId | Body | UUID | 원본 DB 인스턴스의 식별자 |
 | backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
 | backup.dbVersion | Body | Enum | DB 엔진 버전 |
 | backup.utilVersion | Body | String | 유틸리티 버전 |
@@ -3852,13 +3852,13 @@ GET /v4.0/backups/{backupId}
         "isSuccessful": true
     },
     "backup": {
-        "backupId": "backupId-example",
+        "backupId": "550e8400-e29b-41d4-a716-446655440000",
         "regionCode": "KR1",
         "backupName": "backupName-example",
         "backupStatus": "BACKING_UP",
-        "dbInstanceId": "dbInstanceId-example",
+        "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
         "dbInstanceName": "dbInstanceName-example",
-        "dbVersion": "ENUM_VALUE",
+        "dbVersion": "MYSQL_V8036",
         "utilVersion": "utilVersion-example",
         "backupType": "AUTO",
         "backupMethodType": "FULL",
@@ -4025,10 +4025,10 @@ POST /v4.0/backups/{backupId}/restore
     "network": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "usePublicAccess": false,
-        "availabilityZone": "ENUM_VALUE"
+        "availabilityZone": "kr-pub-a"
     },
     "storage": {
-        "storageType": "ENUM_VALUE",
+        "storageType": "General SSD",
         "storageSize": 20,
         "storageAutoscale": {
             "useStorageAutoscale": false
@@ -4111,7 +4111,7 @@ GET /v4.0/db-security-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
 | dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
 | dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
@@ -4131,7 +4131,7 @@ GET /v4.0/db-security-groups
     "totalCounts": 1,
     "dbSecurityGroups": [
         {
-            "dbSecurityGroupId": "dbSecurityGroupId-example",
+            "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "dbSecurityGroupName": "dbSecurityGroupName-example",
             "description": "description-example",
             "progressStatus": "NONE",
@@ -4205,7 +4205,7 @@ POST /v4.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4217,7 +4217,7 @@ POST /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4276,12 +4276,12 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
 | dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
 | description | Body | String | DB 보안 그룹에 대한 추가 정보 |
 | progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
 | rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.ruleId | Body | UUID | DB 보안 그룹 규칙의 식별자 |
 | rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
 | rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
 | rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
@@ -4305,13 +4305,13 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupName": "dbSecurityGroupName-example",
     "description": "description-example",
     "progressStatus": "NONE",
     "rules": [
         {
-            "ruleId": "ruleId-example",
+            "ruleId": "550e8400-e29b-41d4-a716-446655440000",
             "description": "description-example",
             "direction": "INGRESS",
             "etherType": "IPV4",
@@ -4399,7 +4399,7 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4411,7 +4411,7 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4470,7 +4470,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4482,7 +4482,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4542,7 +4542,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| jobId | Body | UUID | 작업의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4554,7 +4554,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4587,7 +4587,7 @@ GET /v4.0/parameter-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 파라미터 그룹 수 |
 | parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
@@ -4609,10 +4609,10 @@ GET /v4.0/parameter-groups
     "totalCounts": 1,
     "parameterGroups": [
         {
-            "parameterGroupId": "parameterGroupId-example",
+            "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "parameterGroupName": "parameterGroupName-example",
             "description": "description-example",
-            "dbVersion": "ENUM_VALUE",
+            "dbVersion": "MYSQL_V8036",
             "parameterGroupType": "USER",
             "parameterGroupStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -4654,7 +4654,7 @@ POST /v4.0/parameter-groups
 {
     "parameterGroupName": "parameterGroupName",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
+    "dbVersion": "MYSQL_V8036"
 }
 ```
 
@@ -4665,7 +4665,7 @@ POST /v4.0/parameter-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4677,7 +4677,7 @@ POST /v4.0/parameter-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4736,13 +4736,13 @@ GET /v4.0/parameter-groups/{parameterGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 | parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
 | description | Body | String | 파라미터 그룹에 대한 추가 정보 |
 | dbVersion | Body | Enum | DB 엔진 유형 |
 | parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
 | parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterId | Body | UUID | 파라미터의 식별자 |
 | parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
 | parameters.parameterName | Body | String | 파라미터 이름 |
 | parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
@@ -4764,14 +4764,14 @@ GET /v4.0/parameter-groups/{parameterGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "parameterGroupName": "parameterGroupName-example",
     "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
+    "dbVersion": "MYSQL_V8036",
     "parameterGroupStatus": "STABLE",
     "parameters": [
         {
-            "parameterId": "parameterId-example",
+            "parameterId": "550e8400-e29b-41d4-a716-446655440000",
             "parameterFileGroup": "CLIENT",
             "parameterName": "parameterName-example",
             "fileParameterName": "fileParameterName-example",
@@ -4868,7 +4868,7 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4880,7 +4880,7 @@ POST /v4.0/parameter-groups/{parameterGroupId}/copy
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "parameterGroupId": "parameterGroupId-example"
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4983,7 +4983,7 @@ GET /v4.0/user-groups
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
 | userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroups.createdYmdt | Body | DateTime | 생성 일시 |
 | userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
@@ -5001,7 +5001,7 @@ GET /v4.0/user-groups
     "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
@@ -5053,7 +5053,7 @@ POST /v4.0/user-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5065,7 +5065,7 @@ POST /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example"
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5124,11 +5124,11 @@ GET /v4.0/user-groups/{userGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
 | members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberId | Body | UUID | 프로젝트 멤버의 식별자 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
 
@@ -5142,12 +5142,12 @@ GET /v4.0/user-groups/{userGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "userGroupId": "userGroupId-example",
+    "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "userGroupName": "userGroupName-example",
     "userGroupTypeCode": "ENTIRE",
     "members": [
         {
-            "memberId": "memberId-example"
+            "memberId": "550e8400-e29b-41d4-a716-446655440000"
         }
     ],
     "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -5224,7 +5224,7 @@ GET /v4.0/notification-groups
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
 | notificationGroups | Body | Array | 알림 그룹 목록 |
-| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
 | notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
@@ -5244,7 +5244,7 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "notificationGroupId-example",
+            "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "notificationGroupName": "notificationGroupName-example",
             "notifyEmail": false,
             "notifySms": false,
@@ -5305,7 +5305,7 @@ POST /v4.0/notification-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5317,7 +5317,7 @@ POST /v4.0/notification-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example"
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -5376,16 +5376,16 @@ GET /v4.0/notification-groups/{notificationGroupId}
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
 | notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
 | notifyEmail | Body | Boolean | 이메일 알림 여부 |
 | notifySms | Body | Boolean | SMS 알림 여부 |
 | isEnabled | Body | Boolean | 활성화 여부 |
 | dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceId | Body | UUID | DB 인스턴스의 식별자 |
 | dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
 | userGroups | Body | Array | 사용자 그룹 목록 |
-| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupId | Body | UUID | 사용자 그룹의 식별자 |
 | userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
 | createdYmdt | Body | DateTime | 생성 일시 |
 | updatedYmdt | Body | DateTime | 수정 일시 |
@@ -5400,20 +5400,20 @@ GET /v4.0/notification-groups/{notificationGroupId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "notificationGroupName": "notificationGroupName-example",
     "notifyEmail": false,
     "notifySms": false,
     "isEnabled": false,
     "dbInstances": [
         {
-            "dbInstanceId": "dbInstanceId-example",
+            "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
             "dbInstanceName": "dbInstanceName-example"
         }
     ],
     "userGroups": [
         {
-            "userGroupId": "userGroupId-example",
+            "userGroupId": "550e8400-e29b-41d4-a716-446655440000",
             "userGroupName": "userGroupName-example"
         }
     ],
@@ -5698,7 +5698,7 @@ GET /v4.0/event-subscriptions
 |-----|-----|-----|-----|
 | totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
 | eventSubscriptions | Body | Array | 이벤트 구독 목록 |
-| eventSubscriptions.eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
 | eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
 | eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
@@ -5724,7 +5724,7 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "eventSubscriptionId-example",
+            "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000",
             "eventCategoryType": "ALL",
             "eventSubscriptionName": "eventSubscriptionName-example",
             "enabled": false,
@@ -5804,7 +5804,7 @@ POST /v4.0/event-subscriptions
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptionId | Body | UUID | 이벤트 구독의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5816,7 +5816,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "eventSubscriptionId-example"
+    "eventSubscriptionId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -2,36 +2,29 @@
 
 ## RDS for MariaDB API 공통 정보
 
-### API 엔드포인트
-
-| 리전        | 엔드포인트                                         |
-|-----------|-----------------------------------------------|
-| 한국(판교) 리전 | https://kr1-rds-mariadb.api.nhncloudservice.com |
-
 ### 인증 및 권한
 
 RDS for MariaDB은(는) API 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 발급 받은 토큰은 Appkey와 함께 요청 Header에 포함해야 합니다.
 
-| 이름                  | 종류     | 형식     | 필수 | 설명                                                          |
-|---------------------|--------|--------|----|-------------------------------------------------------------|
-| X-TC-APP-KEY        | Header | String | O  | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
-| X-NHN-AUTHORIZATION | Header | String | O  | Public API로 발급 받은 Bearer 유형 토큰                              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| X-TC-APP-KEY | Header | String | O | RDS for MariaDB 서비스의 Appkey 또는 프로젝트 통합 Appkey |
+| X-NHN-AUTHORIZATION | Header | String | O | Public API로 발급 받은 Bearer 유형 토큰 |
 
+또한 프로젝트 권한에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER` 역할에는 아래처럼 기본 권한이 부여돼 있고 프로젝트 내 역할 그룹 관리 메뉴에서 필요한 권한만 부여할 수 있습니다.
 
-또한 프로젝트 멤버 역할에 따라 호출할 수 있는 API가 제한됩니다. `RDS for MariaDB ADMIN`, `RDS for MariaDB VIEWER`로 구분하여 권한을 부여할 수 있습니다.
-
-* `RDS for MariaDB ADMIN` 권한은 모든 기능을 사용 가능합니다.
-* `RDS for MariaDB VIEWER` 권한은 정보를 조회하는 기능만 사용 가능합니다.
+* `RDS for MariaDB ADMIN` 역할은 API 실행에 필요한 모든 권한이 부여됩니다.
+* `RDS for MariaDB VIEWER` 역할은 정보를 조회하는 권한만 부여됩니다.
     * DB 인스턴스를 생성, 수정, 삭제하거나, DB 인스턴스를 대상으로 하는 어떠한 기능도 사용할 수 없습니다.
-    * 단, 알림 그룹 및 사용자 그룹 관련 기능은 사용 가능합니다.
+    * 단, 알림 그룹과 사용자 그룹 관련된 기능은 사용할 수 있습니다.
 
 API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같은 오류가 발생합니다.
 
-| resultCode | resultMessage | 설명          |
-|------------|---------------|-------------|
-| 80401      | Unauthorized  | 인증에 실패했습니다. |
-| 80403      | Forbidden     | 권한이 없습니다.   |
+| resultCode | resultMessage | 설명 |
+|------------|---------------|-----|
+| 80401 | Unauthorized | 인증에 실패했습니다. |
+| 80403 | Forbidden | 권한이 없습니다. |
 
 ### 응답 공통 정보
 
@@ -49,43 +42,55 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 ```
 
 #### 필드
-| 이름            | 형식      | 설명                                      |
-|---------------|---------|-----------------------------------------|
-| resultCode    | Number  | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
-| resultMessage | String  | 결과 메시지                                  |
-| isSuccessful  | Boolean | 성공 여부                                   |
+| 이름 | 형식 | 설명 |
+|-----|-----|-----|
+| resultCode | Number | 결과 코드<br/>- 성공: `0`<br/>- 실패: `0`이 아닌 값 |
+| resultMessage | String | 결과 메시지 |
+| isSuccessful | Boolean | 성공 여부 |
 
+### API 엔드포인트
+
+| 리전 | 엔드포인트 |
+|------|----------|
+| 한국(판교) 리전 | https://kr1-rds-mariadb.api.nhncloudservice.com |
 
 ### DB 엔진 유형
 
-| DB 엔진 유형        | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
-|-----------------|----------|------------------|--|
-| MARIADB_V10330  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10611  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10612  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10616  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V10622  | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101107 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101108 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V101113 | O        | O                | NATIVE, ED25519 |
-| MARIADB_V11407  | O        | O                | NATIVE, ED25519 |
+| DB 엔진 유형 | 생성 가능 여부 | OBS로부터 복원 가능 여부 | 인증 플러그인 지원 |
+|------------|----------|------------------|------------|
+| MARIADB_V10330 | X | X | NATIVE, ED25519 |
+| MARIADB_V10611 | X | X | NATIVE, ED25519 |
+| MARIADB_V10612 | X | X | NATIVE, ED25519 |
+| MARIADB_V10616 | X | X | NATIVE, ED25519 |
+| MARIADB_V10622 | X | X | NATIVE, ED25519 |
+| MARIADB_V10625 | X | X | NATIVE, ED25519 |
+| MARIADB_V101107 | O | O | NATIVE, ED25519 |
+| MARIADB_V101108 | O | O | NATIVE, ED25519 |
+| MARIADB_V101113 | O | O | NATIVE, ED25519 |
+| MARIADB_V101116 | O | O | NATIVE, ED25519 |
+| MARIADB_V11407 | O | O | NATIVE, ED25519 |
+| MARIADB_V11410 | O | O | NATIVE, ED25519 |
+| MARIADB_V11806 | O | O | NATIVE, ED25519 |
 
-* ENUM 타입의 dbVersion 필드에서 해당 값을 사용할 수 있습니다.
+* ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
-## 프로젝트 정보
+## DB 보안 그룹
 
-### 리전 목록 보기
+### DB 보안 그룹 진행 상태
+
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
+
+### DB 보안 그룹 목록 보기
 
 ```http
-GET /v4.0/project/regions
+GET /v4.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | 프로젝트 정보 조회 |
 
 #### 요청
 
@@ -93,11 +98,16 @@ GET /v4.0/project/regions
 
 #### 응답
 
-| 이름                 | 종류   | 형식      | 설명                                                                         |
-|--------------------|------|---------|----------------------------------------------------------------------------|
-| regions            | Body | Array   | 리전 목록                                                                      |
-| regions.regionCode | Body | Enum    | 리전 코드<br/>- `KR1`: 한국(판교) 리전 |
-| regions.isEnabled  | Body | Boolean | 리전의 활성화 여부                                                                 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -109,61 +119,10 @@ GET /v4.0/project/regions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "regions": [
+    "totalCounts": 1,
+    "dbSecurityGroups": [
         {
-            "regionCode": "KR1",
-            "isEnabled": true
-        }
-    ]
-}
-```
-
-</details>
-
----
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
-
-#### 필요 권한
-
-| 권한명                                     | 설명         |
-|-----------------------------------------|------------|
-| RDSforMariaDB:Project.Get | 프로젝트 정보 조회 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                   | 종류   | 형식     | 설명              |
-|----------------------|------|--------|-----------------|
-| members              | Body | Array  | 프로젝트 멤버 목록      |
-| members.memberId     | Body | UUID   | 프로젝트 멤버의 식별자    |
-| members.memberName   | Body | String | 프로젝트 멤버의 이름     |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber  | Body | String | 프로젝트 멤버의 전화번호   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "memberId": "1b1d3627-507a-49ea-8cb7-c86dfa9caa58",
-            "memberName": "홍길동",
-            "emailAddress": "gildong.hong@nhn.com",
-            "phoneNumber": "+821012345678"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -174,50 +133,38 @@ GET /v4.0/project/members
 
 ---
 
-## DB 인스턴스 사양
-
-### DB 인스턴스 사양 목록 보기
+### DB 보안 그룹 생성하기
 
 ```http
-GET /v4.0/db-flavors
+POST /v4.0/db-security-groups
 ```
-
-#### 필요 권한
-
-| 권한명                                       | 설명               |
-|-------------------------------------------|------------------|
-| RDSforMariaDB:DbFlavor.List | DB 인스턴스 사양 목록 보기 |
 
 #### 요청
 
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                     | 종류   | 형식     | 설명              |
-|------------------------|------|--------|-----------------|
-| dbFlavors              | Body | Array  | DB 인스턴스 사양 목록   |
-| dbFlavors.dbFlavorId   | Body | UUID   | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름   |
-| dbFlavors.ram          | Body | Number | 메모리 용량(MB)      |
-| dbFlavors.vcpus        | Body | Number | CPU 코어 수        |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
         {
-            "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-            "dbFlavorName": "m2.c1m2",
-            "ram": 2048,
-            "vcpus": 1
+            "description": "description-example"
         }
     ]
 }
@@ -226,36 +173,11 @@ GET /v4.0/db-flavors
 </p>
 </details>
 
----
-
-## 네트워크
-
-### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명        |
-|------------------------------------------|-----------|
-| RDSforMariaDB:Network.List | 서브넷 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
 #### 응답
 
-| 이름                       | 종류   | 형식      | 설명               |
-|--------------------------|------|---------|------------------|
-| subnets                  | Body | Array   | 서브넷 목록           |
-| subnets.subnetId         | Body | UUID    | 서브넷의 식별자         |
-| subnets.subnetName       | Body | String  | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr       | Body | String  | 서브넷의 CIDR        |
-| subnets.usingGateway     | Body | Boolean | 게이트웨이 사용 여부      |
-| subnets.availableIpCount | Body | Number  | 사용 가능한 IP 수      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -267,15 +189,297 @@ GET /v4.0/network/subnets
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "subnets": [
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 상세 보기
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | 포트 객체 |
+| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | 최소 포트 범위 |
+| rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 생성 일시 |
+| rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
         {
-            "subnetId": "1b2a9b23-0725-4b92-8c78-35db66b8ad9f",
-            "subnetName": "Default Network",
-            "subnetCidr": "192.168.0.0/24",
-            "usingGateway": true,
-            "availableIpCount": 240
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
-    ]
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 규칙 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
 }
 ```
 
@@ -292,23 +496,17 @@ GET /v4.0/network/subnets
 GET /v4.0/db-versions
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명          |
-|--------------------------------------------|-------------|
-| RDSforMariaDB:DbVersion.List | DB 엔진 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식      | 설명                    |
-|------------------------------|------|---------|-----------------------|
-| dbVersions                   | Body | Array   | DB 엔진 목록              |
-| dbVersions.dbVersion         | Body | String  | DB 엔진 유형              |
-| dbVersions.dbVersionName     | Body | String  | DB 엔진 이름              |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbVersions | Body | Array | DB 엔진 목록 |
+| dbVersions.dbVersion | Body | String | DB 엔진 유형 |
+| dbVersions.dbVersionName | Body | String | DB 엔진 이름 |
 | dbVersions.restorableFromObs | Body | Boolean | 오브젝트 스토리지로부터 복원 가능 여부 |
 
 <details><summary>예시</summary>
@@ -323,252 +521,9 @@ GET /v4.0/db-versions
     },
     "dbVersions": [
         {
-            "dbVersion": "MARIADB_V10330",
-            "dbVersionName": "Maria DB 10.3.30",
-            "restorableFromObs": true
+            "restorableFromObs": false
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 데이터 스토리지
-
-### 데이터 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
-
-#### 필요 권한
-
-| 권한명                                      | 설명                |
-|------------------------------------------|-------------------|
-| RDSforMariaDB:Storage.List | 데이터 스토리지 타입 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름           | 종류   | 형식    | 설명             |
-|--------------|------|-------|----------------|
-| storageTypes | Body | Array | 데이터 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": [
-        "General SSD",
-        "General HDD"
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 작업 정보
-
-### 작업 상태
-
-| 상태명                | 설명                   |
-|--------------------|----------------------|
-| `PREPARING`        | 작업이 준비 중인 경우         |
-| `READY`            | 작업이 준비 완료된 경우        |
-| `RUNNING`          | 작업이 진행 중인 경우         |
-| `COMPLETED`        | 작업이 완료된 경우           |
-| `REGISTERED`       | 작업이 등록된 경우           |
-| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
-| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
-| `CANCELED`         | 작업이 취소된 경우           |
-| `FAILED`           | 작업이 실패한 경우           |
-| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
-| `DELETED`          | 작업이 삭제된 경우           |
-| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
-
-### 작업 정보 상세 보기
-
-```http
-GET /v4.0/jobs/{jobId}
-```
-
-#### 필요 권한
-
-| 권한명                                 | 설명          |
-|-------------------------------------|-------------|
-| RDSforMariaDB:Job.Get | 작업 정보 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름    | 종류  | 형식   | 필수 | 설명      |
-|-------|-----|------|----|---------|
-| jobId | URL | UUID | O  | 작업의 식별자 |
-
-#### 응답
-
-| 이름                             | 종류   | 형식       | 설명                                |
-|--------------------------------|------|----------|-----------------------------------|
-| jobId                          | Body | UUID     | 작업의 식별자                           |
-| jobStatus                      | Body | Enum     | 작업의 현재 상태                         |
-| resourceRelations              | Body | Array    | 연관 리소스 목록                         |
-| resourceRelations.resourceType | Body | Enum     | 연관 리소스 유형                         |
-| resourceRelations.resourceId   | Body | UUID     | 연관 리소스의 식별자                       |
-| createdYmdt                    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                    | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "0ddb042c-5af6-43fb-a914-f4dd0540eb7c",
-    "jobStatus": "RUNNING",
-    "resourceRelations": [
-        {
-            "resourceType": "DB_INSTANCE",
-            "resourceId": "56b39dcf-65eb-47ec-9d4f-09f160ba2266"
-        }
-    ],
-    "createdYmdt": "2023-02-22T20:47:12+09:00",
-    "updatedYmdt": "2023-02-22T20:49:46+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명               |
-|--------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.List | DB 인스턴스 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름                                 | 종류   | 형식       | 설명                                                                       |
-|------------------------------------|------|----------|--------------------------------------------------------------------------|
-| dbInstanceGroups                   | Body | Array    | DB 인스턴스 그룹 목록                                                            |
-| dbInstanceGroups.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                          |
-| dbInstanceGroups.replicationType   | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성 |
-| dbInstanceGroups.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-| dbInstanceGroups.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "dbInstanceGroupId": "05de0746-89fd-49c8-94f9-9c5b1df97009",
-            "replicationType": "STANDALONE",
-            "createdYmdt": "2023-02-13T17:35:20+09:00",
-            "updatedYmdt": "2023-02-13T17:35:20+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명               |
-|-------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstanceGroup.Get | DB 인스턴스 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명              |
-|-------------------|-----|------|----|-----------------|
-| dbInstanceGroupId | URL | UUID | O  | DB 인스턴스 그룹의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                                    |
-|------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceGroupId            | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| replicationType              | Body | Enum     | DB 인스턴스 그룹의 복제 형태<br/>- `STANDALONE`: 단일<br/>- `HIGH_AVAILABILITY`: 고가용성                                                              |
-| dbInstances                  | Body | Array    | DB 인스턴스 그룹에 속한 DB 인스턴스 목록                                                                                                             |
-| dbInstances.dbInstanceId     | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceType   | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| createdYmdt                  | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                  | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "36617a8e-0df8-4b16-b6ea-6306019e95da",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceId": "6d2db0ef-fe9b-4ed4-97b1-d97fcb4cf1b8",
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE"
-        }
-    ],
-    "createdYmdt": "2023-03-03T17:38:14+09:00",
-    "updatedYmdt": "2023-03-03T17:38:14+09:00"
 }
 ```
 
@@ -601,8 +556,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 | `BACKING_UP`               | 백업 중         |
 | `CANCELING`                | 취소 중         |
 | `CREATING`                 | 생성 중         |
-| `CREATING_SCHEMA`          | DB 스키마 생성 중	 |
-| `CREATING_USER`            | 사용자 생성 중	    |
+| `CREATING_SCHEMA`          | DB 스키마 생성 중  |
+| `CREATING_USER`            | 사용자 생성 중     |
 | `DELETING`                 | 삭제 중         |
 | `DELETING_SCHEMA`          | DB 스키마 삭제 중  |
 | `DELETING_USER`            | 사용자 삭제 중     |
@@ -621,8 +576,8 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 | `STARTING`                 | 시작 중         |
 | `STOPPING`                 | 정지 중         |
 | `SYNCING_SCHEMA`           | DB 스키마 동기화 중 |
-| `SYNCING_USER`             | 사용자 동기화 중	   |
-| `UPDATING_USER`            | 사용자 수정 중	    |
+| `SYNCING_USER`             | 사용자 동기화 중    |
+| `UPDATING_USER`            | 사용자 수정 중     |
 
 ### DB 인스턴스 목록 보기
 
@@ -630,32 +585,26 @@ GET /v4.0/db-instance-groups/{dbInstanceGroupId}
 GET /v4.0/db-instances
 ```
 
-#### 필요 권한
-
-| 권한명                                         | 설명            |
-|---------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.List | DB 인스턴스 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                            | 종류   | 형식       | 설명                                                                                                                                    |
-|-------------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstances                   | Body | Array    | DB 인스턴스 목록                                                                                                                            |
-| dbInstances.dbInstanceId      | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstances.dbInstanceGroupId | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstances.dbInstanceName    | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| dbInstances.description       | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbInstances.dbVersion         | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbInstances.dbPort            | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstances.dbInstanceType    | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstances.dbInstanceStatus  | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| dbInstances.progressStatus    | Body | Enum     | DB 인스턴스의 현재 진행 상태                                                                                                                     |
-| dbInstances.createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| dbInstances.updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstances | Body | Array | DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| dbInstances.description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbInstances.dbVersion | Body | Enum | DB 엔진 유형 |
+| dbInstances.dbPort | Body | Number | DB 포트 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| dbInstances.progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbInstances.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstances.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -669,104 +618,9 @@ GET /v4.0/db-instances
     },
     "dbInstances": [
         {
-            "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-            "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-            "dbInstanceName": "db-instance",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "dbPort": 10000,
-            "dbInstanceType": "MASTER",
-            "dbInstanceStatus": "AVAILABLE",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-01-23T12:03:13+09:00",
-            "updatedYmdt": "2023-02-02T17:20:17+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 상세 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                          | 종류   | 형식       | 설명                                                                                                                                    |
-|-----------------------------|------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                | Body | UUID     | DB 인스턴스의 식별자                                                                                                                          |
-| dbInstanceGroupId           | Body | UUID     | DB 인스턴스 그룹의 식별자                                                                                                                       |
-| dbInstanceName              | Body | String   | DB 인스턴스를 식별할 수 있는 이름                                                                                                                  |
-| description                 | Body | String   | DB 인스턴스에 대한 추가 정보                                                                                                                     |
-| dbVersion                   | Body | Enum     | DB 엔진 유형                                                                                                                              |
-| dbPort                      | Body | Number   | DB 포트                                                                                                                                 |
-| dbInstanceType              | Body | Enum     | DB 인스턴스의 역할 타입<br/>- `MASTER`: 마스터<br/>- `FAILED_MASTER`: 장애 조치된 마스터<br/>- `CANDIDATE_MASTER`: 예비 마스터<br/>- `READ_ONLY_SLAVE`: 읽기 복제본 |
-| dbInstanceStatus            | Body | Enum     | DB 인스턴스의 현재 상태                                                                                                                        |
-| progressStatus              | Body | Enum     | DB 인스턴스의 현재 작업 진행 상태                                                                                                                  |
-| dbFlavorId                  | Body | UUID     | DB 인스턴스 사양의 식별자                                                                                                                       |
-| parameterGroupId            | Body | UUID     | DB 인스턴스에 적용된 파라미터 그룹의 식별자                                                                                                             |
-| dbSecurityGroupIds          | Body | Array    | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록                                                                                                         |
-| notificationGroupIds        | Body | Array    | DB 인스턴스에 적용된 알림 그룹의 식별자 목록                                                                                                            |
-| useDeletionProtection       | Body | Boolean  | DB 인스턴스 삭제 보호 여부                                                                                                                      |
-| useSlowQueryAnalysis        | Body | Boolean  | Slow query 분석 여부                                                                                                                      |
-| supportAuthenticationPlugin | Body | Boolean  | 인증 플러그인 지원 여부                                                                                                                         |
-| needToApplyParameterGroup   | Body | Boolean  | 최신 파라미터 그룹 적용 필요 여부                                                                                                                   |
-| needMigration               | Body | Boolean  | 마이그레이션 필요 여부                                                                                                                          |
-| supportDbVersionUpgrade     | Body | Boolean  | DB 버전 업그레이드 지원 여부                                                                                                                     |
-| createdYmdt                 | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-| updatedYmdt                 | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                     |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceId": "d067593b-1acc-4ccc-9e8a-cc72d6d79ec3",
-    "dbInstanceGroupId": "51c7d080-ff36-4025-84b1-9d9d0b4fe9e0",
-    "dbInstanceName": "db-instance",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbInstanceType": "MASTER",
-    "dbInstanceStatus": "AVAILABLE",
-    "progressStatus": "NONE",
-    "dbFlavorId": "e9ed4ef6-78d7-46fa-ace9-32481e97f3b7",
-    "parameterGroupId": "b03e8b13-de27-4d04-a488-ff5689589372",
-    "dbSecurityGroupIds": ["01908c35-d2c9-4852-baf0-17f06ec42c03"],
-    "notificationGroupIds": ["83a62a33-ddbf-4a04-8653-e54463d5b1ac"],
-    "useDeletionProtection": false,
-    "useSlowQueryAnalysis": true,
-    "supportAuthenticationPlugin": true,
-    "needToApplyParameterGroup": false,
-    "needMigration": false,
-    "supportDbVersionUpgrade": true,
-    "createdYmdt": "2022-11-23T12:03:13+09:00",
-    "updatedYmdt": "2022-12-02T17:20:17+09:00"
 }
 ```
 
@@ -781,86 +635,103 @@ GET /v4.0/db-instances/{dbInstanceId}
 POST /v4.0/db-instances
 ```
 
-#### 필요 권한
+#### 공통 요청
 
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Create | DB 인스턴스 생성하기 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| dbPort | Body | Number | O | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| authenticationPlugin | Body | Enum | X | 인증 Plugin<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | TLS Option<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 데이터 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
-#### 요청
+#### 고가용성 사용 시
 
-| 이름                      | 종류    | 형식      | 필수 | 설명                                                                  |
-|-------------------------|-------|---------|----|---------------------------------------------------------------------|
-| dbInstanceName          | Body  | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName | Body  | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                         |
-| description             | Body  | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId              | Body  | UUID    | O  | DB 인스턴스 사양의 식별자                                                     |
-| dbVersion               | Body  | Enum    | O  | DB 엔진 유형                                                            |
-| dbPort                  | Body  | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| dbUserName              | Body  | String  | O  | DB 사용자 계정명                                                          |
-| dbPassword              | Body  | String  | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                    |
-| parameterGroupId        | Body  | UUID    | O  | 파라미터 그룹의 식별자                                                        |
-| dbSecurityGroupIds      | Body  | Array   | X  | DB 보안 그룹의 식별자 목록                                                    |
-| userGroupIds            | Body  | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability     | Body  | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval            | Body  | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                | Body  | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification  | Body  | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection   | Body  | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         |
-| useSlowQueryAnalysis    | Body  | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                  |
-| authenticationPlugin                         | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                                                                                                                                                                  |
-| network.subnetId                             | Body | UUID    | O  | 서브넷의 식별자                                                                                                                                                                                                                    |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                                                                                             |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                                                                                                                                                                    |
-| storage                                      | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                                                                                                                                                                  |    
-| storage.storageType                          | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                                                                                                                                                                         |
-| storage.storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                                                                                                                           |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                   |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                       |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                         |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                   |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                   |
-| backup                                       | Body | Object  | O  | 백업 정보 객체                                                                                                                                                                                                                    |
-| backup.backupPeriod                          | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                          |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                     |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | O  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbVersion": "MARIADB_V10330",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
     "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE",
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
     "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 1800,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "00:00:00",
-                "backupWndDuration": "ONE_HOUR"
+                "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
     }
@@ -872,52 +743,140 @@ POST /v4.0/db-instances
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                      | 종류   | 형식      | 필수 | 설명                                          |
-|-------------------------|------|---------|----|---------------------------------------------|
-| dbInstanceId            | URL  | UUID    | O  | DB 인스턴스의 식별자                                |
-| dbInstanceName          | Body | String  | X  | DB 인스턴스를 식별할 수 있는 마스터 이름                    |
-| dbInstanceCandidateName | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름 |
-| description             | Body | String  | X  | DB 인스턴스에 대한 추가 정보                           |
-| dbPort                  | Body | Number  | X  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`  |
-| useSlowQueryAnalysis | Body | Boolean  | X | Slow query 분석 여부 |
-| dbFlavorId         | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                           |
-| parameterGroupId   | Body | UUID    | X  | 파라미터 그룹의 식별자                                                              |
-| dbSecurityGroupIds | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                          |
-| executeBackup      | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| useOnlineFailover  | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| waitReplicationDelay  | Body | Boolean | X  | 복제 지연 해소 대기 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| useReadOnly  | Body | Boolean | X  | 읽기 전용으로 변경 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbInstanceName": "db-instance2",
-    "description": "description2",
-    "dbPort": 10001,
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 오브젝트 스토리지를 이용한 DB 인스턴스 복원
+
+```http
+POST /v4.0/db-instances/restore-from-obs
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | O | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | O | DB 포트 |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Body | Object | O | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | O | 스토리지 타입 |
+| storage.storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.subnetId | Body | UUID | O | 서브넷의 식별자 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| backup | Body | Object | O | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | O | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
+| restore.username | Body | String | O | NHN Cloud 계정 혹은 IAM 멤버 ID |
+| restore.password | Body | String | O | 백업이 저장된 오브젝트 스토리지의 API 비밀번호 |
+| restore.targetContainer | Body | String | O | 백업이 저장된 오브젝트 스토리지의 컨테이너 |
+| restore.objectPath | Body | String | O | 컨테이너에 저장된 백업의 경로 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | Body | UUID | O | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "dbVersion": "ENUM_VALUE",
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "tenantId": "tenantId-example",
+        "username": "username-example",
+        "password": "password-example",
+        "targetContainer": "targetContainer-example",
+        "objectPath": "objectPath-example"
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
     "dbSecurityGroupIds": [],
-    "executeBackup": true
+    "userGroupIds": [],
+    "useDeletionProtection": false
 }
 ```
 
@@ -926,9 +885,26 @@ PUT /v4.0/db-instances/{dbInstanceId}
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -938,218 +914,19 @@ PUT /v4.0/db-instances/{dbInstanceId}
 DELETE /v4.0/db-instances/{dbInstanceId}
 ```
 
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Delete | DB 인스턴스 삭제하기 |
-
 #### 요청
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| deleteAutoBackup          | Body | Boolean  | X  | 자동 백업 삭제 여부<br/>- 기본값: `false` |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/restart
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Restart | DB 인스턴스 재시작하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| useOnlineFailover | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| executeBackup     | Body | Boolean | X  | 현재 시점 백업 진행 여부<br/>- 기본값: `false`                                         |
-| waitReplicationDelay     | Body | Boolean | X  | 복제 지연 해소 대기 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false`                                         |
-| useReadOnly     | Body | Boolean | X  | 읽기 전용으로 변경 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false`                                         |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-### DB 인스턴스 강제 재시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/force-restart
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명               |
-|-----------------------------------------------------|------------------|
-| RDSforMariaDB:DbInstance.ForceRestart | DB 인스턴스 강제 재시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-
-| 이름                | 종류   | 형식      | 필수 | 설명                                                                        |
-|-------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId      | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| deleteAutoBackup | Body | Boolean | X | 자동 백업 삭제 여부<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 인스턴스 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/start
-```
-
-#### 필요 권한
-
-| 권한명                                          | 설명           |
-|----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Start | DB 인스턴스 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 정지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/stop
-```
-
-#### 필요 권한
-
-| 권한명                                         | 설명           |
-|---------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Stop | DB 인스턴스 정지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 복제하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/replicate
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명           |
-|--------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Replicate | DB 인스턴스 복제하기 |
-
-#### 요청
-
-| 이름                                           | 종류   | 형식      | 필수 | 설명                                                                        |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                                 | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| dbInstanceName                               | Body | String  | O  | DB 인스턴스를 식별할 수 있는 이름                                                      |
-| description                                  | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                         |
-| dbFlavorId                                   | Body | UUID    | X  | DB 인스턴스 사양의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                   |
-| dbPort                                       | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`        |
-| parameterGroupId                             | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                      |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB 보안 그룹의 식별자 목록<br/>- 기본값: 원본 DB 인스턴스 값                                  |
-| userGroupIds                                 | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                            |
-| useDefaultNotification                       | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                            |
-| useDeletionProtection                        | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                               |
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                        |
-| network                                      | Body | Object  | O  | 네트워크 정보 객체                                                                |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: 원본 DB 인스턴스 값                                       |
-| network.availabilityZone                     | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                  |
-| storage                                      | Body | Object  | X  | 데이터 스토리지 정보 객체                                                            |    
-| storage.storageType                          | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 예시: `General SSD`                        |
-| storage.storageSize                          | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048` |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                         |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                             |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `50`<br/>- 최댓값: `95`                               |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최댓값: `4096`                                         |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                         |
-| backup                                       | Body | Object  | X  | 백업 정보 객체                                                                  |
-| backup.backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`       |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `10`          |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                                           |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | X  | 백업 시작 시각<br/>- 예시: `00:00:00`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | X  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간<br/>- 기본값: 원본 DB 인스턴스 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance-replicate",
-    "description": "description",
-    "dbPort": 11000,
-    "network": {
-        "availabilityZone": "kr-pub-a"
-    },
-    "storage": {
-        "stroageSize": 100
-    }
+    "deleteAutoBackup": false
 }
 ```
 
@@ -1158,194 +935,9 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 승격하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/promote
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Promote | DB 인스턴스 승격하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 인스턴스 재구축하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/rebuild
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Rebuild | DB 인스턴스 재구축하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 복원 정보 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                      | 종류   | 형식       | 설명                                                                                                                                                                           |
-|-----------------------------------------|------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oldestRestorableYmdt                    | Body | DateTime | 가장 오래된 복원 가능한 시각                                                                                                                                                             |
-| latestRestorableYmdt                    | Body | DateTime | 가장 최신의 복원 가능한 시각                                                                                                                                                             |
-| restorableBackups                       | Body | Array    | 복원 가능한 백업 목록                                                                                                                                                                 |
-| restorableBackups.backup                | Body | Object   | 백업 정보 객체                                                                                                                                                                     |
-| restorableBackups.backup.backupId       | Body | UUID     | 백업의 식별자                                                                                                                                                                      |
-| restorableBackups.backup.backupName     | Body | String   | 백업 이름                                                                                                                                                                        |
-| restorableBackups.backup.useBackupLock  | Body | Boolean  | 테이블 잠금 사용 여부                                                                                                                                                                 |
-| restorableBackups.backup.backupSize     | Body | Number   | 백업 크기                                                                                                                                                                        |
-| restorableBackups.backup.backupType     | Body | Enum     | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`: 수동                                                                                                                   |
-| restorableBackups.backup.backupStatus   | Body | Enum     | 백업 상태<br/>- `BACKING_UP`: 백업 중인 경우<br/>- `COMPLETED`: 백업이 완료된 경우<br/>- `DELETING`: 백업이 삭제 중인 경우<br/>- `DELETED`: 백업이 삭제된 경우<br/>- `ERROR`: 오류가 발생한 경우 |
-| restorableBackups.backup.dbInstanceId   | Body | UUID     | 원본 DB 인스턴스의 식별자                                                                                                                                                              |
-| restorableBackups.backup.dbInstanceName | Body | String   | 원본 DB 인스턴스의 이름                                                                                                                                                               |
-| restorableBackups.backup.dbVersion      | Body | String   | DB 엔진 유형                                                                                                                                                                     |
-| restorableBackups.backup.failoverCount  | Body | Number   | 장애 조치 횟수                                                                                                                                                                     |
-| restorableBackups.backup.binLogFileName | Body | String   | 바이너리 로그 파일명                                                                                                                                                                |
-| restorableBackups.backup.binLogPosition | Body | Number   | 바이너리 로그 파일 위치                                                                                                                                                                |
-| restorableBackups.backup.createdYmdt    | Body | DateTime | 백업 생성 일시                                                                                                                                                                     |
-| restorableBackups.backup.updatedYmdt    | Body | DateTime | 백업 갱신 일시                                                                                                                                                                     |
-| restorableBackups.restorableBinLogs     | Body | Array    | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록                                                                                                                                             |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-	"header": {
-		"resultCode": 0,
-		"resultMessage": "SUCCESS",
-		"isSuccessful": true
-	},
-    "oldestRestorableYmdt": "2023-07-09T16:33:33+09:00",
-	"latestRestorableYmdt": "2023-07-10T15:44:44+09:00",
-	"restorableBackups": [
-		{
-			"backup": {
-				"backupId": "145d889a-fe08-474f-8f58-bde576ff96a9",
-				"backupName": "example-backup-name",
-				"backupStatus": "COMPLETED",
-				"dbInstanceId": "dba1be25-9429-4589-9716-7fb6daad7cb9",
-				"dbInstanceName": "original-db-instance-name",
-				"dbVersion": "MARIADB_V10330",
-				"backupType": "MANUAL",
-				"backupSize": 8299904,
-				"useBackupLock": true,
-				"failoverCount": 0,
-				"binLogFileName": "mysql-bin.000001",
-				"binLogPosition": 367916037,
-				"createdYmdt": "2023-07-10T15:44:44+09:00",
-				"updatedYmdt": "2023-07-10T15:46:07+09:00"
-			},
-			"restorableBinLogs": [
-				"mysql-bin.000001"
-			]
-		}
-	]
-}
-```
-
-</p>
-</details>
-
----
-
-### 복원될 마지막 쿼리 조회
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 공통 요청
-
-| 이름           | 종류    | 형식   | 필수 | 설명                                                                                                                          |
-|--------------|-------|------|----|-----------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID | O  | DB 인스턴스의 식별자                                                                                                                |
-| restoreType  | Query | Enum | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입 |
-
-#### restoreType이 `TIMESTAMP`인 경우
-
-| 이름          | 종류    | 형식       | 필수 | 설명                                        |
-|-------------|-------|----------|----|-------------------------------------------|
-| restoreYmdt | Query | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-#### restoreType이 `BINLOG`인 경우
-
-| 이름             | 종류    | 형식     | 필수 | 설명                 |
-|----------------|-------|--------|----|--------------------|
-| backupId       | Query | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| binLogFileName | Query | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| binLogPosition | Query | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-#### 응답
-
-| 이름           | 종류   | 형식       | 설명                                   |
-|--------------|------|----------|--------------------------------------|
-| executedYmdt | Body | DateTime | 쿼리 수행 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| lastQuery    | Body | String   | 마지막 수행 쿼리                            |
 
 <details><summary>예시</summary>
 <p>
@@ -1357,8 +949,7 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "executedYmdt": "2023-03-17T14:02:29+09:00",
-    "lastQuery": "INSERT INTO `test`.`test`SET  @1='0123'"
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -1367,633 +958,45 @@ GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
 
 ---
 
-### 복원
+### DB 인스턴스 상세 보기
 
 ```http
-POST /v4.0/db-instances/{dbInstanceId}/restore
+GET /v4.0/db-instances/{dbInstanceId}
 ```
-
-#### 필요 권한
-
-| 권한명                                            | 설명           |
-|------------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Restore | DB 인스턴스 복원하기 |
-
-#### 공통 요청
-
-| 이름                                                  | 종류   | 형식      | 필수 | 설명                                                                                                                                                   |
-|-----------------------------------------------------|------|---------|----|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                                        | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                         |
-| restore                                             | Body | Object  | O  | 복원 정보 객체                                                                                                                                             |
-| restore.restoreType                                 | Body | Enum    | O  | 복원 타입 종류<br/>- `TIMESTAMP`: 복원 가능한 시간 이내의 시간을 이용한 시점 복원 타입<br/>- `BINLOG`: 복원 가능한 바이너리 로그 위치를 이용한 시점 복원 타입<br/>- `BACKUP`: 기존에 생성한 백업을 이용한 스냅숏 복원 타입 |
-| dbInstanceName                                      | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                                                                                             |
-| dbInstanceCandidateName                             | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 고가용성 사용 시 필수                                                                                                       |
-| description                                         | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                                                                                    |
-| dbFlavorId                                          | Body | UUID    | X  | DB 인스턴스 사양의 식별자                                                                                                                                      |
-| dbPort                                              | Body | Number  | X  | DB 포트<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                                                                                   |
-| parameterGroupId                                    | Body | UUID    | X  | 파라미터 그룹의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                 |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                                                                                     |
-| userGroupIds                                        | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                                                                                       |
-| useHighAvailability                                 | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                                                                                                        |
-| pingInterval                                        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600`                                                                                  |
-| pingType                                            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT`                                                                                  |
-| useDefaultNotification                              | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                                                                                                       |
-| useDeletionProtection                               | Body | Boolean | X  | 삭제 보호 여부<br>기본값: `false`                                                                                                                             |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                                                                                                   |
-| network                                             | Body | Object  | X  | 네트워크 정보 객체                                                                                                                                           |
-| network.subnetId                                    | Body | UUID    | X  | 서브넷의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                     |
-| network.usePublicAccess                             | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                                                                                                       |
-| network.availabilityZone                            | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: 랜덤 선택                                                                                            |
-| storage                                             | Body | Object  | X  | 데이터 스토리지 정보 객체                                                                                                                                       |
-| storage.storageType                                 | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`<br/>- 기본값: 원본 DB 인스턴스 값                                                                                          |
-| storage.storageSize                                 | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                                                                            |
-| storage.storageAutoscale                            | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                                                                                                    |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | 스토리지 자동 확장 여부                                                                                                                                        |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 자동 확장 조건(%)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `50`<br/>- 최댓값: `95`                                                                                  |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 자동 확장 최대 크기(GB) <br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최댓값: `4096`                                                                                           |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                                                                            |
-| backup                                              | Body | Object  | X  | 백업 정보 객체                                                                                                                                             |
-| backup.backupPeriod                                 | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                  |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                   |
-| backup.backupRetryCount                             | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                              |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| backup.backupSchedules | Body | Array | X | 예정된 자동 백업 목록<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
-
-| 이름                  | 종류   | 형식       | 필수 | 설명                                                                                             |
-|---------------------|------|----------|----|------------------------------------------------------------------------------------------------|
-| restore.restoreYmdt | Body | DateTime | O  | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)<br>복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다. |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "TIMESTAMP",
-		"restoreYmdt": "2023-07-10T15:44:44+09:00"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
-
-| 이름                            | 종류   | 형식     | 필수 | 설명                 |
-|-------------------------------|------|--------|----|--------------------|
-| restore.backupId              | Body | UUID   | O  | 복원에 사용할 백업의 식별자    |
-| restore.binLog                | Body | Object | O  | 바이너리 로그 정보 객체      |
-| restore.binLog.binLogFileName | Body | String | O  | 복원에 사용할 바이너리 로그 이름 |
-| restore.binLog.binLogPosition | Body | Number | O  | 복원에 사용할 바이너리 로그 위치 |
-
-* 바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그를 복원할 수 있습니다.
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BINLOG",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36",
-		"binLogFileName": "mysql-bin.000001",
-		"binLogPosition": 1234567
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
-
-| 이름               | 종류   | 형식   | 필수                           | 설명              |
-|------------------|------|------|------------------------------|-----------------|
-| restore.backupId | Body | UUID | O(restoreType이 `BACKUP`인 경우) | 복원에 사용할 백업의 식별자 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"restoreType": "BACKUP",
-        "backupId":"3ae7914f-9b42-4729-b125-87417b72cf36"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-### 오브젝트 스토리지로부터 복원
-
-```http
-POST /v4.0/db-instances/restore-from-obs
-```
-
-#### 필요 권한
-
-| 권한명                                                   | 설명                      |
-|-------------------------------------------------------|-------------------------|
-| RDSforMariaDB:DbInstance.RestoreFromObs | DB 인스턴스 오브젝트 스토리지로부터 복원 |
-
-#### 요청
-
-| 이름                                                  | 종류   | 형식      | 필수 | 설명                                                                                     |
-|-----------------------------------------------------|------|---------|----|----------------------------------------------------------------------------------------|
-| restore                                             | Body | Object  | O  | 복원 정보 객체                                                                               |
-| restore.tenantId                                    | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 테넌트 ID                                                              |
-| restore.username                                    | Body | String  | O  | NHN Cloud 계정 또는 IAM 계정 ID                                                              |
-| restore.password                                    | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 API 비밀번호                                                            |
-| restore.targetContainer                             | Body | String  | O  | 백업이 저장된 오브젝트 스토리지의 컨테이너                                                                |
-| restore.objectPath                                  | Body | String  | O  | 컨테이너에 저장된 백업의 경로                                                                       |
-| dbVersion                                           | Body | Enum    | O  | DB 엔진 유형                                                                               |
-| dbInstanceName                                      | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                                               |
-| dbInstanceCandidateName                             | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                                            |
-| description                                         | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                                      |
-| dbFlavorId                                          | Body | UUID    | O  | DB 인스턴스 사양의 식별자                                                                        |
-| dbPort                                              | Body | Number  | O  | DB 포트<br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                            |
-| parameterGroupId | Body | UUID    | O  | 파라미터 그룹의 식별자                                                                           |
-| dbSecurityGroupIds                                  | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                                       |
-| userGroupIds                                        | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                                         |
-| useHighAvailability                                 | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                           |
-| pingInterval                                        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                                            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification                              | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                          |
-| useDeletionProtection                               | Body | Boolean | X  | 삭제 보호 여부<br>기본값: `false`                                                               |
-| useSlowQueryAnalysis                                | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                                     |
-| network                                             | Body | Object  | O  | 네트워크 정보 객체                                                                             |
-| network.subnetId                                    | Body | UUID    | O  | 서브넷의 식별자                                                                               |
-| network.usePublicAccess                             | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                          |
-| network.availabilityZone                            | Body | Enum    | O  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`                                |
-| storage                                             | Body | Object  | O  | 데이터 스토리지 정보 객체                                                                         |
-| storage.storageType                                 | Body | Enum    | O  | 데이터 스토리지 타입<br/>- 예시: `General SSD`                                     |
-| storage.storageSize                                 | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                     |
-| storage.storageAutoscale                            | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                                      |
-| storage.storageAutoscale.useStorageAutoscale        | Body | Boolean | X  | 스토리지 자동 확장 여부                                                                          |
-| storage.storageAutoscale.threshold                  | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                                            |
-| storage.storageAutoscale.maxStorageSize             | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                                      |
-| storage.storageAutoscale.cooldownTime               | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                                      |
-| backup                                              | Body | Object  | O  | 백업 정보 객체                                                                               |
-| backup.backupPeriod                                 | Body | Number  | O  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                           |
-| backup.ftwrlWaitTimeout                             | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                             | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| backup.backupSchedules | Body | Array | O | 예정된 자동 백업 목록                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
-
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbInstanceName": "db-instance",
-    "description": "description",
-    "dbFlavorId": "71f69bf9-3c01-4c1a-b135-bb75e93f6268",
-    "dbPort": 10000,
-    "dbVersion": "MARIADB_V10330",
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "parameterGroupId": "488bf4f5-d8f7-459b-ace6-529b606c8570",
-    "dbSecurityGroupIds": [
-        "b0483a3d-e8e2-46f6-9e84-d5e31b0d44f4"
-    ],
-    "userGroupIds": [],
-    "network": {
-		"subnetId": "3ae7914f-9b42-4729-b125-87417b72cf36",
-		"availabilityZone": "kr-pub-a"
-	},
-	"storage": {
-		"storageType": "General SSD",
-		"storageSize": 20
-	},
-	"restore": {
-		"tenantId":"tenant-id",
-        "username":"username",
-        "password":"password",
-        "targetContainer":"targetContainer",
-        "objectPath":"objectPath"
-	},
-	"backup": {
-		"backupPeriod": 1,
-		"backupSchedules": [
-			{
-				"backupWndBgnTime": "00:00:00",
-				"backupWndDuration": "ONE_HOUR_AND_HALF"
-			}
-		]
-	}
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
-
----
-
-
-### DB 인스턴스 삭제 보호 설정 변경하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명           |
-|-----------------------|------|---------|----|--------------|
-| dbInstanceId          | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| useDeletionProtection | Body | Boolean | O  | 삭제 보호 여부     |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 고가용성 상태
-
-| 상태                               | 설명                              |
-|----------------------------------|---------------------------------|
-| `CREATED`                        | 고가용성이 생성된 경우                    |
-| `STABLE`                         | 고가용성이 정상인 경우                    |
-| `PAUSING`                        | 고가용성이 일시 중지 중인 경우               |
-| `PAUSED`                         | 고가용성이 일시 중지된 경우                 |
-| `PAUSED_DUE_TO_TASK`             | 작업으로 인해 고가용성이 일시 중지된 경우         |
-| `DISABLE_MASTER_IN_REPLICATION`  | 마스터 비정상 복제 감지로 고가용성이 중단된 경우     |
-| `DISABLE_MHA_PROCESS`            | 고가용성 프로세스가 중단된 경우               |
-| `DISABLE_REPLICATION_STOP`       | 복제 중단으로 인해 고가용성이 중단된 경우         |
-| `DISABLE_REPLICATION_DELAY`      | 복제 지연으로 인해 고가용성이 중단된 경우         |
-| `MASTER_FAILURE_DETECTION`       | 마스터 장애가 감지된 경우                  |
-| `FAILOVER_STARTED`               | 장애 조치가 시작된 경우                   |
-| `FAILOVER_FAILED`                | 장애 조치가 실패한 경우                   |
-| `FAILOVER_COMPLETED`             | 장애 조치가 완료된 경우                   |
-| `DELETED`                        | 고가용성이 삭제된 경우                    |
-
----
-
-### 고가용성 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명         |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                  | 종류   | 형식      | 설명                                                                                                                  |
-|---------------------|------|---------|---------------------------------------------------------------------------------------------------------------------|
-| useHighAvailability | Body | Boolean | 고가용성 사용 여부                                                                                                          |
-| haStatus            | Body | Enum    | 고가용성 상태                                                                                                          |
-| pingInterval        | Body | Number  | Ping 간격(초)                                                                                                          |
-| pingType            | Body | Enum    | Ping 타입<br/>- `INSERT`<br/>- `SELECT`                                                                                |
-
-<details><summary>예시</summary>
-
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "useHighAvailability": true,
-    "haStatus": "STABLE",
-    "pingInterval": 3,
-    "pingType": "INSERT"
-}
-```
-
-</p>
-
-</details>
-
----
-
-### 고가용성 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/high-availability
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Modify | 고가용성 수정하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식      | 필수 | 설명                                                   |
-|---------------------|------|---------|----|------------------------------------------------------|
-| dbInstanceId        | URL  | UUID    | O  | DB 인스턴스의 식별자                                         |
-| useHighAvailability | Body | Boolean | O  | 고가용성 사용 여부                                           |
-| pingInterval        | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType            | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- `INSERT`<br/>- `SELECT` |
-| dbInstanceCandidateName        | Body | String  | O  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 고가용성 사용 시 필수값 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 다시 시작하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명           |
-|-----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Resume | 고가용성 다시 시작하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 일시 중지하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명           |
-|----------------------------------------------------|--------------|
-| RDSforMariaDB:HighAvailability.Pause | 고가용성 일시 중지하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 복구하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명        |
-|-----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Repair | 고가용성 복구하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 고가용성 분리하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명        |
-|----------------------------------------------------|-----------|
-| RDSforMariaDB:HighAvailability.Split | 고가용성 분리하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 데이터 스토리지 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/storage-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식      | 설명                                                                                   |
-|--------------------------------------|------|---------|--------------------------------------------------------------------------------------|
-| storageType                          | Body | Enum    | 데이터 스토리지 타입                                                                          |
-| storageSize                          | Body | Number  | 데이터 스토리지 크기(GB)                                                                      |
-| storageStatus                        | Body | Enum    | 데이터 스토리지의 현재 상태<br/>- `DETACHED`: 부착되지 않음<br/>- `ATTACHED`: 부착됨<br/>- `DELETED`: 삭제됨 |
-| storageAutoscale                     | Body | Object  | 데이터 스토리지 자동 확장 객체                                                                    |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부                                                                        |
-| storageAutoscale.threshold           | Body | Number  | 자동 확장 조건(%)                                                                          |
-| storageAutoscale.maxStorageSize      | Body | Number  | 자동 확장 최대 크기(GB)                                                                      |
-| storageAutoscale.cooldownTime        | Body | Number  | 자동 확장 쿨다운 시간(분)                                                                      |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| description | Body | String | DB 인스턴스에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| dbPort | Body | Number | DB 포트 |
+| dbInstanceType | Body | Enum | DB 인스턴스 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| progressStatus | Body | Enum | DB 인스턴스의 현재 진행 상태<br/>- NONE<br/>- APPLYING_PARAMETER_GROUP<br/>- BACKING_UP<br/>- CANCELING<br/>- CREATING<br/>- CREATING_SCHEMA<br/>- CREATING_USER<br/>- DELETING<br/>- DELETING_SCHEMA<br/>- DELETING_USER<br/>- EXPORTING_BACKUP<br/>- FAILING_OVER<br/>- MIGRATING<br/>- MODIFYING<br/>- PREPARING<br/>- PROMOTING<br/>- PROMOTING_FORCIBLY<br/>- REBUILDING<br/>- REPAIRING<br/>- REPLICATING<br/>- RESTARTING<br/>- RESTARTING_FORCIBLY<br/>- RESTORING<br/>- STARTING<br/>- STOPPING<br/>- SYNCING_SCHEMA<br/>- SYNCING_USER<br/>- UPDATING_USER<br/>- WAIT_MANUAL_CONTROL |
+| dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | String | DB 인스턴스에 적용된 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | DB 인스턴스에 적용된 DB 보안 그룹의 식별자 목록 |
+| notificationGroupIds | Body | Array | DB 인스턴스에 적용된 알림 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | DB 인스턴스 삭제 보호 여부 |
+| useSlowQueryAnalysis | Body | Boolean | Slow query 분석 여부 |
+| supportAuthenticationPlugin | Body | Boolean | 인증 plugin 지원 여부 |
+| needToApplyParameterGroup | Body | Boolean | 최신 파라미터 그룹 적용 필요 여부 |
+| needMigration | Body | Boolean | 마이그레이션 필요 여부 |
+| supportDbVersionUpgrade | Body | Boolean | DB 버전 업그레이드 지원 여부 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2005,54 +1008,108 @@ GET /v4.0/db-instances/{dbInstanceId}/storage-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "storageType": "General SSD",
-    "storageSize": 20,
-    "storageStatus": "ATTACHED",
-    "storageAutoscale": {
-         "useStorageAutoscale": true,
-         "threshold": 80,
-         "maxStorageSize": 100,
-         "cooldownTime": 10
-    }
+    "dbInstanceId": "dbInstanceId-example",
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "dbInstanceName": "dbInstanceName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "dbPort": 1,
+    "dbInstanceType": "MASTER",
+    "dbInstanceStatus": "BEFORE_CREATE",
+    "progressStatus": "NONE",
+    "dbFlavorId": "dbFlavorId-example",
+    "parameterGroupId": "parameterGroupId-example",
+    "dbSecurityGroupIds": [],
+    "notificationGroupIds": [],
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": false,
+    "supportAuthenticationPlugin": false,
+    "needToApplyParameterGroup": false,
+    "needMigration": false,
+    "supportDbVersionUpgrade": false,
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
 
-
 ---
 
-### 데이터 스토리지 정보 수정하기
+### DB 인스턴스 수정하기
 
 ```http
-PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+PUT /v4.0/db-instances/{dbInstanceId}
 ```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
 
 #### 요청
 
-| 이름                                   | 종류   | 형식      | 필수 | 설명                                                                        |
-|--------------------------------------|------|---------|----|---------------------------------------------------------------------------|
-| dbInstanceId                         | URL  | UUID    | O  | DB 인스턴스의 식별자                                                              |
-| storageSize                          | Body | Number  | O  | 데이터 스토리지 크기(GB)<br/>- 최솟값: 현재값<br/>- 최댓값: `2048`                          |
-| useOnlineFailover                    | Body | Boolean | X  | 장애 조치를 이용한 재시작 여부<br/>고가용성을 사용 중인 DB 인스턴스에서만 사용 가능합니다.<br/>- 기본값: `false` |
-| storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                         |
-| storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부                                                             |
-| storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95`                               |
-| storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096`                                         |
-| storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440`                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | X | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| dbInstanceCandidateName | Body | String | X | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbVersion | Body | Enum | X | DB 엔진 버전 코드 |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부 |
+| useDummy | Body | Boolean | X | 단일 DB 인스턴스의 DB 버전 업그레이드 시 더미 사용 여부<br/>- 기본값: `false` |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "dbInstanceCandidateName": "dbInstanceCandidateName",
+    "description": "description-example",
+    "dbPort": 1,
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbVersion": "ENUM_VALUE",
+    "useSlowQueryAnalysis": false,
+    "useDummy": false,
+    "dbSecurityGroupIds": [],
+    "executeBackup": false,
+    "useOnlineFailover": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -2062,32 +1119,26 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 GET /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                                | 종류   | 형식      | 설명             |
-|-----------------------------------|------|---------|----------------|
-| backupPeriod                      | Body | Number  | 백업 보관 기간(일)    |
-| ftwrlWaitTimeout                  | Body | Number  | 쿼리 지연 대기 시간(초) |
-| backupRetryCount                  | Body | Number  | 백업 재시도 횟수      |
-| replicationRegion                 | Body | Enum    | 백업 복제 리전       |
-| useBackupLock                     | Body | Boolean | 테이블 잠금 사용 여부   |
-| backupSchedules                   | Body | Array   | 예정된 자동 백업 목록   |
-| backupSchedules.backupWndBgnTime  | Body | String  | 백업 시작 시각       |
-| backupSchedules.backupWndDuration | Body | Enum    | 백업 Duration    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| backupPeriod | Body | Number | 백업 보관 기간(일) |
+| ftwrlWaitTimeout | Body | Number | 쿼리 지연 대기 시간(초) |
+| backupRetryCount | Body | Number | 백업 재시도 횟수 |
+| replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
+| backupSchedules | Body | Array | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
 <p>
@@ -2100,14 +1151,13 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
         "isSuccessful": true
     },
     "backupPeriod": 1,
-    "ftwrlWaitTimeout": 1800,
-    "backupRetryCount": 0,
-    "replicationRegion": null,
+    "ftwrlWaitTimeout": 1,
+    "backupRetryCount": 1,
+    "replicationRegion": "KR1",
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "00:00:00",
-            "backupWndDuration": "ONE_HOUR_AND_HALF"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2115,7 +1165,6 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 
 </p>
 </details>
-
 
 ---
 
@@ -2125,36 +1174,33 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 ```
 
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
 #### 요청
 
-| 이름                                    | 종류   | 형식      | 필수 | 설명                                                                                                                                                                                                                          |
-|---------------------------------------|------|---------|----|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId                          | URL  | UUID    | O  | DB 인스턴스의 식별자                                                                                                                                                                                                                |
-| backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730`                                                                                                                                                                                 |
-| ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600`                                                                                                                                                                            |
-| backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10`                                                                                                                                                                                    |
-| useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부                                                                                                                                                                                                                |
-| backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록                                                                                                                                                                                                                   |
-| backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
+| backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
+| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "backupPeriod": 5,
-    "useBackupLock": true,
+    "backupPeriod": 0,
+    "ftwrlWaitTimeout": 0,
+    "backupRetryCount": 0,
+    "replicationRegion": "KR1",
+    "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "01:00:00",
-            "backupWndDuration": "TWO_HOURS"
+            "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
 }
@@ -2165,45 +1211,9 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 네트워크 정보 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                                        | 설명            |
-|--------------------------------------------|---------------|
-| RDSforMariaDB:DbInstance.Get | DB 인스턴스 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                     | 종류   | 형식     | 설명                                                                                                                                      |
-|------------------------|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| availabilityZone       | Body | Enum   | DB 인스턴스를 생성할 가용성 영역                                                                                                                     |
-| subnet                 | Body | Object | 서브넷 객체                                                                                                                                  |
-| subnet.subnetId        | Body | UUID   | 서브넷의 식별자                                                                                                                                |
-| subnet.subnetName      | Body | UUID   | 서브넷을 식별할 수 있는 이름                                                                                                                        |
-| subnet.subnetCidr      | Body | UUID   | 서브넷의 CIDR                                                                                                                               |
-| endPoints              | Body | Array  | 접속 정보 목록                                                                                                                                |
-| endPoints.domain       | Body | String | 도메인                                                                                                                                     |
-| endPoints.ipAddress    | Body | String | IP 주소                                                                                                                                   |
-| endPoints.endPointType | Body | Enum   | 접속 정보 타입<br>-`EXTERNAL`: 외부 접속 도메인<br>-`INTERNAL`: 내부 접속 도메인<br>-`PUBLIC`: (Deprecated) 외부 접속 도메인<br>-`PRIVATE`: (Deprecated) 내부 접속 도메인 |
 
 <details><summary>예시</summary>
 <p>
@@ -2215,19 +1225,7 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "availabilityZone": "kr-pub-a",
-    "subnet": {
-        "subnetId": "bd453789-34ae-416c-9f78-05b9e43a46be",
-        "subnetName": "Default Network",
-        "subnetCidr": "192.168.0.0/16"
-    },
-    "endPoints": [
-        {
-            "domain": "ea548a78-d85f-43b4-8ddf-c88d999b9905.internal.kr1.mariadb.rds.nhncloudservice.com",
-            "ipAddress": "192.168.0.2",
-            "endPointType": "INTERNAL"
-        }
-    ]
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -2236,509 +1234,28 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
 
 ---
 
-### 네트워크 정보 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/network-info
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명           |
-|-----------------------------------------------|--------------|
-| RDSforMariaDB:DbInstance.Modify | DB 인스턴스 수정하기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식      | 필수 | 설명           |
-|-----------------|------|---------|----|--------------|
-| dbInstanceId    | URL  | UUID    | O  | DB 인스턴스의 식별자 |
-| usePublicAccess | Body | Boolean | O  | 외부 접속 가능 여부 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명                  |
-|-------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceUser.List | DB 인스턴스 내 사용자 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                           | 종류   | 형식       | 설명                                                                                                                          |
-|------------------------------|------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| dbUsers                      | Body | Array    | DB 사용자 목록                                                                                                                   |
-| dbUsers.dbUserId             | Body | UUID     | DB 사용자의 식별자                                                                                                                 |
-| dbUsers.dbUserName           | Body | String   | DB 사용자 계정 이름                                                                                                                |
-| dbUsers.host                 | Body | String   | DB 사용자 계정의 호스트 이름                                                                                                           |
-| dbUsers.authorityType        | Body | Enum     | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/>            |
-| dbUsers.dbUserStatus         | Body | Enum     | DB 사용자의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `UPDATING`: 수정 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbUsers.authenticationPlugin         | Body | Enum    | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-| dbUsers.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-| dbUsers.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                           |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbUsers": [
-        {
-            "dbUserId": "4b3d530b-fd02-4d59-a620-83d019a67bbb",
-            "dbUserName": "db-user",
-            "host": "%",
-            "authorityType": "DDL",
-            "dbUserStatus": "STABLE",
-            "createdYmdt": "2023-03-17T14:02:29+09:00",
-            "updatedYmdt": "2023-03-17T14:02:31+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 사용자 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-users
-```
-
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Create | DB 인스턴스 내 사용자 생성하기 |
-
-#### 요청
-
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserName           | Body | String | O  | DB 사용자 계정 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `32`                                                                  |
-| dbPassword           | Body | String | O  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| host                 | Body | String | O  | DB 사용자 계정의 호스트명<br/>- 예시: `1.1.1.%`                                                                              |
-| authorityType        | Body | Enum   | O  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- 기본값: `NATIVE`(미지원 시 `ED25519`)<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbUserName": "db-user",
-    "dbPassword": "password",
-    "host": "1.1.1.%",
-    "authorityType": "CRUD"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 수정하기
-
-```http
-PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Modify | DB 인스턴스 내 사용자 수정하기 |
-
-#### 요청
-
-| 이름                   | 종류   | 형식     | 필수 | 설명                                                                                                               |
-|----------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId         | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                                                     |
-| dbUserId             | URL  | UUID   | O  | DB 사용자의 식별자                                                                                                      |
-| dbPassword           | Body | String | X  | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256`                                                                 |
-| authorityType        | Body | Enum   | X  | DB 사용자 권한 타입<br/>- `READ`: SELECT 쿼리 수행 가능한 권한<br/>- `CRUD`: DML 쿼리 수행 가능한 권한<br/>- `DDL`: DDL 쿼리 수행 가능한 권한<br/> |
-| authenticationPlugin | Body | Enum    | X  | 인증 플러그인<br/>- NATIVE: `mysql_native_password`<br />- ED25519: `auth_ed25519` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "authorityType": "DDL"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 사용자 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                 |
-|---------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceUser.Delete | DB 인스턴스 내 사용자 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbUserId     | URL | UUID | O  | DB 사용자의 식별자  |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 스키마 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명                  |
-|---------------------------------------------------|---------------------|
-| RDSforMariaDB:DbInstanceSchema.List | DB 인스턴스 내 스키마 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                                                                                   |
-|--------------------------|------|----------|------------------------------------------------------------------------------------------------------|
-| dbSchemas                | Body | Array    | DB 스키마 목록                                                                                            |
-| dbSchemas.dbSchemaId     | Body | UUID     | DB 스키마의 식별자                                                                                          |
-| dbSchemas.dbSchemaName   | Body | String   | DB 스키마 이름                                                                                            |
-| dbSchemas.dbSchemaStatus | Body | Enum     | DB 스키마의 현재 상태<br/>- `STABLE`: 생성됨<br/>- `CREATING`: 생성 중<br/>- `DELETING`: 삭제 중<br/>- `DELETED`: 삭제됨 |
-| dbSchemas.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSchemas": [
-        {
-            "dbSchemaId": "7c9a94b8-86c1-435d-8af2-82a5e9d53fd4",
-            "dbSchemaName": "schema",
-            "dbSchemaStatus": "STABLE",
-            "createdYmdt": "2023-03-20T13:37:45+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 스키마 생성하기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/db-schemas
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명                 |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Create | DB 인스턴스 내 스키마 생성하기 |
-
-#### 요청
-
-| 이름           | 종류   | 형식     | 필수 | 설명           |
-|--------------|------|--------|----|--------------|
-| dbInstanceId | URL  | UUID   | O  | DB 인스턴스의 식별자 |
-| dbSchemaName | Body | String | O  | DB 스키마 이름    |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 스키마 삭제하기
-
-```http
-DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
-```
-
-#### 필요 권한
-
-| 권한명                                                 | 설명                 |
-|-----------------------------------------------------|--------------------|
-| RDSforMariaDB:DbInstanceSchema.Delete | DB 인스턴스 내 스키마 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|--------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
-| dbSchemaId   | URL | UUID | O  | DB 스키마의 식별자  |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### 로그 파일 목록 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명                    |
-|------------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.List | DB 인스턴스 내 로그 파일 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류    | 형식    | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|-------|----|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID  | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileTypes | Query | Array | X  | 로그 파일 타입 종류 목록<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### 응답
-
-| 이름                   | 종류   | 형식       | 설명                                                                                                                                                                                           |
-|----------------------|------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| logFiles             | Body | Array    | 로그 파일 목록                                                                                                                                                                                     |
-| logFiles.logFileName | Body | String   | 로그 파일명                                                                                                                                                                                     |
-| logFiles.logFileType | Body | Enum     | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-| logFiles.logFileSize | Body | Number   | 로그 파일 크기(Byte)                                                                                                                                                                               |
-| logFiles.createdYmdt | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                                                                            |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "logFiles": [
-        {
-            "logFileName": "xtra_full.log-20230317",
-            "logFileType": "BACKUP",
-            "logFileSize": 4096,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 로그 파일 내용 보기
-
-```http
-GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
-```
-
-#### 필요 권한
-
-| 권한명                                           | 설명                    |
-|-----------------------------------------------|-----------------------|
-| RDSforMariaDB:DbInstanceLog.Get | DB 인스턴스 내 로그 파일 내용 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름           | 종류    | 형식     | 필수 | 설명                                                                                                                                                                                              |
-|--------------|-------|--------|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID   | O  | DB 인스턴스의 식별자                                                                                                                                                                                    |
-| logFileName  | URL   | String | O  | 로그 파일명                                                                                                                                                                                        |
-| logFileType  | Query | Enum   | O  | 로그 파일 타입 종류<br/>- `ERROR`: error.log<br/>- `BINLOG`: mysql-bin<br/>- `GENERAL`: general.log<br/>- `SLOW_QUERY`: slow_query.log<br/>- `AUDIT`: server_audit.log<br/>- `BACKUP`: xtra_full.log |
-
-#### 응답
-
-| 이름      | 종류   | 형식     | 설명                        |
-|---------|------|--------|---------------------------|
-| content | Body | String | 로그 파일 내용(최대 65533 Bytes) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "content": "..."
-}
-```
-
-</p>
-</details>
-
----
-
-### 로그 파일 내보내기
-
-```http
-POST /v4.0/db-instances/{dbInstanceId}/log-files/export
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명                   |
-|--------------------------------------------------|----------------------|
-| RDSforMariaDB:DbInstanceLog.Export | DB 인스턴스 내 로그 파일 내보내기 |
-
-#### 요청
-
-| 이름              | 종류   | 형식     | 필수 | 설명                             |
-|-----------------|------|--------|----|--------------------------------|
-| dbInstanceId    | URL  | UUID   | O  | DB 인스턴스의 식별자                   |
-| logFileNames    | Body | Array  | O  | 로그 파일명 목록<br/>- 최소 크기: `1`   |
-| tenantId        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID      |
-| password        | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 로그 파일의 경로            |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "logFileNames": ["xtra_full.log-20230317"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "logs/backup"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### BinLog 목록 보기
+### 바이너리 로그 목록 보기
 
 ```http
 GET /v4.0/db-instances/{dbInstanceId}/binlogs
 ```
 
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceBinLog.List | BinLog 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류    | 형식      | 필수 | 설명                                                                                   |
-|--------------|-------|---------|----|---------------------------------------------------------------------------------------|
-| dbInstanceId | URL   | UUID    | O  | DB 인스턴스의 식별자                                                                         |
-| deletable    | Query | Boolean | X  | 삭제 가능한 BinLog만 조회할지 여부<br/>- `true`: 마지막 BinLog 제외<br/>- `false`: 전체<br/>- 기본값: `false` |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
 
 #### 응답
 
-| 이름                     | 종류   | 형식       | 설명                                |
-|------------------------|------|----------|-----------------------------------|
-| binLogs                | Body | Array    | BinLog 파일 목록                      |
-| binLogs.binLogFileName | Body | String   | BinLog 파일명                      |
-| binLogs.binLogFileSize | Body | Number   | BinLog 파일 크기(Byte)                |
-| binLogs.createdYmdt    | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| binLogs | Body | Array | BinLog 파일 목록 |
+| binLogs.binLogFileName | Body | String | BinLog 파일 이름 |
+| binLogs.binLogFileSize | Body | Number | BinLog 파일 크기 (Byte) |
+| binLogs.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2752,9 +1269,7 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
     },
     "binLogs": [
         {
-            "binLogFileName": "mysql-bin.000001",
-            "binLogFileSize": 1073741824,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2765,24 +1280,18 @@ GET /v4.0/db-instances/{dbInstanceId}/binlogs
 
 ---
 
-### BinLog 삭제
+### 바이너리 로그 삭제
 
 ```http
 POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 ```
 
-#### 필요 권한
-
-| 권한명                                                | 설명        |
-|----------------------------------------------------|------------|
-| RDSforMariaDB:DbInstanceBinLog.Purge | BinLog 삭제 |
-
 #### 요청
 
-| 이름                 | 종류   | 형식     | 필수 | 설명                                     |
-|--------------------|------|--------|----|----------------------------------------|
-| dbInstanceId       | URL  | UUID   | O  | DB 인스턴스의 식별자                           |
-| lastBinLogFileName | Body | String | O  | 삭제할 마지막 BinLog 파일명(해당 파일 직전까지 삭제됩니다) |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| lastBinLogFileName | Body | String | O | 삭제할 마지막 BinLog 파일 이름 (해당 파일 직전까지 삭제됨) |
 
 <details><summary>예시</summary>
 <p>
@@ -2800,22 +1309,6 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
 ### 인증서 파일 목록 보기
@@ -2824,29 +1317,23 @@ POST /v4.0/db-instances/{dbInstanceId}/binlogs/purge
 GET /v4.0/db-instances/{dbInstanceId}/certificates
 ```
 
-#### 필요 권한
-
-| 권한명                                                    | 설명           |
-|--------------------------------------------------------|---------------|
-| RDSforMariaDB:DbInstanceCertificate.List | 인증서 파일 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름           | 종류  | 형식   | 필수 | 설명           |
-|--------------|-----|------|----|---------------|
-| dbInstanceId | URL | UUID | O  | DB 인스턴스의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
 
 #### 응답
 
-| 이름                           | 종류   | 형식       | 설명                                                                           |
-|------------------------------|------|----------|------------------------------------------------------------------------------|
-| certificates                 | Body | Array    | 인증서 파일 목록                                                                    |
-| certificates.fileName        | Body | String   | 인증서 파일명                                                                    |
-| certificates.certificateType | Body | Enum     | 인증서 타입<br/>- `CA_FILE`: CA 인증서<br/>- `CERT_FILE`: 인증서<br/>- `KEY_FILE`: 비밀 키 |
-| certificates.fileSize        | Body | Number   | 인증서 파일 크기(Byte)                                                              |
-| certificates.createdYmdt     | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                            |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| certificates | Body | Array | 인증서 파일 목록 |
+| certificates.fileName | Body | String | 인증서 파일 이름 |
+| certificates.certificateType | Body | Enum | 인증서 타입<br/>- CA_FILE<br/>- CERT_FILE<br/>- KEY_FILE |
+| certificates.fileSize | Body | Number | 인증서 파일 크기(Byte) |
+| certificates.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -2860,10 +1347,7 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
     },
     "certificates": [
         {
-            "fileName": "ca.pem",
-            "certificateType": "CA_FILE",
-            "fileSize": 2048,
-            "createdYmdt": "2023-03-17T14:02:29+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -2880,35 +1364,29 @@ GET /v4.0/db-instances/{dbInstanceId}/certificates
 POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명          |
-|----------------------------------------------------------|-------------|
-| RDSforMariaDB:DbInstanceCertificate.Export | 인증서 파일 내보내기 |
-
 #### 요청
 
-| 이름               | 종류   | 형식     | 필수 | 설명                                                                           |
-|------------------|------|--------|----|------------------------------------------------------------------------------|
-| dbInstanceId     | URL  | UUID   | O  | DB 인스턴스의 식별자                                                                 |
-| certificateTypes | Body | Array  | O  | 업로드할 인증서 타입<br/>- `CA_FILE`: CA 인증서<br/>- `CERT_FILE`: 인증서<br/>- `KEY_FILE`: 비밀 키 |
-| tenantId         | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID                                                |
-| username         | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID                                                    |
-| password         | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호                                              |
-| targetContainer  | Body | String | O  | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너                                                  |
-| objectPath       | Body | String | O  | 컨테이너에 저장될 인증서 파일의 경로                                                         |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| certificateTypes | Body | Array | O | 업로드할 인증서 타입 목록 |
+| tenantId | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 인증서 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 인증서 파일의 경로 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "certificateTypes": ["CA_FILE", "CERT_FILE", "KEY_FILE"],
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "certificates/"
+    "certificateTypes": [],
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -2917,9 +1395,2159 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSchemas | Body | Array | DB 스키마 목록 |
+| dbSchemas.dbSchemaId | Body | String | DB 스키마의 식별자 |
+| dbSchemas.dbSchemaName | Body | String | DB 스키마 이름 |
+| dbSchemas.dbSchemaStatus | Body | Enum | DB 스키마의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbSchemas.createdYmdt | Body | DateTime | 생성 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSchemas": [
+        {
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 생성하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-schemas
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbSchemaName | Body | String | O | DB 스키마 이름<br/>- 최대 길이: `64`<br/>- 영문 시작, 영문/숫자/_ 허용, 1~64자, MySQL 예약어 불가 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSchemaName": "dbSchemaName-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 스키마 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-schemas/{dbSchemaId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbSchemaId | URL | UUID | O | DB 스키마의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbUsers | Body | Array | DB 사용자 목록 |
+| dbUsers.dbUserId | Body | String | DB 사용자의 식별자 |
+| dbUsers.dbUserName | Body | String | DB 사용자 계정 이름 |
+| dbUsers.host | Body | String | DB 사용자 계정의 호스트 이름 |
+| dbUsers.authorityType | Body | Enum | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| dbUsers.dbUserStatus | Body | Enum | DB 사용자의 현재 상태<br/>- STABLE<br/>- CREATING<br/>- UPDATING<br/>- SYNCING<br/>- DELETING<br/>- DELETED |
+| dbUsers.createdYmdt | Body | DateTime | 생성 일시 |
+| dbUsers.updatedYmdt | Body | DateTime | 수정 일시 |
+| dbUsers.authenticationPlugin | Body | Enum | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| dbUsers.tlsOption | Body | Enum | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbUsers": [
+        {
+            "tlsOption": "NONE"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 생성하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/db-users
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserName | Body | String | O | DB 사용자 계정명<br/>- 최소 길이: `1`<br/>- 최대 길이: `32` |
+| dbPassword | Body | String | O | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| host | Body | String | O | DB 사용자 계정의 호스트명<br/>- 최대 길이: `45` |
+| authorityType | Body | Enum | O | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | 인증서 옵션<br/>- 기본값: `NONE`<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbUserName": "dbUserName",
+    "dbPassword": "dbPassword",
+    "host": "host-example",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 사용자 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/db-users/{dbUserId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbUserId | URL | UUID | O | DB 사용자의 식별자 |
+| dbPassword | Body | String | X | DB 사용자 계정 암호<br/>- 최소 길이: `4`<br/>- 최대 길이: `256` |
+| authorityType | Body | Enum | X | DB 사용자 권한 타입<br/>- CUSTOM: `사용자 정의 권한`<br/>- READ: `읽기 권한`<br/>- CRUD: `CRUD 권한`<br/>- DDL: `DDL 권한`<br/>- ALL: `전체 권한` |
+| authenticationPlugin | Body | Enum | X | 사용자 인증 플러그인<br/>- NATIVE: `mysql_native_password 인증`<br/>- ED25519: `ed25519 인증 (MariaDB 전용)` |
+| tlsOption | Body | Enum | X | 인증서 옵션<br/>- NONE: `TLS 미사용`<br/>- SSL: `SSL 인증`<br/>- X509: `X509 인증서 인증` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbPassword": "dbPassword",
+    "authorityType": "CUSTOM",
+    "authenticationPlugin": "NATIVE",
+    "tlsOption": "NONE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 삭제 보호 설정 변경
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/deletion-protection
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useDeletionProtection | Body | Boolean | O | 삭제 보호 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 강제 재시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/force-restart
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 고가용성 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| useHighAvailability | Body | Boolean | 고가용성 사용 여부<br/>- 기본값: `false` |
+| haStatus | Body | Enum | 고가용성 상태<br/>- CREATED: `생성됨`<br/>- STABLE: `정상`<br/>- PAUSING: `일시 중지 중`<br/>- DISABLE: `정지`<br/>- DISABLE_MASTER_IN_REPLICATION: `마스터 비정상 복제 감지로 인한 고가용성 중단`<br/>- DISABLE_MHA_PROCESS: `고가용성 프로세스 중단`<br/>- DISABLE_REPLICATION_STOP: `복제 중단으로 인한 고가용성 중단`<br/>- DISABLE_REPLICATION_DELAY: `복제 지연으로 인한 고가용성 중단`<br/>- FAILOVER_STARTED: `장애 조치 시작`<br/>- FAILOVER_FAILED: `장애 조치 실패`<br/>- FAILOVER_COMPLETED: `장애 조치 완료`<br/>- DELETED: `삭제됨`<br/>- PAUSED: `일시 중지`<br/>- PAUSED_DUE_TO_TASK: `작업으로 인한 일시 중지`<br/>- MASTER_FAILURE_DETECTION: `마스터 장애 감지` |
+| pingInterval | Body | Number | Ping 간격(초) |
+| pingType | Body | String | Ping 방식 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "useHighAvailability": false,
+    "haStatus": "CREATED",
+    "pingInterval": 1,
+    "pingType": "pingType-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/high-availability
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useHighAvailability | Body | Boolean | O | 고가용성 사용 여부 |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useHighAvailability": false,
+    "pingInterval": 1
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 일시 중지하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/pause
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 복구하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/repair
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 다시 시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/resume
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 고가용성 분리하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/high-availability/split
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| logFiles | Body | Array | 로그 파일 목록 |
+| logFiles.logFileName | Body | String | 로그 파일 이름 |
+| logFiles.logFileType | Body | Enum | 로그 파일 타입 종류<br/>- ERROR<br/>- BINLOG<br/>- GENERAL<br/>- SLOW_QUERY<br/>- AUDIT<br/>- BACKUP |
+| logFiles.logFileSize | Body | Number | 로그 파일 크기(Byte) |
+| logFiles.createdYmdt | Body | DateTime | 생성 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "logFiles": [
+        {
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 내보내기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/log-files/export
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O |  |
+| logFileNames | Body | Array | O | 로그 파일 이름 목록 |
+| tenantId | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 회원 또는 IAM 멤버 ID |
+| password | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 로그 파일이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 로그 파일의 경로 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "logFileNames": [],
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 로그 파일 내용 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/log-files/{logFileName}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| logFileName | URL | UUID | O | 로그 파일 이름 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| content | Body | String | 로그 파일 내용 (최대 65533 bytes) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "content": "content-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 목록 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/maintenances
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| type | Query | String | X |  |
+| statuses | Query | String | X |  |
+| category | Query | String | X |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 유지 관리 목록 갯수 |
+| maintenances | Body | Array | 유지 관리 목록 |
+| maintenances.maintenanceId | Body | String | 유지 관리 아이디 |
+| maintenances.dbInstanceId | Body | String | DB 인스턴스 아이디 |
+| maintenances.category | Body | Enum | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| maintenances.description | Body | String | 유지 관리 설명 |
+| maintenances.type | Body | Enum | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| maintenances.payload | Body | Object | 유지 관리 타입에 따른 Payload |
+| maintenances.required | Body | Boolean | 유지 관리 필수 여부 |
+| maintenances.deadlineYmdt | Body | DateTime | 유지 관리 강제 적용 일시 |
+| maintenances.status | Body | Enum | 유지 관리 상태<br/>- PENDING: `대기`<br/>- READY: `준비`<br/>- RUNNING: `실행 중`<br/>- COMPLETED: `완료`<br/>- FAILED: `실패`<br/>- EXCLUDED: `제외`<br/>- DELETED: `삭제`<br/>- UNKNOWN |
+| maintenances.executionType | Body | Enum | 유지 관리 실행 타입<br/>- SCHEDULED: `예약 실행 (유지 관리 기간 자동 실행)`<br/>- MANUAL: `수동 실행 (즉시 실행)`<br/>- FORCED: `강제 실행 (데드라인 초과 자동 실행)` |
+| maintenances.addedYmdt | Body | DateTime | 유지 관리 스케줄 등록 일시 |
+| maintenances.executionStartedYmdt | Body | DateTime | 유지 관리 시작 일시 |
+| maintenances.executionCompletedYmdt | Body | DateTime | 유지 관리 종료 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "maintenances": [
+        {
+            "executionCompletedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 즉시 실행하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/execute-now
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| configId | Body | String | O | 설정 아이디 |
+| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | Body | String | X | 유지 관리 설명 |
+| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 유지 관리 예약하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/maintenances/schedule
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| configId | Body | String | O | 설정 아이디 |
+| category | Body | Enum | O | 유지 관리 카테고리<br/>- USER: `사용자 유지 관리 카테고리`<br/>- PROVIDER: `Provider 유지 관리 카테고리`<br/>- AUTO: `자동 유지 관리 카테고리` |
+| description | Body | String | X | 유지 관리 설명 |
+| type | Body | Enum | O | 유지 관리 타입<br/>- UPDATE_DB_INSTANCE: `DB 인스턴스 수정(사양 변경, 포트 변경, 파라미터 그룹 변경)`<br/>- UPGRADE_ENGINE_VERSION: `엔진 버전 업그레이드`<br/>- APPLY_CHANGE_PARAMETER: `파라미터 그룹의 파라미터 변경`<br/>- UPGRADE_OS: `운영체제 버전 업그레이드`<br/>- PATCH_SECURITY: `보안 업데이트`<br/>- MIGRATION: `하이퍼바이저 점검을 위한 마이그레이션`<br/>- CLEANUP_STORAGE: `스토리지 정리` |
+| payload | Body | String | O | 유지 관리 타입에 따른 Payload |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "configId": "configId-example",
+    "category": "USER",
+    "description": "description-example",
+    "type": "UPDATE_DB_INSTANCE",
+    "payload": "payload-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 인스턴스 유지 관리 삭제하기
+
+```http
+DELETE /v4.0/db-instances/{dbInstanceId}/maintenances/{maintenanceId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| maintenanceId | URL | UUID | O | 유지 관리 아이디 |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 네트워크 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availabilityZone | Body | String | DB 인스턴스를 생성할 가용성 영역 |
+| subnet | Body | Object | 서브넷 객체 |
+| subnet.subnetId | Body | String | 서브넷의 식별자 |
+| subnet.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnet.subnetCidr | Body | String | 서브넷의 CIDR |
+| endPoints | Body | Array | 접속 정보 목록 |
+| endPoints.domain | Body | String | 도메인 |
+| endPoints.ipAddress | Body | String | IP 주소 |
+| endPoints.endPointType | Body | String | 접속 정보 타입 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZone": "availabilityZone-example",
+    "subnet": {
+        "subnetId": "subnetId-example",
+        "subnetName": "subnetName-example",
+        "subnetCidr": "subnetCidr-example"
+    },
+    "endPoints": [
+        {
+            "endPointType": "endPointType-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 네트워크 정보 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/network-info
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| usePublicAccess | Body | Boolean | O | 외부 접속 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "usePublicAccess": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 승격하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/promote
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 재구축하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/rebuild
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복제하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/replicate
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자 |
+| dbPort | Body | Number | X | DB 포트<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Body | Object | O | 네트워크 정보 객체 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부 |
+| network.availabilityZone | Body | Enum | O | DB 인스턴스를 생성할 가용성 영역 |
+| storage | Body | Object | X | 스토리지 정보 객체 |
+| storage.storageType | Body | Enum | X | 데이터 스토리지 타입 |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB)<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | X | 백업 정보 객체 |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일)<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
+    "network": {
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    }
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 재시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restart
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| useOnlineFailover | Body | Boolean | X | 장애 조치를 이용한 재시작 여부<br/>- 기본값: `false` |
+| executeBackup | Body | Boolean | X | 현재 시점 백업 진행 여부<br/>- 기본값: `false` |
+| waitReplicationDelay | Body | Boolean | X | 복제 지연 해소 대기<br/>- 기본값: `false` |
+| useReadOnly | Body | Boolean | X | 쓰기 부하 차단<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "useOnlineFailover": false,
+    "executeBackup": false,
+    "waitReplicationDelay": false,
+    "useReadOnly": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원 정보 조회
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| oldestRestorableYmdt | Body | DateTime | 가장 오래된 복원 가능한 시각 |
+| latestRestorableYmdt | Body | DateTime | 가장 최신의 복원 가능한 시각 |
+| restorableBackups | Body | Array | 복원 가능한 백업 목록 |
+| restorableBackups.backup | Body | Object | 백업 정보 객체 |
+| restorableBackups.backup.backupId | Body | String | 백업의 식별자 |
+| restorableBackups.backup.backupName | Body | String | 백업 이름 |
+| restorableBackups.backup.backupStatus | Body | Enum | 백업 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| restorableBackups.backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| restorableBackups.backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
+| restorableBackups.backup.dbVersion | Body | Enum | DB 엔진 유형 |
+| restorableBackups.backup.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| restorableBackups.backup.backupSize | Body | Number | 백업 크기 |
+| restorableBackups.backup.useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
+| restorableBackups.backup.failoverCount | Body | Number | 장애 조치 횟수 |
+| restorableBackups.backup.binLogFileName | Body | String | 바이너리 로그 파일 이름 |
+| restorableBackups.backup.binLogPosition | Body | Object | 바이너리 로그 파일 위치 |
+| restorableBackups.backup.createdYmdt | Body | DateTime | 백업 생성 일시 |
+| restorableBackups.backup.updatedYmdt | Body | DateTime | 백업 갱신 일시 |
+| restorableBackups.restorableBinLogs | Body | Array | 해당 백업을 이용하여 복원 가능한 바이너리 로그 이름 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "oldestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "latestRestorableYmdt": "2023-12-31T15:00:00+09:00",
+    "restorableBackups": [
+        {
+            "restorableBinLogs": []
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 복원될 마지막 쿼리 조회
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/restoration-info/last-query
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| executedYmdt | Body | DateTime | 쿼리 수행 일시 |
+| lastQuery | Body | String | 마지막 수행 쿼리 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "executedYmdt": "2023-12-31T15:00:00+09:00",
+    "lastQuery": "lastQuery-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 복원
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/restore
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미입력 시 원본 인스턴스의 사양이 적용됩니다. |
+| dbPort | Body | Number | X | DB 포트 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| storage | Body | Object | X | 스토리지 정보 객체. 미입력 시 원본 인스턴스의 스토리지 설정이 적용됩니다. |
+| storage.storageType | Body | Enum | X | 스토리지 타입. 미입력 시 원본 인스턴스의 스토리지 타입이 적용됩니다. |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미입력 시 원본 인스턴스의 스토리지 크기가 적용됩니다.<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| network | Body | Object | X | 네트워크 정보 객체. 미입력 시 원본 인스턴스의 네트워크 설정이 적용됩니다. |
+| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미입력 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미입력 시 랜덤 선택 |
+| backup | Body | Object | X | 백업 정보 객체. 미입력 시 원본 인스턴스의 백업 설정이 적용됩니다. |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미입력 시 원본 인스턴스의 백업 보관 기간이 적용됩니다.<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초)<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
+| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
+| restore | Body | Object | O | 복원 정보 객체 |
+| restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
+| restore.binLog.binLogFileName | Body | String | X | 복원에 사용할 바이너리 로그 이름 |
+| restore.binLog.binLogPosition | Body | Object | X | 복원에 사용할 바이너리 로그 위치 |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미입력 시 원본 인스턴스의 파라미터 그룹이 적용됩니다. |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록. 미입력 시 원본 인스턴스의 보안 그룹이 적용됩니다. |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+
+#### 고가용성 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+#### Timestamp를 이용한 시점 복원 시 요청(restoreType이 `TIMESTAMP`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.restoreYmdt | Body | DateTime | X | DB 인스턴스 복원 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+
+복원 정보 조회로 조회한 가장 최신의 복원 가능한 시간 이전에 대해서만 복원이 가능합니다.
+
+#### 바이너리 로그를 이용한 시점 복원 시 요청(restoreType이 `BINLOG`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
+| restore.binLog | Body | Object | X | 복원에 사용할 바이너리 로그 정보 객체 |
+
+바이너리 로그를 이용한 시점 복원 시 기준 백업의 바이너리 로그 파일 및 위치를 기준으로 그 이후에 기록된 로그에 대해 복원이 가능합니다.
+
+#### 백업을 이용한 복원 시 요청(restoreType이 `BACKUP`인 경우)
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| restore.backupId | Body | UUID | X | 복원에 사용할 백업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "storage": {
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
+    },
+    "network": {
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
+    },
+    "backup": {
+        "backupPeriod": 0,
+        "ftwrlWaitTimeout": 1800,
+        "backupRetryCount": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": true,
+        "backupSchedules": [
+            {
+                "backupWndDuration": "HALF_AN_HOUR"
+            }
+        ]
+    },
+    "restore": {
+        "restoreType": "TIMESTAMP",
+        "binLog": {
+            "binLogFileName": "binLogFileName-example",
+            "binLogPosition": {
+            }
+        }
+    },
+    "useDefaultNotification": false,
+    "useSlowQueryAnalysis": true,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useDeletionProtection": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 시작하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/start
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 정지하기
+
+```http
+POST /v4.0/db-instances/{dbInstanceId}/stop
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 스토리지 정보 보기
+
+```http
+GET /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageType | Body | String | 데이터 스토리지 타입 |
+| storageSize | Body | Number | 데이터 스토리지 크기(GB) |
+| storageStatus | Body | Enum | 데이터 스토리지의 현재 상태<br/>- DELETED: `삭제됨`<br/>- PENDING_DELETION: `삭제 유예됨`<br/>- DELETION_RESERVED: `삭제 예약됨 (스냅샷 정리 대기)`<br/>- DETACHED: `해제됨`<br/>- ATTACHED: `할당됨` |
+| storageAutoscale | Body | Object | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | 스토리지 자동 확장 여부 |
+| storageAutoscale.threshold | Body | Number | 자동 확장 조건(%) |
+| storageAutoscale.maxStorageSize | Body | Number | 자동 확장 최대 크기(GB) |
+| storageAutoscale.cooldownTime | Body | Number | 자동 확장 쿨다운 시간(분) |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageType": "storageType-example",
+    "storageSize": 1,
+    "storageStatus": "DELETED",
+    "storageAutoscale": {
+        "useStorageAutoscale": false,
+        "threshold": 1,
+        "maxStorageSize": 1,
+        "cooldownTime": 1
+    }
+}
+```
+
+</p>
+</details>
+
+---
+
+### 스토리지 정보 수정하기
+
+```http
+PUT /v4.0/db-instances/{dbInstanceId}/storage-info
+```
+
+#### 공통 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceId | URL | UUID | O | DB 인스턴스의 식별자 |
+| storageSize | Body | Number | O | 데이터 스토리지 크기(GB)<br/>- 최댓값: `2048` |
+| storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체 |
+| storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부 |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "storageSize": 1,
+    "storageAutoscale": {
+        "useStorageAutoscale": false
+    }
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 그룹 상세 보기
+
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
+        {
+            "dbInstanceStatus": "BEFORE_CREATE"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 사양
+
+### DB 인스턴스 사양 목록 보기
+
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbFlavors": [
+        {
+            "vcpus": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 가용성 영역
+
+### 가용성 영역 목록 보기
+
+```http
+GET /v4.0/availability-zones
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| availabilityZones | Body | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "availabilityZones": [
+        {
+            "zoneState": {
+                "available": false
+            }
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 네트워크
+
+### 서브넷 목록 보기
+
+```http
+GET /v4.0/network/subnets
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| subnets | Body | Array | 서브넷 목록 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 데이터 스토리지
+
+### 스토리지 타입 목록 보기
+
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 타입 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 모니터링
+
+### 통계 정보 조회
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### Metric 목록 보기
+
+```http
+GET /v4.0/metrics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric 목록 |
+| metrics.measureName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "metrics": [
+        {
+            "unit": "unit-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -2935,123 +3563,32 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 | `DELETED`    | 백업이 삭제된 경우   |
 | `ERROR`      | 오류가 발생한 경우   |
 
-### 백업 상세 보기
-
-```http
-GET /v4.0/backups/{backupId}
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명       |
-|----------------------------------------|----------|
-| RDSforMariaDB:Backup.Get | 백업 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름                      | 종류   | 형식       | 설명              |
-|-------------------------|------|----------|-----------------|
-| backup                  | Body | Object   | 백업 상세 정보        |
-| backup.backupId         | Body | UUID     | 백업의 식별자         |
-| backup.regionCode       | Body | Enum     | 리전 코드           |
-| backup.backupName       | Body | String   | 백업을 식별할 수 있는 이름 |
-| backup.backupStatus     | Body | Enum     | 백업의 현재 상태       |
-| backup.dbInstanceId     | Body | UUID     | 원본 DB 인스턴스의 식별자 |
-| backup.dbInstanceName   | Body | String   | 원본 DB 인스턴스의 이름  |
-| backup.dbVersion        | Body | Enum     | DB 엔진 버전        |
-| backup.backupType       | Body | Enum     | 백업 유형                             |
-| backup.backupMethodType | Body | Enum     | 백업 방식                             |
-| backup.backupFileType   | Body | Enum     | 백업 파일 유형                          |
-| backup.backupSize       | Body | Number   | 백업의 크기(Byte)                      |
-| backup.isReplicable     | Body | Boolean  | 복제 가능 여부                          |
-| backup.binLogFileName   | Body | String   | 바이너리 로그 파일명                       |
-| backup.binLogPosition   | Body | Number   | 바이너리 로그 위치                        |
-| backup.createdYmdt      | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| backup.updatedYmdt      | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "backup": {
-        "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-        "regionCode": "KR1",
-        "backupName": "backup",
-        "backupStatus": "COMPLETED",
-        "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-        "dbInstanceName": "db-instance",
-        "dbVersion": "MARIADB_V10330",
-        "backupType": "AUTO",
-        "backupMethodType": "FULL",
-        "backupFileType": "XTRA_BACKUP",
-        "backupSize": 4996786,
-        "isReplicable": true,
-        "binLogFileName": "mysql-bin.000001",
-        "binLogPosition": 154,
-        "createdYmdt": "2023-02-21T00:35:00+09:00",
-        "updatedYmdt": "2023-02-22T00:35:32+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
 ### 백업 목록 조회
 
 ```http
 GET /v4.0/backups
 ```
 
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Backup.List | 백업 목록 조회 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-| backupType   | Query | Enum   | X  | 백업 유형<br/>- `AUTO`: 자동<br/>- `MANUAL`:  수동<br/>- 기본값: 전체 |
-| dbInstanceId | Query | UUID   | X  | 원본 DB 인스턴스의 식별자                                          |
-| dbVersion    | Query | Enum   | X  | DB 엔진 유형                                                 |
-
 #### 응답
 
-| 이름                   | 종류   | 형식       | 설명                                |
-|----------------------|------|----------|-----------------------------------|
-| totalCounts          | Body | Number   | 전체 백업 목록 수                        |
-| backups              | Body | Array    | 백업 목록                             |
-| backups.backupId     | Body | UUID     | 백업의 식별자                           |
-| backups.backupName   | Body | String   | 백업을 식별할 수 있는 이름                   |
-| backups.backupStatus | Body | Enum     | 백업의 현재 상태                         |
-| backups.dbInstanceId | Body | UUID     | 원본 DB 인스턴스의 식별자                   |
-| backups.dbVersion    | Body | Enum     | DB 엔진 유형                          |
-| backups.backupType   | Body | Enum     | 백업 유형                             |
-| backups.backupSize   | Body | Number   | 백업의 크기(Byte)                      |
-| createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 백업 목록 수 |
+| backups | Body | Array | 백업 목록 |
+| backups.backupId | Body | String | 백업의 식별자 |
+| backups.backupName | Body | String | 백업을 식별할 수 있는 이름 |
+| backups.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backups.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backups.dbVersion | Body | Enum | DB 엔진 유형 |
+| backups.utilVersion | Body | String | 유틸리티 버전 |
+| backups.backupType | Body | Enum | 백업 유형<br/>- AUTO<br/>- MANUAL |
+| backups.backupSize | Body | Number | 백업의 크기(Byte) |
+| backups.createdYmdt | Body | DateTime | 생성 일시 |
+| backups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -3066,15 +3603,7 @@ GET /v4.0/backups
     "totalCounts": 1,
     "backups": [
         {
-            "backupId": "0017f136-3e01-4530-94aa-20661afe6632",
-            "backupName": "backup",
-            "backupStatus": "COMPLETED",
-            "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd",
-            "dbVersion": "MARIADB_V10330",
-            "backupType": "AUTO",
-            "backupSize": 4996786,
-            "createdYmdt": "2023-02-21T00:35:00+09:00",
-            "updatedYmdt": "2023-02-22T00:35:32+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -3091,89 +3620,166 @@ GET /v4.0/backups
 POST /v4.0/backups
 ```
 
-#### 필요 권한
+#### 요청
 
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Create | 백업 생성하기 |
-
-#### 공통 요청
-
-| 이름               | 종류   | 형식     | 필수 | 설명                                                                                   |
-|------------------|------|--------|----|--------------------------------------------------------------------------------------|
-| backupName       | Body | String | O  | 백업을 식별할 수 있는 이름                                                                      |
-| backupMethodType | Body | Enum   | O  | 백업 방식 타입 종류<br/>- `FULL`: 전체 백업<br/>- `INCREMENTAL`: 증분 백업 <br/>- `SNAPSHOT`: 스냅숏 백업 |
-
-#### 전체 백업(backupMethodType이 `FULL`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB 인스턴스의 식별자 |
-
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupName | Body | String | O | 백업을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| baseBackupId | Body | UUID | X | 원본 백업의 식별자 |
+| dbInstanceId | Body | UUID | X | DB 인스턴스의 식별자 |
+| backupMethodType | Body | Enum | O | 백업 방식 타입<br/>- FULL: `전체 백업`<br/>- INCREMENTAL: `증분 백업`<br/>- SNAPSHOT: `스냅숏 백업` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "backupName": "example-backup-name",
-    "backupMethodType": "FULL",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
+    "backupName": "backupName",
+    "baseBackupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbInstanceId": "550e8400-e29b-41d4-a716-446655440000",
+    "backupMethodType": "FULL"
 }
 ```
 
 </p>
 </details>
-
-#### 증분 백업(backupMethodType이 `INCREMENTAL`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명         |
-|--------------|------|------|----|------------|
-| baseBackupId | Body | UUID | O  | 기준 백업의 식별자 |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "INCREMENTAL",
-    "baseBackupId": "3ae7914f-9b42-4729-b125-87417b72cf36"
-}
-```
-
-</p>
-</details>
-
-
-#### 스냅숏 백업(backupMethodType이 `SNAPSHOT`인 경우)
-
-| 이름           | 종류   | 형식   | 필수 | 설명           |
-|--------------|------|------|----|--------------|
-| dbInstanceId | Body | UUID | O  | DB 인스턴스의 식별자 |
-
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "backupName": "example-backup-name",
-    "backupMethodType": "SNAPSHOT",
-    "dbInstanceId": "142e6ccc-3bfb-4e1e-84f7-38861284fafd"
-}
-```
-
-</p>
-</details>
-
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 백업 삭제하기
+
+```http
+DELETE /v4.0/backups/{backupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | UUID | 요청한 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 백업 단건 조회
+
+```http
+GET /v4.0/backups/{backupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| backup | Body | Object | 백업 상세 정보 |
+| backup.backupId | Body | String | 백업의 식별자 |
+| backup.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| backup.backupName | Body | String | 백업을 식별할 수 있는 이름 |
+| backup.backupStatus | Body | Enum | 백업의 현재 상태<br/>- BACKING_UP: `백업 중 (스피너)`<br/>- VERIFYING: `검증 중 (스피너)`<br/>- COMPLETED: `사용 가능 (녹색 아이콘)`<br/>- DELETING: `삭제 중 (스피너)`<br/>- DELETED: `삭제 됨 (회색 아이콘)`<br/>- ERROR: `에러 (적색 아이콘)` |
+| backup.dbInstanceId | Body | String | 원본 DB 인스턴스의 식별자 |
+| backup.dbInstanceName | Body | String | 원본 DB 인스턴스의 이름 |
+| backup.dbVersion | Body | Enum | DB 엔진 버전 |
+| backup.utilVersion | Body | String | 유틸리티 버전 |
+| backup.backupType | Body | Enum | 백업 유형 (AUTO, MANUAL)<br/>- AUTO<br/>- MANUAL |
+| backup.backupMethodType | Body | Enum | 백업 방식 (FULL, SNAPSHOT, INCREMENTAL)<br/>- FULL<br/>- INCREMENTAL<br/>- SNAPSHOT |
+| backup.backupFileType | Body | Enum | 백업 파일 유형<br/>- XBSTREAM<br/>- TAR_ZSTD<br/>- TAR_LZ4<br/>- TAR_GZIP<br/>- SNAPSHOT |
+| backup.backupSize | Body | Number | 백업의 크기(Byte) |
+| backup.isReplicable | Body | Boolean | 복제 가능 여부 |
+| backup.binLogFileName | Body | String | 바이너리 로그 파일명 |
+| backup.binLogPosition | Body | Object | 바이너리 로그 위치 |
+| backup.createdYmdt | Body | DateTime | 생성 일시 |
+| backup.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "backup": {
+        "backupId": "backupId-example",
+        "regionCode": "KR1",
+        "backupName": "backupName-example",
+        "backupStatus": "BACKING_UP",
+        "dbInstanceId": "dbInstanceId-example",
+        "dbInstanceName": "dbInstanceName-example",
+        "dbVersion": "ENUM_VALUE",
+        "utilVersion": "utilVersion-example",
+        "backupType": "AUTO",
+        "backupMethodType": "FULL",
+        "backupFileType": "XBSTREAM",
+        "backupSize": 1,
+        "isReplicable": false,
+        "binLogFileName": "binLogFileName-example",
+        "binLogPosition": {
+        },
+        "createdYmdt": "2023-12-31T15:00:00+09:00",
+        "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    }
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3183,33 +3789,27 @@ POST /v4.0/backups
 POST /v4.0/backups/{backupId}/export
 ```
 
-#### 필요 권한
-
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Export | 백업 내보내기 |
-
 #### 요청
 
-| 이름              | 종류   | 형식     | 필수 | 설명                          |
-|-----------------|------|--------|----|-----------------------------|
-| backupId        | URL  | UUID   | O  | 백업의 식별자                     |
-| tenantId        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 테넌트 ID   |
-| username        | Body | String | O  | NHN Cloud 계정 또는 IAM 계정 ID   |
-| password        | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
-| targetContainer | Body | String | O  | 백업이 저장될 오브젝트 스토리지의 컨테이너     |
-| objectPath      | Body | String | O  | 컨테이너에 저장될 백업의 경로            |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| tenantId | Body | String | O | 백업이 저장될 오브젝트 스토리지의 테넌트 ID<br/>- 최소 길이: `32`<br/>- 최대 길이: `32` |
+| username | Body | String | O | NHN Cloud 계정 혹은 IAM 회원 ID |
+| password | Body | String | O | 백업이 저장될 오브젝트 스토리지의 API 비밀번호 |
+| targetContainer | Body | String | O | 백업이 저장될 오브젝트 스토리지의 컨테이너 |
+| objectPath | Body | String | O | 컨테이너에 저장될 백업의 경로 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "tenantId": "399631c404744dbbb18ce4fa2dc71a5a",
-    "username": "gildong.hong@nhn.com",
-    "password": "password",
-    "targetContainer": "container",
-    "objectPath": "backups/backup_file"
+    "tenantId": "tenantId-example",
+    "username": "username-example",
+    "password": "password-example",
+    "targetContainer": "targetContainer-example",
+    "objectPath": "objectPath-example"
 }
 ```
 
@@ -3218,12 +3818,26 @@ POST /v4.0/backups/{backupId}/export
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
-> [주의]
-> 수동 백업의 경우 백업이 수행된 DB 인스턴스가 존재하지 않으면, 백업을 오브젝트 스토리지로 내보낼 수 없습니다.
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+</p>
+</details>
 
 ---
 
@@ -3233,75 +3847,93 @@ POST /v4.0/backups/{backupId}/export
 POST /v4.0/backups/{backupId}/restore
 ```
 
-#### 필요 권한
+#### 공통 요청
 
-| 권한명                                        | 설명      |
-|--------------------------------------------|---------|
-| RDSforMariaDB:Backup.Restore | 백업 복원하기 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| backupId | URL | UUID | O |  |
+| dbInstanceName | Body | String | O | DB 인스턴스를 식별할 수 있는 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 인스턴스에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbFlavorId | Body | UUID | X | DB 인스턴스 사양의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbPort | Body | Number | X | DB 포트. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: 3306, 최댓값: 43306 |
+| parameterGroupId | Body | UUID | X | 파라미터 그룹의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| dbSecurityGroupIds | Body | Array | X | DB 보안 그룹의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
+| useHighAvailability | Body | Boolean | X | 고가용성 사용 여부<br/>- 기본값: `false` |
+| pingInterval | Body | Number | X | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
+| useDefaultNotification | Body | Boolean | X | 기본 알림 사용 여부<br/>- 기본값: `false` |
+| useDeletionProtection | Body | Boolean | X | 삭제 보호 여부<br/>- 기본값: `false` |
+| useSlowQueryAnalysis | Body | Boolean | X | Slow query 분석 여부<br/>- 기본값: `true` |
+| network | Body | Object | X | 네트워크 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| network.subnetId | Body | UUID | X | 서브넷의 식별자. 미지정 시 원본 인스턴스 값 사용 |
+| network.usePublicAccess | Body | Boolean | X | 외부 접속 가능 여부<br/>- 기본값: `false` |
+| network.availabilityZone | Body | Enum | X | DB 인스턴스를 생성할 가용성 영역. 미지정 시 랜덤 선택 |
+| storage | Body | Object | X | 스토리지 정보 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageType | Body | Enum | X | 스토리지 타입. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageSize | Body | Number | X | 데이터 스토리지 크기(GB). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `20` |
+| storage.storageAutoscale | Body | Object | X | 데이터 스토리지 자동 확장 객체. 미지정 시 원본 인스턴스 값 사용 |
+| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X | 스토리지 자동 확장 여부<br/>- 기본값: `false` |
+| backup | Body | Object | X | 백업 정보 객체. 미지정 시 원본 인스턴스 백업 설정 사용 |
+| backup.backupPeriod | Body | Number | X | 백업 보관 기간(일). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `730` |
+| backup.backupRetryCount | Body | Number | X | 백업 재시도 횟수. 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `10` |
+| backup.ftwrlWaitTimeout | Body | Number | X | 쿼리 지연 대기 시간(초). 미지정 시 원본 인스턴스 값 사용<br/>- 최솟값: `0`<br/>- 최댓값: `21600` |
+| backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
+| backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
+| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
-#### 요청
+#### 고가용성 사용 시
 
-| 이름                                           | 종류   | 형식      | 필수 | 설명                                                                  |
-|----------------------------------------------|------|---------|----|---------------------------------------------------------------------|
-| backupId                                     | URL  | UUID    | O  | 백업의 식별자                                                             |
-| dbInstanceName                               | Body | String  | O  | DB 인스턴스를 식별할 수 있는 마스터 이름                                            |
-| dbInstanceCandidateName                      | Body | String  | X  | DB 인스턴스를 식별할 수 있는 예비 마스터 이름(고가용성 사용 시 필수 값)                         |
-| description                                  | Body | String  | X  | DB 인스턴스에 대한 추가 정보                                                   |
-| dbFlavorId                                   | Body | UUID    | X  | DB 인스턴스 사양의 식별자          <br/> - 기본값: 원본 DB 인스턴스 값                                           |
-| dbPort                                       | Body | Integer | X  | DB 포트 <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `3306`<br/>- 최댓값: `43306`                          |
-| parameterGroupId                             | Body | UUID    | X  | 파라미터 그룹의 식별자    <br/> - 기본값: 원본 DB 인스턴스 값                                                          |
-| dbSecurityGroupIds                           | Body | Array   | X  | DB 보안 그룹의 식별자 목록                                                    ||network|Body|Object|O|네트워크 정보 객체|
-| userGroupIds                                 | Body | Array   | X  | 사용자 그룹의 식별자 목록                                                      |
-| useHighAvailability                          | Body | Boolean | X  | 고가용성 사용 여부<br/>- 기본값: `false`                                       |
-| pingInterval                                 | Body | Number  | X  | 고가용성 사용 시 Ping 간격(초)<br/>- 기본값: `3`<br/>- 최솟값: `1`<br/>- 최댓값: `600` |
-| pingType                                     | Body | Enum    | X  | 고가용성 사용 시 Ping 타입<br/>- 기본값: `INSERT`<br/>- `INSERT`<br/>- `SELECT` |
-| useDefaultNotification                       | Body | Boolean | X  | 기본 알림 사용 여부<br/>- 기본값: `false`                                      |
-| useDeletionProtection                        | Body | Boolean | X  | 삭제 보호 여부<br/>- 기본값: `false`                                         | 
-| useSlowQueryAnalysis                         | Body | Boolean | X  | Slow query 분석 여부<br/>- 기본값: `true`                                  |
-| network                                      | Body | Object  | X  | 네트워크 정보 객체                                                          |
-| network.subnetId                             | Body | UUID    | X  | 서브넷의 식별자<br/>- 기본값: 원본 DB 인스턴스 값                                                            |
-| network.usePublicAccess                      | Body | Boolean | X  | 외부 접속 가능 여부<br/>- 기본값: `false`                                      |
-| network.availabilityZone                     | Body | Enum    | X  | DB 인스턴스를 생성할 가용성 영역<br/>- 예시: `kr-pub-a`<br/>- 기본값: 랜덤 선택                            |
-| storage                                      | Body | Object  | X  | 데이터 스토리지 정보 객체                                                      |
-| storage.storageType                          | Body | Enum    | X  | 데이터 스토리지 타입<br/>- 예시: `General SSD`<br/>- 기본값: 원본 DB 인스턴스 값                                 |
-| storage.storageSize                          | Body | Number  | X  | 데이터 스토리지 크기(GB)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `20`<br/>- 최댓값: `2048`                   |
-| storage.storageAutoscale                     | Body | Object  | X  | 데이터 스토리지 자동 확장 객체                                                   |
-| storage.storageAutoscale.useStorageAutoscale | Body | Boolean | X  | 스토리지 자동 확장 여부    <br/> - 기본값: 원본 DB 인스턴스 값                                                         |
-| storage.storageAutoscale.threshold           | Body | Number  | X  | 자동 확장 조건(%) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `50`<br/>- 최댓값: `95`                         |
-| storage.storageAutoscale.maxStorageSize      | Body | Number  | X  | 자동 확장 최대 크기(GB) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최댓값: `4096`                                   |
-| storage.storageAutoscale.cooldownTime        | Body | Number  | X  | 자동 확장 쿨다운 시간(분) <br/> - 기본값: 원본 DB 인스턴스 값     <br/>- 최솟값: `10`<br/>- 최댓값: `1440`                   |
-| backup                                       | Body | Object  | X  | 백업 정보 객체                                                            |
-| backup.backupPeriod                          | Body | Number  | X  | 백업 보관 기간(일)<br/>- 기본값: 원본 DB 인스턴스 값<br/>- 최솟값: `0`<br/>- 최댓값: `730`                         |
-| backup.ftwrlWaitTimeout                      | Body | Number  | X  | 쿼리 지연 대기 시간(초)<br/>- 기본값: `1800`<br/>- 최솟값: `0`<br/>- 최댓값: `21600`  |
-| backup.backupRetryCount                      | Body | Number  | X  | 백업 재시도 횟수<br/>- 기본값: `0`<br/>- 최솟값: `0`<br/>- 최댓값: `10`             |
-| backup.useBackupLock                         | Body | Boolean | X  | 테이블 잠금 사용 여부<br/>- 기본값: `true`                                                                                                                                                                                              |
-| backup.backupSchedules                       | Body | Array   | X  | 예정된 자동 백업 목록<br/>- 기본값: 원본 DB 인스턴스 값                                                                                                                                                                                                                   |
-| backup.backupSchedules.backupWndBgnTime      | Body | String  | O  | 백업 시작 시각<br/>- 예시: `00:00:00`                                                                                                                                                                                               |
-| backup.backupSchedules.backupWndDuration     | Body | Enum    | O  | 백업 Duration<br/>백업 시작 시각부터 Duration 안에 자동 백업이 실행됩니다.<br/>- `HALF_AN_HOUR`: 30분<br/>- `ONE_HOUR`: 1시간<br/>- `ONE_HOUR_AND_HALF`: 1시간 30분<br/>- `TWO_HOURS`: 2시간<br/>- `TWO_HOURS_AND_HALF`: 2시간 30분<br/>- `THREE_HOURS`: 3시간 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceCandidateName | Body | String | O | DB 인스턴스를 식별할 수 있는 예비 마스터 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+
+#### 스토리지 자동 확장 사용 시
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| storage.storageAutoscale.threshold | Body | Number | O | 자동 확장 조건(%)<br/>- 최솟값: `50`<br/>- 최댓값: `95` |
+| storage.storageAutoscale.maxStorageSize | Body | Number | O | 자동 확장 최대 크기(GB)<br/>- 최댓값: `4096` |
+| storage.storageAutoscale.cooldownTime | Body | Number | O | 자동 확장 쿨다운 시간(분)<br/>- 최솟값: `10`<br/>- 최댓값: `1440` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
-
 {
-    "dbInstanceName": "db-instance-restore",
-    "dbFlavorId": "50be6d9c-02d6-4594-a2d4-12010eb65ec0",
-    "dbPort": 10000,
-    "parameterGroupId": "132d383c-38e3-468a-a826-5e9a8fff15d0",
+    "dbInstanceName": "dbInstanceName",
+    "description": "description-example",
+    "dbFlavorId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbPort": 1,
+    "parameterGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "dbSecurityGroupIds": [],
+    "userGroupIds": [],
+    "useHighAvailability": false,
+    "pingInterval": 3,
+    "useDefaultNotification": false,
+    "useDeletionProtection": false,
+    "useSlowQueryAnalysis": true,
     "network": {
-        "subnetId": "e721a9dd-dad0-4cf0-a53b-dd654ebfc683",
-        "availabilityZone": "kr-pub-a"
+        "subnetId": "550e8400-e29b-41d4-a716-446655440000",
+        "usePublicAccess": false,
+        "availabilityZone": "ENUM_VALUE"
     },
     "storage": {
-        "storageType": "General SSD",
-        "storageSize": 20
+        "storageType": "ENUM_VALUE",
+        "storageSize": 20,
+        "storageAutoscale": {
+            "useStorageAutoscale": false
+        }
     },
     "backup": {
-        "backupPeriod": 1,
+        "backupPeriod": 0,
+        "backupRetryCount": 0,
+        "ftwrlWaitTimeout": 0,
+        "replicationRegion": "KR1",
+        "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3314,84 +3946,10 @@ POST /v4.0/backups/{backupId}/restore
 
 #### 응답
 
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
 | jobId | Body | UUID | 요청한 작업의 식별자 |
 
----
-
-### 백업 삭제하기
-
-```http
-DELETE /v4.0/backups/{backupId}
-```
-
-#### 필요 권한
-
-| 권한명                                       | 설명      |
-|-------------------------------------------|---------|
-| RDSforMariaDB:Backup.Delete | 백업 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름       | 종류  | 형식   | 필수 | 설명      |
-|----------|-----|------|----|---------|
-| backupId | URL | UUID | O  | 백업의 식별자 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-## DB 보안 그룹
-
-### DB 보안 그룹 진행 상태
-
-| 상태              | 설명           |
-|-----------------|--------------|
-| `NONE`          | 진행 중인 작업이 없음 |
-| `CREATING_RULE` | 규칙 정책 생성 중   |
-| `UPDATING_RULE` | 규칙 정책 수정 중   |
-| `DELETING_RULE` | 규칙 정책 삭제 중   |
-
-### DB 보안 그룹 목록 보기
-
-```http
-GET /v4.0/db-security-groups
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명             |
-|--------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.List | DB 보안 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식       | 설명                                |
-|--------------------------------------|------|----------|-----------------------------------|
-| dbSecurityGroups                     | Body | Array    | DB 보안 그룹 목록                       |
-| dbSecurityGroups.dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                     |
-| dbSecurityGroups.dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름             |
-| dbSecurityGroups.description         | Body | String   | DB 보안 그룹에 대한 추가 정보                |
-| dbSecurityGroups.progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                |
-| dbSecurityGroups.createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| dbSecurityGroups.updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
 <details><summary>예시</summary>
 <p>
 
@@ -3402,827 +3960,7 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroups": [
-        {
-            "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-            "dbSecurityGroupName": "dbSecurityGroup",
-            "description": "description",
-            "progressStatus": "NONE",
-            "createdYmdt": "2023-02-19T19:18:13+09:00",
-            "updatedYmdt": "2022-02-19T19:18:13+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 상세 보기
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명             |
-|-------------------------------------------------|----------------|
-| RDSforMariaDB:DbSecurityGroup.Get | DB 보안 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-| 이름                  | 종류   | 형식       | 설명                                                                                                                 |
-|---------------------|------|----------|--------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId   | Body | UUID     | DB 보안 그룹의 식별자                                                                                                      |
-| dbSecurityGroupName | Body | String   | DB 보안 그룹을 식별할 수 있는 이름                                                                                              |
-| description         | Body | String   | DB 보안 그룹에 대한 추가 정보                                                                                                 |
-| progressStatus      | Body | Enum     | DB 보안 그룹의 현재 진행 상태                                                                                                 |
-| rules               | Body | Array    | DB 보안 그룹 규칙 목록                                                                                                     |
-| rules.ruleId        | Body | UUID     | DB 보안 그룹 규칙의 식별자                                                                                                   |
-| rules.description   | Body | String   | DB 보안 그룹 규칙에 대한 추가 정보                                                                                              |
-| rules.direction     | Body | Enum     | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                       |
-| rules.etherType     | Body | Enum     | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                     |
-| rules.port          | Body | Object   | 포트 객체                                                                                                              |
-| rules.port.portType | Body | Enum     | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number   | 최소 포트 범위                                                                                                           |
-| rules.port.maxPort  | Body | Number   | 최대 포트 범위                                                                                                           |
-| rules.cidr          | Body | String   | 허용할 트래픽의 원격 소스                                                                                                     |
-| rules.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| rules.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| createdYmdt         | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-| updatedYmdt         | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                  |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroup": {
-        "dbSecurityGroupId": "fe4f2aee-afbb-4c19-a5e9-eb2eab394708",
-        "dbSecurityGroupName": "dbSecurityGroup",
-        "description": "description",
-        "progressStatus": "NONE",
-        "rules": [
-            {
-                "ruleId": "17c88ef6-95f1-4678-84f9-fee1b22e250d",
-                "description": "description",
-                "direction": "INGRESS",
-                "etherType": "IPV4",
-                "port": {
-                    "portType": "PORT_RANGE",
-                    "minPort": 10000,
-                    "maxPort": 10005
-                },
-                "cidr": "0.0.0.0/0",
-                "createdYmdt": "2023-02-19T19:18:13+09:00",
-                "updatedYmdt": "2023-02-19T19:18:13+09:00"
-            }
-        ],
-        "createdYmdt": "2023-02-19T19:18:13+09:00",
-        "updatedYmdt": "2023-02-19T19:18:13+09:00"
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 생성하기
-
-```http
-POST /v4.0/db-security-groups
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Create | DB 보안 그룹 생성하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|---------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupName | Body | String | O  | DB 보안 그룹을 식별할 수 있는 이름                                                                                                                                                                    |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보                                                                                                                                                                       |
-| rules               | Body | Array  | O  | DB 보안 그룹 규칙 목록                                                                                                                                                                           |
-| rules.description   | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| rules.direction     | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| rules.etherType     | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| rules.cidr          | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-| rules.port          | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| rules.port.portType | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| rules.port.minPort  | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| rules.port.maxPort  | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description",
-    "rules": [
-        {
-            "direction": "INGRESS",
-            "etherType": "IPV4",
-            "port": {
-                "portType": "PORT_RANGE",
-                "minPort": 10000,
-                "maxPort": 10005
-            },
-            "cidr": "0.0.0.0/0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                | 종류   | 형식   | 설명            |
-|-------------------|------|------|---------------|
-| dbSecurityGroupId | Body | UUID | DB 보안 그룹의 식별자 |
-
----
-
-### DB 보안 그룹 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Modify | DB 보안 그룹 수정하기 |
-
-#### 요청
-
-| 이름                  | 종류   | 형식     | 필수 | 설명                    |
-|---------------------|------|--------|----|-----------------------|
-| dbSecurityGroupId   | URL  | UUID   | O  | DB 보안 그룹의 식별자         |
-| dbSecurityGroupName | Body | String | X  | DB 보안 그룹을 식별할 수 있는 이름 |
-| description         | Body | String | X  | DB 보안 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroup",
-    "description": "description"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                | 설명            |
-|----------------------------------------------------|---------------|
-| RDSforMariaDB:DbSecurityGroup.Delete | DB 보안 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류  | 형식   | 필수 | 설명            |
-|-------------------|-----|------|----|---------------|
-| dbSecurityGroupId | URL | UUID | O  | DB 보안 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 생성하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "PORT",
-        "minPort": 10000,
-        "maxPort": 10000
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Modify | DB 보안 그룹 규칙 수정하기 |
-
-#### 요청
-
-| 이름                | 종류   | 형식     | 필수 | 설명                                                                                                                                                                                       |
-|-------------------|------|--------|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dbSecurityGroupId | URL  | UUID   | O  | DB 보안 그룹의 식별자                                                                                                                                                                            |
-| ruleId            | URL  | UUID   | O  | DB 보안 그룹 규칙의 식별자                                                                                                                                                                         |
-| description       | Body | String | X  | DB 보안 그룹 규칙에 대한 추가 정보                                                                                                                                                                    |
-| direction         | Body | Enum   | O  | 통신 방향<br/>- `INGRESS`: 수신<br/>- `EGRESS`: 송신                                                                                                                                             |
-| etherType         | Body | Enum   | O  | Ether 타입<br/>- `IPV4`: IPv4<br/>- `IPV6`: IPv6                                                                                                                                           |
-| port              | Body | Object | O  | 포트 객체                                                                                                                                                                                    |
-| port.portType     | Body | Enum   | O  | 포트 타입<br/>- `DB_PORT`: 각 DB 인스턴스 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 필요하지 않습니다.<br/>- `PORT`: 지정된 포트값으로 설정됩니다. `minPort`값과 `maxPort`값이 같아야 합니다.<br/>- `PORT_RANGE`: 지정된 포트 범위로 설정됩니다. |
-| port.minPort      | Body | Number | X  | 최소 포트 범위<br/>- 최솟값: 1                                                                                                                                                                    |
-| port.maxPort      | Body | Number | X  | 최대 포트 범위<br/>- 최댓값: 65535                                                                                                                                                                |
-| cidr              | Body | String | O  | 허용할 트래픽의 원격 소스<br/>- 예시: `1.1.1.1/32`                                                                                                                                                    |
-
-> [주의]
-> DB 포트는 송신 방향으로 설정할 수 없습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "DB_PORT"
-    },
-    "cidr": "0.0.0.0/0"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 필요 권한
-
-| 권한명                                                    | 설명               |
-|--------------------------------------------------------|------------------|
-| RDSforMariaDB:DbSecurityGroupRule.Create | DB 보안 그룹 규칙 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식    | 필수 | 설명                  |
-|-------------------|-------|-------|----|---------------------|
-| dbSecurityGroupId | URL   | UUID  | O  | DB 보안 그룹의 식별자       |
-| ruleIds           | Query | Array | O  | DB 보안 그룹 규칙의 식별자 목록 |
-
-#### 응답
-
-| 이름    | 종류   | 형식   | 설명          |
-|-------|------|------|-------------|
-| jobId | Body | UUID | 요청한 작업의 식별자 |
-
----
-
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명            |
-|-------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.List | 파라미터 그룹 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름        | 종류    | 형식   | 필수 | 설명       |
-|-----------|-------|------|----|----------|
-| dbVersion | Query | Enum | X  | DB 엔진 유형 |
-
-#### 응답
-
-| 이름                                   | 종류   | 형식       | 설명                                                                |
-|--------------------------------------|------|----------|-------------------------------------------------------------------|
-| parameterGroups                      | Body | Array    | 파라미터 그룹 목록                                                        |
-| parameterGroups.parameterGroupId     | Body | UUID     | 파라미터 그룹의 식별자                                                      |
-| parameterGroups.parameterGroupName   | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                              |
-| parameterGroups.description          | Body | String   | 파라미터 그룹에 대한 추가 정보                                                 |
-| parameterGroups.dbVersion            | Body | Enum     | DB 엔진 유형                                                          |
-| parameterGroups.parameterGroupStatus | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요 |
-| parameterGroups.createdYmdt          | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-| parameterGroups.updatedYmdt          | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroups": [
-        {
-            "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-            "parameterGroupName": "parameter-group",
-            "description": null,
-            "dbVersion": "MARIADB_V10330",
-            "parameterGroupStatus": "STABLE",
-            "createdYmdt": "2023-02-31T15:28:17+09:00",
-            "updatedYmdt": "2023-02-31T15:28:17+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-
----
-
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                            | 설명            |
-|------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Get | 파라미터 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-| 이름                            | 종류   | 형식       | 설명                                                                                                     |
-|-------------------------------|------|----------|--------------------------------------------------------------------------------------------------------|
-| parameterGroupId              | Body | UUID     | 파라미터 그룹의 식별자                                                                                           |
-| parameterGroupName            | Body | String   | 파라미터 그룹을 식별할 수 있는 이름                                                                                   |
-| description                   | Body | String   | 파라미터 그룹에 대한 추가 정보                                                                                      |
-| dbVersion                     | Body | Enum     | DB 엔진 유형                                                                                               |
-| parameterGroupStatus          | Body | Enum     | 파라미터 그룹의 현재 상태<br/>- `STABLE`: 적용 완료<br/>- `NEED_TO_APPLY`: 적용 필요                                      |
-| parameters                    | Body | Array    | 파라미터 목록                                                                                                |
-| parameters.parameterId        | Body | UUID     | 파라미터 식별자                                                                                               |
-| parameters.parameterFileGroup | Body | Enum     | 파라미터 파일 그룹 타입<br/>- `CLIENT`: client<br/>- `MYSQL`: mysql<br/>- `MYSQLD`: mysqld                       |
-| parameters.parameterName      | Body | String   | 파라미터 이름                                                                                                |
-| parameters.fileParameterName  | Body | String   | 파라미터 파일명                                                                                             |
-| parameters.value              | Body | String   | 현재 설정된 값                                                                                               |
-| parameters.defaultValue       | Body | String   | 기본값                                                                                                    |
-| parameters.allowedValue       | Body | String   | 허용된 값                                                                                                  |
-| parameters.updateType         | Body | Enum     | 수정 타입<br/>- `VARIABLE`: 언제든 수정 가능<br/>- `CONSTANT`: 수정 불가능<br/>- `INIT_VARIABLE`: DB 인스턴스 생성 시에만 수정 가능 |
-| parameters.applyType          | Body | Enum     | 적용 타입<br/>- `SESSION`: 세션 적용<br/>- `FILE`: 설정 파일 적용(재시작 필요)<br/>- `BOTH`: 전체(재시작 필요)                   |
-| createdYmdt                   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-| updatedYmdt                   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                      |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "404e8a89-ca4d-4fca-96c2-1518754d50b7",
-    "parameterGroupName": "parameter-group",
-    "description": null,
-    "dbVersion": "MARIADB_V10330",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "parameterId": "fa040b5e-f29f-46de-8f0d-bba4cb82887a",
-            "parameterFileGroup": "client",
-            "parameterName": "socket",
-            "fileParameterName": "socket",
-            "value": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "defaultValue": "/home/tcrds/db/mysql/tmp/mysql.sock",
-            "allowedValue": "",
-            "updateType": "CONSTANT",
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-03-13T11:02:28+09:00",
-    "updatedYmdt": "2023-03-13T11:02:28+09:00"
-}
-```
-
-</p>
-</details>
-
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Create | 파라미터 그룹 생성하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-| dbVersion          | Body | Enum   | O  | DB 엔진 유형             |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group",
-    "dbVersion": "MARIADB_V10330"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 필요 권한
-
-| 권한명                                             | 설명           |
-|-------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Copy | 파라미터 그룹 복사하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | O  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group-copy",
-    "description": "copy"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름               | 종류   | 형식   | 설명           |
-|------------------|------|------|--------------|
-| parameterGroupId | Body | UUID | 파라미터 그룹의 식별자 |
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                 | 종류   | 형식     | 필수 | 설명                   |
-|--------------------|------|--------|----|----------------------|
-| parameterGroupId   | URL  | UUID   | O  | 파라미터 그룹의 식별자         |
-| parameterGroupName | Body | String | X  | 파라미터 그룹을 식별할 수 있는 이름 |
-| description        | Body | String | X  | 파라미터 그룹에 대한 추가 정보    |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameter-group"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Modify | 파라미터 그룹 수정하기 |
-
-#### 요청
-
-| 이름                             | 종류   | 형식     | 필수 | 설명           |
-|--------------------------------|------|--------|----|--------------|
-| parameterGroupId               | URL  | UUID   | O  | 파라미터 그룹의 식별자 |
-| modifiedParameters             | Body | Array  | O  | 변경할 파라미터 목록  |
-| modifiedParameters.parameterId | Body | UUID   | O  | 파라미터의 식별자    |
-| modifiedParameters.value       | Body | String | O  | 변경할 파라미터 값   |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "parameterId": "3abac558-7274-44e1-9f4a-f100f53f67ba",
-            "value": "0"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 필요 권한
-
-| 권한명                                              | 설명            |
-|--------------------------------------------------|---------------|
-| RDSforMariaDB:ParameterGroup.Reset | 파라미터 그룹 재설정하기 |
-
-#### 요청
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명           |
-|---------------------------------------------------|--------------|
-| RDSforMariaDB:ParameterGroup.Delete | 파라미터 그룹 삭제하기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름               | 종류  | 형식   | 필수 | 설명           |
-|------------------|-----|------|----|--------------|
-| parameterGroupId | URL | UUID | O  | 파라미터 그룹의 식별자 |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "jobId": "550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
@@ -4239,25 +3977,20 @@ DELETE /v4.0/parameter-groups/{parameterGroupId}
 GET /v4.0/user-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                        | 설명           |
-|--------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.List | 사용자 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                       | 종류   | 형식       | 설명                                |
-|--------------------------|------|----------|-----------------------------------|
-| userGroups               | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId   | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| userGroups.createdYmdt   | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| userGroups.updatedYmdt   | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 사용자 그룹 목록 수 |
+| userGroups | Body | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| userGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4269,74 +4002,12 @@ GET /v4.0/user-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
+    "totalCounts": 1,
     "userGroups": [
         {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team",
-            "createdYmdt": "2023-02-23T10:07:54+09:00",
-            "updatedYmdt": "2023-02-26T01:15:50+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 사용자 그룹 상세 보기
-
-```http
-GET /v4.0/user-groups/{userGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                       | 설명           |
-|-------------------------------------------|--------------|
-| RDSforMariaDB:UserGroup.Get | 사용자 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
-
-#### 응답
-
-| 이름                | 종류   | 형식       | 설명                                                                                                        |
-|-------------------|------|----------|-----------------------------------------------------------------------------------------------------------|
-| userGroupId       | Body | UUID     | 사용자 그룹의 식별자                                                                                               |
-| userGroupName     | Body | String   | 사용자 그룹을 식별할 수 있는 이름                                                                                       |
-| userGroupTypeCode | Body | Enum     | 사용자 그룹 종류    <br /> `ENTIRE`: 프로젝트 멤버 전체를 포함하는 사용자 그룹 <br /> `INDIVIDUAL_MEMBER`: 특정 프로젝트 멤버를 포함하는 사용자 그룹 |
-| members           | Body | Array    | 프로젝트 멤버 목록                                                                                                |
-| members.memberId  | Body | UUID     | 프로젝트 멤버의 식별자                                                                                              |
-| createdYmdt       | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-| updatedYmdt       | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                         |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-    "userGroupName": "dev-team",
-	"userGroupTypeCode": "INDIVIDUAL_MEMBER",
-    "members": [
-        {
-            "memberId": "1321e759-2ef3-4b85-9921-b13e918b24b5"
-        }
-    ],
-    "createdYmdt": "2023-02-23T10:07:54+09:00",
-    "updatedYmdt": "2023-02-26T01:15:50+09:00"
 }
 ```
 
@@ -4351,36 +4022,22 @@ GET /v4.0/user-groups/{userGroupId}
 POST /v4.0/user-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Create | 사용자 그룹 생성하기 |
-
 #### 요청
 
-| 이름            | 종류   | 형식      | 필수 | 설명                                                        |
-|---------------|------|---------|----|-----------------------------------------------------------|
-| userGroupName | Body | String  | O  | 사용자 그룹을 식별할 수 있는 이름                                       |
-| memberIds     | Body | Array   | O  | 프로젝트 멤버의 식별자 목록 <br /> `selectAll`이 true인 경우 해당 필드 값은 무시됩니다 |
-| selectAll     | Body | Boolean | X  | 프로젝트 멤버 전체 여부 <br /> true인 경우 해당 그룹은 전체 멤버를 대상으로 설정됩니다        |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | O | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5"
-    ]
-}
-```
-
-```json
-{
-    "userGroupName": "dev-team",
-    "selectAll": true
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
 }
 ```
 
@@ -4389,52 +4046,9 @@ POST /v4.0/user-groups
 
 #### 응답
 
-| 이름          | 종류   | 형식   | 설명          |
-|-------------|------|------|-------------|
-| userGroupId | Body | UUID | 사용자 그룹의 식별자 |
-
----
-
-### 사용자 그룹 수정하기
-
-```http
-PUT /v4.0/user-groups/{userGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Modify | 사용자 그룹 수정하기 |
-
-#### 요청
-
-| 이름            | 종류   | 형식      | 필수 | 설명                                                 |
-|---------------|------|---------|----|----------------------------------------------------|
-| userGroupId   | URL  | UUID    | O  | 사용자 그룹의 식별자                                        |
-| userGroupName | Body | String  | X  | 사용자 그룹을 식별할 수 있는 이름                                |
-| memberIds     | Body | Array   | X  | 프로젝트 멤버의 식별자 목록                                    |
-| selectAll     | Body | Boolean | X  | 프로젝트 멤버 전체 여부 <br /> true인 경우 해당 그룹은 전체 멤버를 대상으로 설정됩니다 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "userGroupName": "dev-team",
-    "memberIds": [
-        "1321e759-2ef3-4b85-9921-b13e918b24b5",
-        "f9064b09-2b15-442e-a4b0-3a5a2754555e"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4445,7 +4059,8 @@ PUT /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "userGroupId-example"
 }
 ```
 
@@ -4460,21 +4075,45 @@ PUT /v4.0/user-groups/{userGroupId}
 DELETE /v4.0/user-groups/{userGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                                          | 설명          |
-|----------------------------------------------|-------------|
-| RDSforMariaDB:UserGroup.Delete | 사용자 그룹 삭제하기 |
-
 #### 요청
 
-| 이름          | 종류  | 형식   | 필수 | 설명          |
-|-------------|-----|------|----|-------------|
-| userGroupId | URL | UUID | O  | 사용자 그룹의 식별자 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 사용자 그룹 상세 보기
+
+```http
+GET /v4.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| userGroupTypeCode | Body | Enum | 사용자 그룹 종류<br/>- ENTIRE<br/>- INDIVIDUAL_MEMBER |
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4485,12 +4124,57 @@ DELETE /v4.0/user-groups/{userGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "userGroupId": "userGroupId-example",
+    "userGroupName": "userGroupName-example",
+    "userGroupTypeCode": "ENTIRE",
+    "members": [
+        {
+            "memberId": "memberId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
 </p>
 </details>
+
+---
+
+### 사용자 그룹 수정하기
+
+```http
+PUT /v4.0/user-groups/{userGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| userGroupId | URL | UUID | O |  |
+| userGroupName | Body | String | O | 사용자 그룹을 식별할 수 있는 이름 |
+| memberIds | Body | Array | X | 프로젝트 멤버의 식별자 목록 |
+| selectAll | Body | Boolean | X | 프로젝트 멤버 전체 포함 여부<br/>- 기본값: `false` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "userGroupName": "userGroupName-example",
+    "memberIds": [],
+    "selectAll": false
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4502,28 +4186,22 @@ DELETE /v4.0/user-groups/{userGroupId}
 GET /v4.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                                | 설명          |
-|----------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.List | 알림 그룹 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                       | 종류   | 형식       | 설명                                |
-|------------------------------------------|------|----------|-----------------------------------|
-| notificationGroups                       | Body | Array    | 알림 그룹 목록                          |
-| notificationGroups.notificationGroupId   | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroups.notificationGroupName | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notificationGroups.notifyEmail           | Body | Boolean  | 이메일 알림 여부                         |
-| notificationGroups.notifySms             | Body | Boolean  | SMS 알림 여부                         |
-| notificationGroups.isEnabled             | Body | Boolean  | 활성화 여부                            |
-| notificationGroups.createdYmdt           | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| notificationGroups.updatedYmdt           | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroups | Body | Array | 알림 그룹 목록 |
+| notificationGroups.notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroups.notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notificationGroups.notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notificationGroups.notifySms | Body | Boolean | SMS 알림 여부 |
+| notificationGroups.isEnabled | Body | Boolean | 활성화 여부 |
+| notificationGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| notificationGroups.updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4537,90 +4215,9 @@ GET /v4.0/notification-groups
     },
     "notificationGroups": [
         {
-            "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-            "notificationGroupName": "dev-team-noti",
-            "notifyEmail": true,
-            "notifySms": false,
-            "isEnabled": true,
-            "createdYmdt": "2023-02-20T13:34:13+09:00",
-            "updatedYmdt": "2023-02-20T13:34:13+09:00"
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 알림 그룹 상세 보기
-
-```http
-GET /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                               | 설명          |
-|---------------------------------------------------|-------------|
-| RDSforMariaDB:NotificationGroup.Get | 알림 그룹 상세 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
-
-#### 응답
-
-| 이름                         | 종류   | 형식       | 설명                                |
-|----------------------------|------|----------|-----------------------------------|
-| notificationGroupId        | Body | UUID     | 알림 그룹의 식별자                        |
-| notificationGroupName      | Body | String   | 알림 그룹을 식별할 수 있는 이름                |
-| notifyEmail                | Body | Boolean  | 이메일 알림 여부                         |
-| notifySms                  | Body | Boolean  | SMS 알림 여부                         |
-| isEnabled                  | Body | Boolean  | 활성화 여부                            |
-| dbInstances                | Body | Array    | 감시 대상 DB 인스턴스 목록                  |
-| dbInstances.dbInstanceId   | Body | UUID     | DB 인스턴스의 식별자                      |
-| dbInstances.dbInstanceName | Body | String   | DB 인스턴스를 식별할 수 있는 이름              |
-| userGroups                 | Body | Array    | 사용자 그룹 목록                         |
-| userGroups.userGroupId     | Body | UUID     | 사용자 그룹의 식별자                       |
-| userGroups.userGroupName   | Body | String   | 사용자 그룹을 식별할 수 있는 이름               |
-| createdYmdt                | Body | DateTime | 생성 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| updatedYmdt                | Body | DateTime | 수정 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "notificationGroupId": "b3901f17-9971-4d1e-8a81-8448cf533dc7",
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": true,
-    "notifySms": false,
-    "isEnabled": true,
-    "dbInstances": [
-        {
-            "dbInstanceId": "ed5cb985-526f-4c54-9ae0-40288593de65",
-            "dbInstanceName": "database"
-        }
-    ],
-    "userGroups": [
-        {
-            "userGroupId": "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0",
-            "userGroupName": "dev-team"
-        }
-    ],
-    "createdYmdt": "2023-02-20T13:34:13+09:00",
-    "updatedYmdt": "2023-02-20T13:34:13+09:00"
 }
 ```
 
@@ -4635,85 +4232,28 @@ GET /v4.0/notification-groups/{notificationGroupId}
 POST /v4.0/notification-groups
 ```
 
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Create | 알림 그룹 생성하기 |
-
 #### 요청
 
-| 이름                    | 종류   | 형식      | 필수 | 설명                          |
-|-----------------------|------|---------|----|-----------------------------|
-| notificationGroupName | Body | String  | O  | 알림 그룹을 식별할 수 있는 이름          |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부<br/>- 기본값: `true` |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부<br/>- 기본값: `true` |
-| isEnabled             | Body | Boolean | X  | 활성화 여부<br/>- 기본값: `true`    |
-| dbInstanceIds         | Body | Array   | O  | 감시 대상 DB 인스턴스의 식별자 목록       |
-| userGroupIds          | Body | Array   | O  | 사용자 그룹의 식별자 목록              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupName | Body | String | O | 알림 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `true` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `true` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `true` |
+| dbInstanceIds | Body | Array | O | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | O | 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "notificationGroupName": "dev-team-noti",
-    "notifyEmail": false,
-    "isEnable": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65"
-    ],
-    "userGroupIds": [
-        "1aac0437-f32d-4923-ad3c-ac61c1cfdfe0"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름                  | 종류   | 형식   | 설명         |
-|---------------------|------|------|------------|
-| notificationGroupId | Body | UUID | 알림 그룹의 식별자 |
-
----
-
-### 알림 그룹 수정하기
-
-```http
-PUT /v4.0/notification-groups/{notificationGroupId}
-```
-
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Modify | 알림 그룹 수정하기 |
-
-#### 요청
-
-| 이름                    | 종류   | 형식      | 필수 | 설명                    |
-|-----------------------|------|---------|----|-----------------------|
-| notificationGroupId   | URL  | UUID    | O  | 알림 그룹의 식별자            |
-| notificationGroupName | Body | String  | X  | 알림 그룹을 식별할 수 있는 이름    |
-| notifyEmail           | Body | Boolean | X  | 이메일 알림 여부             |
-| notifySms             | Body | Boolean | X  | SMS 알림 여부             |
-| isEnabled             | Body | Boolean | X  | 활성화 여부                |
-| dbInstanceIds         | Body | Array   | X  | 감시 대상 DB 인스턴스의 식별자 목록 |
-| userGroupIds          | Body | Array   | X  | 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
+    "notificationGroupName": "notificationGroupName",
     "notifyEmail": true,
-    "dbInstanceIds": [
-        "ed5cb985-526f-4c54-9ae0-40288593de65",
-        "d51b7da0-682f-47ff-b588-b739f6adc740"
-    ]
+    "notifySms": true,
+    "isEnabled": true,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
@@ -4722,7 +4262,9 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 #### 응답
 
-이 API는 응답 본문을 반환하지 않습니다.
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -4733,7 +4275,8 @@ PUT /v4.0/notification-groups/{notificationGroupId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "notificationGroupId": "notificationGroupId-example"
 }
 ```
 
@@ -4748,67 +4291,51 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 DELETE /v4.0/notification-groups/{notificationGroupId}
 ```
 
-#### 필요 권한
-
-| 권한명                                                  | 설명         |
-|------------------------------------------------------|------------|
-| RDSforMariaDB:NotificationGroup.Delete | 알림 그룹 삭제하기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름                  | 종류  | 형식   | 필수 | 설명         |
-|---------------------|-----|------|----|------------|
-| notificationGroupId | URL | UUID | O  | 알림 그룹의 식별자 |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
 
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
-}
-```
-
-</p>
-</details>
-
 ---
 
-## 모니터링
-
-### Metric 목록 보기
+### 알림 그룹 상세 보기
 
 ```http
-GET /v4.0/metrics
+GET /v4.0/notification-groups/{notificationGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+
 #### 응답
 
-| 이름                  | 종류   | 형식     | 설명        |
-|---------------------|------|--------|-----------|
-| metrics             | Body | Array  | Metric 목록 |
-| metrics.measureName | Body | Enum   | 조회 지표 유형  |
-| metrics.unit        | Body | String | 측정값 단위    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| notificationGroupId | Body | String | 알림 그룹의 식별자 |
+| notificationGroupName | Body | String | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | 이메일 알림 여부 |
+| notifySms | Body | Boolean | SMS 알림 여부 |
+| isEnabled | Body | Boolean | 활성화 여부 |
+| dbInstances | Body | Array | 감시 대상 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceName | Body | String | DB 인스턴스를 식별할 수 있는 이름 |
+| userGroups | Body | Array | 사용자 그룹 목록 |
+| userGroups.userGroupId | Body | String | 사용자 그룹의 식별자 |
+| userGroups.userGroupName | Body | String | 사용자 그룹을 식별할 수 있는 이름 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -4820,12 +4347,23 @@ GET /v4.0/metrics
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "metrics": [
+    "notificationGroupId": "notificationGroupId-example",
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstances": [
         {
-            "measureName": "CPU_USAGE",
-            "unit": "%"
+            "dbInstanceName": "dbInstanceName-example"
         }
-    ]
+    ],
+    "userGroups": [
+        {
+            "userGroupName": "userGroupName-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -4834,69 +4372,44 @@ GET /v4.0/metrics
 
 ---
 
-### 통계 정보 조회
+### 알림 그룹 수정하기
 
 ```http
-GET /v4.0/metric-statistics
+PUT /v4.0/notification-groups/{notificationGroupId}
 ```
-
-#### 필요 권한
-
-| 권한명                                     | 설명       |
-|-----------------------------------------|----------|
-| RDSforMariaDB:Metric.List | 통계 정보 조회 |
 
 #### 요청
 
-| 이름           | 종류    | 형식       | 필수 | 설명                                |
-|--------------|-------|----------|----|-----------------------------------|
-| dbInstanceId | Query | UUID     | O  | DB 인스턴스의 식별자                      |
-| measureNames | Query | Array    | O  | 조회 지표 목록<br/>- 최소 크기: `1`         |
-| from         | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| to           | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-| interval     | Query | Number   | X  | 조회 간격                             |
-
-#### 응답
-
-| 이름                                | 종류   | 형식        | 설명       |
-|-----------------------------------|------|-----------|----------|
-| metricStatistics                  | Body | Array     | 통계 정보 목록 |
-| metricStatistics.measureName      | Body | Enum      | 측정 항목 유형 |
-| metricStatistics.unit             | Body | String    | 측정값 단위   |
-| metricStatistics.values           | Body | Array     | 측정값 목록   |
-| metricStatistics.values.timestamp | Body | Timestamp | 측정 시간    |
-| metricStatistics.values.value     | Body | Object    | 측정값      |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| notificationGroupId | URL | UUID | O |  |
+| notificationGroupName | Body | String | X | 알림 그룹을 식별할 수 있는 이름 |
+| notifyEmail | Body | Boolean | X | 이메일 알림 여부<br/>- 기본값: `false` |
+| notifySms | Body | Boolean | X | SMS 알림 여부<br/>- 기본값: `false` |
+| isEnabled | Body | Boolean | X | 활성화 여부<br/>- 기본값: `false` |
+| dbInstanceIds | Body | Array | X | 감시 대상 DB 인스턴스의 식별자 목록 |
+| userGroupIds | Body | Array | X | 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "metricStatistics": [
-        {
-            "measureName": "MYSQL_STATUS",
-            "unit": "",
-            "values": [
-                [
-                    1679298540,
-                    "1"
-                ],
-                [
-                    1679298600,
-                    "1"
-                ],
-                [
-                    1679298660,
-                    "1"
-                ]
-            ]
-        }
-    ]
+    "notificationGroupName": "notificationGroupName-example",
+    "notifyEmail": false,
+    "notifySms": false,
+    "isEnabled": false,
+    "dbInstanceIds": [],
+    "userGroupIds": []
 }
 ```
 
 </p>
 </details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4915,117 +4428,23 @@ GET /v4.0/metric-statistics
 | TENANT      | 테넌트     |
 | MONITORING  | 모니터링    |
 
-### 이벤트 목록 조회
-
-```http
-GET /v4.0/events
-```
-
-#### 필요 권한
-
-| 권한명                                    | 설명        |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | 이벤트 목록 보기 |
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름                | 종류    | 형식       | 필수 | 설명                                                                                                                                   |
-|-------------------|-------|----------|----|--------------------------------------------------------------------------------------------------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1`                                                                                                           |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20                                        |
-| from              | Query | Datetime | O  | 시작 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| to                | Query | Datetime | O  | 종료 일시(YYYY-MM-DDThh:mm:ss.SSSTZD)                                                                                                    |
-| eventCategoryType | Query | Enum     | O  | 조회할 이벤트 카테고리 유형<br/>- `ALL`: 전체<br/>- `INSTANCE`: DB 인스턴스<br/>- `BACKUP`: 백업<br/>- `DB_SECURITY_GROUP`: DB 보안 그룹<br/>- `TENANT`: 테넌트 |
-| sourceId          | Query | String   | X  | 이벤트가 발생한 대상 리소스의 식별자                                                                                                                 |
-| keyword           | Query | String   | X  | 이벤트 메시지에 포함된 문자열 검색어                                                                                                                 |
-| ascendingOrder    | Query | Enum     | X  | 이벤트 메시지 정렬 순서<br/>- `ASC`: 오름차순<br/>- `DESC`: 내림차순<br/>- 기본값: `DESC`                                                                 |
-
-#### 응답
-
-| 이름                       | 종류   | 형식       | 설명                                    |
-|--------------------------|------|----------|---------------------------------------|
-| totalCounts              | Body | Number   | 전체 이벤트 목록 수                           |
-| events                   | Body | Array    | 이벤트 목록                                |
-| events.eventCategoryType | Body | Enum     | 이벤트 카테고리 유형                           |
-| events.eventCode         | Body | Enum     | 발생한 이벤트의 유형                           |
-| events.sourceId          | Body | String   | 이벤트 소스의 식별자                           |
-| events.sourceName        | Body | String   | 이벤트 소스를 식별할 수 있는 이름                   |
-| events.messages          | Body | Array    | 이벤트 메시지 목록                            |
-| events.messages.langCode | Body | String   | 언어 코드                                 |
-| events.messages.message  | Body | String   | 이벤트 메시지                               |
-| events.eventYmdt         | Body | DateTime | 이벤트 발생 일시(YYYY-MM-DDThh:mm:ss.SSSTZD) |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 28,
-    "events": [
-        {
-            "eventCategoryType": "INSTANCE",
-            "eventCode": "INSTC_02_01",
-            "sourceId": "76f00947-356e-4a20-8922-428368cc45ed",
-            "sourceName": "db-instance",
-            "messages": [
-                {
-                    "langCode": "EN",
-                    "message": "DB instance started"
-                },
-                {
-                    "langCode": "JA",
-                    "message": "DBインスタンスの起動"
-                },
-                {
-                    "langCode": "KO",
-                    "message": "DB 인스턴스 시작"
-                },
-                {
-                    "langCode": "ZH",
-                    "message": "DB instance started"
-                }
-            ],
-            "eventYmdt": "2023-03-20T16:31:59+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
 ### 구독 가능한 이벤트 코드 목록 보기
 
 ```http
 GET /v4.0/event-codes
 ```
 
-#### 필요 권한
-
-| 권한명                                    | 설명        |
-|----------------------------------------|-----------|
-| RDSforMariaDB:Event.List | 이벤트 목록 보기 |
-
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                           | 종류   | 형식    | 설명          |
-|------------------------------|------|-------|-------------|
-| eventCodes                   | Body | Array | 이벤트 코드 목록   |
-| eventCodes.eventCode         | Body | Enum  | 이벤트 코드      |
-| eventCodes.eventCategoryType | Body | Enum  | 이벤트 카테고리 유형 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| eventCodes | Body | Array | 이벤트 코드 목록 |
+| eventCodes.eventCode | Body | Enum | 이벤트 코드 |
+| eventCodes.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 
 <details><summary>예시</summary>
 <p>
@@ -5039,8 +4458,56 @@ GET /v4.0/event-codes
     },
     "eventCodes": [
         {
-            "eventCode": "INSTC_05_01",
-            "eventCategoryType": "INSTANCE"
+            "eventCategoryType": "ALL"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 이벤트 목록 조회
+
+```http
+GET /v4.0/events
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 이벤트 목록 수 |
+| events | Body | Array | 이벤트 목록 |
+| events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
+| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
+| events.messages | Body | Array | 이벤트 메세지 목록 |
+| events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
+| events.messages.message | Body | String | 이벤트 메세지 |
+| events.eventYmdt | Body | DateTime | 이벤트 발생 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "events": [
+        {
+            "eventYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5059,40 +4526,28 @@ GET /v4.0/event-codes
 GET /v4.0/event-subscriptions
 ```
 
-#### 필요 권한
-
-| 권한명                                                    | 설명            |
-|---------------------------------------------------------|---------------|
-| RDSforMariaDB:EventSubscription.List | 이벤트 구독 목록 조회 |
-
 #### 요청
 
-| 이름                | 종류    | 형식       | 필수 | 설명                                       |
-|-------------------|-------|----------|----|------------------------------------------|
-| page              | Query | Number   | X  | 조회할 목록의 페이지<br/>- 기본값: 1 <br/>- 최솟값: `1` |
-| size              | Query | Number   | X  | 조회할 목록의 페이지 크기<br/>- 기본값: 20             |
-| eventSubscriptionId    | Query | UUID   | X  | 이벤트 구독의 식별자                              |
-| eventSubscriptionName  | Query | String | X  | 이벤트 구독을 식별할 수 있는 이름                      |
-| userGroupId            | Query | UUID   | X  | 사용자 그룹의 식별자                              |
+이 API는 요청 본문을 요구하지 않습니다.
 
 #### 응답
 
-| 이름                                            | 종류   | 형식       | 설명                       |
-|-----------------------------------------------|------|----------|--------------------------|
-| totalCounts                                   | Body | Number   | 전체 이벤트 구독 목록 수           |
-| eventSubscriptions                            | Body | Array    | 이벤트 구독 목록                |
-| eventSubscriptions.eventSubscriptionId        | Body | UUID     | 이벤트의 구독 식별자              |
-| eventSubscriptions.eventCategoryType          | Body | Enum     | 이벤트 카테고리 유형              |
-| eventSubscriptions.eventSubscriptionName      | Body | String   | 이벤트 구독을 식별할 수 있는 이름      |
-| eventSubscriptions.enabled                    | Body | Boolean  | 활성화 여부                   |
-| eventSubscriptions.notifyEmail                | Body | Boolean  | 이메일 발송 여부                |
-| eventSubscriptions.notifySms                  | Body | Boolean  | SMS 발송 여부                |
-| eventSubscriptions.eventCodes                 | Body | Array    | 구독할 이벤트 코드 목록            |
-| eventSubscriptions.sources                    | Body | Array    | 구독할 이벤트 소스 목록            |
-| eventSubscriptions.sources.sourceId           | Body | UUID     | 이벤트 소스의 식별자              |
-| eventSubscriptions.sources.eventCategoryType  | Body | Enum     | 이벤트 카테고리 유형              |
-| eventSubscriptions.userGroupIds               | Body | Array    | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
-| eventSubscriptions.createdYmdt                | Body | DateTime | 생성 일시                    |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 이벤트 구독 목록 수 |
+| eventSubscriptions | Body | Array | 이벤트 구독 목록 |
+| eventSubscriptions.eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
+| eventSubscriptions.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.eventSubscriptionName | Body | String | 이벤트 구독의 식별할 수 있는 이름 |
+| eventSubscriptions.enabled | Body | Boolean | 활성화 여부 |
+| eventSubscriptions.notifyEmail | Body | Boolean | 이메일 발송 여부 |
+| eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
+| eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
+| eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
+| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
+| eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -5107,25 +4562,7 @@ GET /v4.0/event-subscriptions
     "totalCounts": 1,
     "eventSubscriptions": [
         {
-            "eventSubscriptionId": "12345678-1234-1234-1234-123456789012",
-            "eventCategoryType": "INSTANCE",
-            "eventSubscriptionName": "example-event-subscription",
-            "enabled": true,
-            "notifyEmail": true,
-            "notifySms": false,
-            "eventCodes": [
-                "INSTC_05_01"
-            ],
-            "sources": [
-                {
-                    "sourceId": "87654321-4321-4321-4321-210987654321",
-                    "eventCategoryType": "INSTANCE"
-                }
-            ],
-            "userGroupIds": [
-                "11111111-2222-3333-4444-555555555555"
-            ],
-            "createdYmdt": "2024-01-01T12:00:00+09:00"
+            "createdYmdt": "2023-12-31T15:00:00+09:00"
         }
     ]
 }
@@ -5142,49 +4579,38 @@ GET /v4.0/event-subscriptions
 POST /v4.0/event-subscriptions
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Create | 이벤트 구독 생성하기 |
-
 #### 요청
 
-| 이름                           | 종류   | 형식      | 필수 | 설명                                    |
-|------------------------------|------|---------|----|-----------------------------------------|
-| eventCategoryType            | Body | Enum    | O  | 이벤트 카테고리 유형                          |
-| eventSubscriptionName        | Body | String  | O  | 이벤트 구독을 식별할 수 있는 이름<br/>- 최대 길이: `100` |
-| enabled                      | Body | Boolean | O  | 활성화 여부                                |
-| notifyEmail                  | Body | Boolean | O  | 이메일 발송 여부                             |
-| notifySms                    | Body | Boolean | O  | SMS 발송 여부                             |
-| eventCodes                   | Body | Array   | O  | 구독할 이벤트 코드 목록                        |
-| sources                      | Body | Array   | O  | 구독할 이벤트 소스 목록                        |
-| sources.sourceId             | Body | UUID    | O  | 이벤트 소스의 식별자                          |
-| sources.eventCategoryType    | Body | Enum    | O  | 이벤트 카테고리 유형                          |
-| userGroupIds                 | Body | Array   | O  | 이벤트 구독할 사용자 그룹의 식별자 목록              |
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | O | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Body | Boolean | O | 활성화 여부 |
+| notifyEmail | Body | Boolean | O | 이메일 발송 여부 |
+| notifySms | Body | Boolean | O | SMS 발송 여부 |
+| eventCodes | Body | Array | O | 구독할 이벤트 코드 목록 |
+| sources | Body | Array | O | 구독할 이벤트 소스 목록 |
+| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | O | 이벤트 구독할 사용자 그룹의 식별자 목록 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "eventCategoryType": "INSTANCE",
-    "eventSubscriptionName": "example-event-subscription",
-    "enabled": true,
-    "notifyEmail": true,
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
     "notifySms": false,
-    "eventCodes": [
-        "INSTC_05_01"
-    ],
+    "eventCodes": [],
     "sources": [
         {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
+            "eventCategoryType": "ALL"
         }
     ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555"
-    ]
+    "userGroupIds": []
 }
 ```
 
@@ -5193,9 +4619,9 @@ POST /v4.0/event-subscriptions
 
 #### 응답
 
-| 이름                    | 종류   | 형식   | 설명          |
-|-----------------------|------|------|-------------|
-| eventSubscriptionId   | Body | UUID | 이벤트 구독의 식별자 |
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| eventSubscriptionId | Body | String | 이벤트 구독의 식별자 |
 
 <details><summary>예시</summary>
 <p>
@@ -5207,86 +4633,7 @@ POST /v4.0/event-subscriptions
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "eventSubscriptionId": "12345678-1234-1234-1234-123456789012"
-}
-```
-
-</p>
-</details>
-
----
-
-### 이벤트 구독 수정하기
-
-```http
-PUT /v4.0/event-subscriptions/{eventSubscriptionId}
-```
-
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Modify | 이벤트 구독 수정하기 |
-
-#### 요청
-
-| 이름                           | 종류   | 형식      | 필수 | 설명                              |
-|------------------------------|------|---------|----|-----------------------------------|
-| eventSubscriptionId          | URL  | UUID    | O  | 이벤트 구독의 식별자                    |
-| eventCategoryType            | Body | Enum    | X  | 이벤트 카테고리 유형                    |
-| eventSubscriptionName        | Body | String  | X  | 이벤트 구독을 식별할 수 있는 이름           |
-| enabled                      | Body | Boolean | X  | 활성화 여부                          |
-| notifyEmail                  | Body | Boolean | X  | 이메일 발송 여부                       |
-| notifySms                    | Body | Boolean | X  | SMS 발송 여부                       |
-| eventCodes                   | Body | Array   | X  | 구독할 이벤트 코드 목록                  |
-| sources                      | Body | Array   | X  | 구독할 이벤트 소스 목록                  |
-| sources.sourceId             | Body | UUID    | X  | 이벤트 소스의 식별자                    |
-| sources.eventCategoryType    | Body | Enum    | X  | 이벤트 카테고리 유형                    |
-| userGroupIds                 | Body | Array   | X  | 이벤트 구독할 사용자 그룹의 식별자 목록        |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "eventSubscriptionName": "updated-event-subscription",
-    "enabled": false,
-    "notifyEmail": false,
-    "notifySms": true,
-    "eventCodes": [
-        "INSTC_05_01",
-        "INSTC_06_01"
-    ],
-    "sources": [
-        {
-            "sourceId": "87654321-4321-4321-4321-210987654321",
-            "eventCategoryType": "INSTANCE"
-        }
-    ],
-    "userGroupIds": [
-        "11111111-2222-3333-4444-555555555555",
-        "22222222-3333-4444-5555-666666666666"
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    }
+    "eventSubscriptionId": "eventSubscriptionId-example"
 }
 ```
 
@@ -5301,21 +4648,115 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 ```
 
-#### 필요 권한
-
-| 권한명                                                      | 설명           |
-|----------------------------------------------------------|--------------|
-| RDSforMariaDB:EventSubscription.Delete | 이벤트 구독 삭제하기 |
-
 #### 요청
 
-| 이름                    | 종류  | 형식   | 필수 | 설명          |
-|-----------------------|-----|------|----|-------------|
-| eventSubscriptionId   | URL | UUID | O  | 이벤트 구독의 식별자 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
 
 #### 응답
 
 이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 이벤트 구독 수정하기
+
+```http
+PUT /v4.0/event-subscriptions/{eventSubscriptionId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| eventSubscriptionId | URL | UUID | O |  |
+| eventCategoryType | Body | Enum | X | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| eventSubscriptionName | Body | String | X | 이벤트 구독을 식별할 수 있는 이름 |
+| enabled | Body | Boolean | X | 활성화 여부 |
+| notifyEmail | Body | Boolean | X | 이메일 발송 여부 |
+| notifySms | Body | Boolean | X | SMS 발송 여부 |
+| eventCodes | Body | Array | X | 구독할 이벤트 코드 목록 |
+| sources | Body | Array | X | 구독할 이벤트 소스 목록 |
+| sources.sourceId | Body | UUID | O | 이벤트 소스의 식별자 |
+| sources.eventCategoryType | Body | Enum | O | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
+| userGroupIds | Body | Array | X | 이벤트 구독할 사용자 그룹의 식별자 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "eventCategoryType": "ALL",
+    "eventSubscriptionName": "eventSubscriptionName-example",
+    "enabled": false,
+    "notifyEmail": false,
+    "notifySms": false,
+    "eventCodes": [],
+    "sources": [
+        {
+            "eventCategoryType": "ALL"
+        }
+    ],
+    "userGroupIds": []
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v4.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
 
 <details><summary>예시</summary>
 <p>
@@ -5326,7 +4767,16 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
         "resultCode": 0,
         "resultMessage": "SUCCESS",
         "isSuccessful": true
-    }
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -5334,3 +4784,422 @@ DELETE /v4.0/event-subscriptions/{eventSubscriptionId}
 </details>
 
 ---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
+
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v4.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 상세 보기
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 목록 |
+| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+## 프로젝트 정보
+
+### 프로젝트 멤버 목록 보기
+
+```http
+GET /v4.0/project/members
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberName | Body | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "members": [
+        {
+            "phoneNumber": "phoneNumber-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 리전 목록 보기
+
+```http
+GET /v4.0/project/regions
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 목록 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
+        {
+            "isEnabled": false
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -75,21 +75,12 @@ API 요청 시 인증에 실패하거나 권한이 없을 경우 다음과 같�
 * ENUM 타입의 dbVersion 필드에 대해 해당 값을 사용할 수 있습니다.
 * 버전에 따라 생성 또는 복원이 불가능한 경우가 있을 수 있습니다.
 
-## DB 보안 그룹
+## 프로젝트 정보
 
-### DB 보안 그룹 진행 상태
-
-| 상태              | 설명           |
-|-----------------|--------------|
-| `NONE`          | 진행 중인 작업이 없음 |
-| `CREATING_RULE` | 규칙 정책 생성 중   |
-| `UPDATING_RULE` | 규칙 정책 수정 중   |
-| `DELETING_RULE` | 규칙 정책 삭제 중   |
-
-### DB 보안 그룹 목록 보기
+### 프로젝트 멤버 목록 보기
 
 ```http
-GET /v4.0/db-security-groups
+GET /v4.0/project/members
 ```
 
 #### 요청
@@ -100,14 +91,11 @@ GET /v4.0/db-security-groups
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
-| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
-| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+| members | Body | Array | 프로젝트 멤버 목록 |
+| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
+| members.memberName | Body | String | 프로젝트 멤버의 이름 |
+| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
+| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
 
 <details><summary>예시</summary>
 <p>
@@ -119,10 +107,9 @@ GET /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "totalCounts": 1,
-    "dbSecurityGroups": [
+    "members": [
         {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            "phoneNumber": "phoneNumber-example"
         }
     ]
 }
@@ -133,38 +120,37 @@ GET /v4.0/db-security-groups
 
 ---
 
-### DB 보안 그룹 생성하기
+### 리전 목록 보기
 
 ```http
-POST /v4.0/db-security-groups
+GET /v4.0/project/regions
 ```
 
 #### 요청
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
-| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | O | 포트 객체 |
-| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| rules.cidr | Body | String | O | CIDR |
-| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| regions | Body | Array | 리전 목록 |
+| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
+| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
 
 <details><summary>예시</summary>
 <p>
 
 ```json
 {
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example",
-    "rules": [
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "regions": [
         {
-            "description": "description-example"
+            "isEnabled": false
         }
     ]
 }
@@ -173,11 +159,29 @@ POST /v4.0/db-security-groups
 </p>
 </details>
 
+---
+
+## DB 인스턴스 사양
+
+### DB 인스턴스 사양 목록 보기
+
+```http
+GET /v4.0/db-flavors
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
+| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
+| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
+| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
+| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
 
 <details><summary>예시</summary>
 <p>
@@ -189,93 +193,11 @@ POST /v4.0/db-security-groups
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "dbSecurityGroupId": "dbSecurityGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 상세 보기
-
-```http
-GET /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
-| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
-| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
-| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
-| rules | Body | Array | DB 보안 그룹 규칙 목록 |
-| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
-| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
-| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| rules.port | Body | Object | 포트 객체 |
-| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| rules.port.minPort | Body | Number | 최소 포트 범위 |
-| rules.port.maxPort | Body | Number | 최대 포트 범위 |
-| rules.cidr | Body | String | CIDR |
-| rules.createdYmdt | Body | DateTime | 생성 일시 |
-| rules.updatedYmdt | Body | DateTime | 수정 일시 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbSecurityGroupId": "dbSecurityGroupId-example",
-    "dbSecurityGroupName": "dbSecurityGroupName-example",
-    "description": "description-example",
-    "progressStatus": "NONE",
-    "rules": [
+    "dbFlavors": [
         {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+            "vcpus": 1
         }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+    ]
 }
 ```
 
@@ -284,59 +206,28 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
 
 ---
 
-### DB 보안 그룹 수정하기
+## 네트워크
+
+### 서브넷 목록 보기
 
 ```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "dbSecurityGroupName": "dbSecurityGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### DB 보안 그룹 규칙 삭제하기
-
-```http
-DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+GET /v4.0/network/subnets
 ```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleIds | Query | String | O |  |
-
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
+| subnets | Body | Array | 서브넷 목록 |
+| subnets.subnetId | Body | String | 서브넷의 식별자 |
+| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
+| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
+| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
+| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
 
 <details><summary>예시</summary>
 <p>
@@ -348,138 +239,11 @@ DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 생성하기
-
-```http
-POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "jobId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 보안 그룹 규칙 수정하기
-
-```http
-PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbSecurityGroupId | URL | UUID | O |  |
-| ruleId | URL | UUID | O |  |
-| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
-| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
-| port | Body | Object | O | 포트 객체 |
-| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
-| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
-| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
-| cidr | Body | String | O | CIDR |
-| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "direction": "INGRESS",
-    "etherType": "IPV4",
-    "port": {
-        "portType": "ALL",
-        "minPort": 3306,
-        "maxPort": 1
-    },
-    "cidr": "cidr-example",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "jobId": "jobId-example"
+    "subnets": [
+        {
+            "availableIpCount": 1
+        }
+    ]
 }
 ```
 
@@ -524,6 +288,214 @@ GET /v4.0/db-versions
             "restorableFromObs": false
         }
     ]
+}
+```
+
+</p>
+</details>
+
+---
+
+## 데이터 스토리지
+
+### 스토리지 타입 목록 보기
+
+```http
+GET /v4.0/storage-types
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| storageTypes | Body | Array | 스토리지 타입 목록 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "storageTypes": []
+}
+```
+
+</p>
+</details>
+
+---
+
+## 작업 정보
+
+### 작업 상태
+
+| 상태명                | 설명                   |
+|--------------------|----------------------|
+| `PREPARING`        | 작업이 준비 중인 경우         |
+| `READY`            | 작업이 준비 완료된 경우        |
+| `RUNNING`          | 작업이 진행 중인 경우         |
+| `COMPLETED`        | 작업이 완료된 경우           |
+| `REGISTERED`       | 작업이 등록된 경우           |
+| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
+| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
+| `CANCELED`         | 작업이 취소된 경우           |
+| `FAILED`           | 작업이 실패한 경우           |
+| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
+| `DELETED`          | 작업이 삭제된 경우           |
+| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
+
+### 작업 정보 상세 보기
+
+```http
+GET /v4.0/jobs/{jobId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| jobId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
+| resourceRelations | Body | Array | 연관 리소스 목록 |
+| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
+| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example",
+    "jobStatus": "DELETED",
+    "resourceRelations": [
+        {
+            "resourceId": "resourceId-example"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+## DB 인스턴스 그룹
+
+### DB 인스턴스 그룹 목록 보기
+
+```http
+GET /v4.0/db-instance-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
+| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 인스턴스 그룹 상세 보기
+
+```http
+GET /v4.0/db-instance-groups/{dbInstanceGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbInstanceGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
+| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
+| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
+| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
+| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
+| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbInstanceGroupId": "dbInstanceGroupId-example",
+    "replicationType": "STANDALONE",
+    "dbInstances": [
+        {
+            "dbInstanceStatus": "BEFORE_CREATE"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
 }
 ```
 
@@ -3219,338 +3191,6 @@ PUT /v4.0/db-instances/{dbInstanceId}/storage-info
 
 ---
 
-## DB 인스턴스 그룹
-
-### DB 인스턴스 그룹 목록 보기
-
-```http
-GET /v4.0/db-instance-groups
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroups | Body | Array | DB 인스턴스 그룹 목록 |
-| dbInstanceGroups.dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| dbInstanceGroups.replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstanceGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| dbInstanceGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroups": [
-        {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### DB 인스턴스 그룹 상세 보기
-
-```http
-GET /v4.0/db-instance-groups/{dbInstanceGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| dbInstanceGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbInstanceGroupId | Body | String | DB 인스턴스 그룹의 식별자 |
-| replicationType | Body | Enum | DB 인스턴스 그룹의 복제 형태<br/>- STANDALONE: `고가용성 사용 안함`<br/>- HIGH_AVAILABILITY: `고가용성 사용` |
-| dbInstances | Body | Array | DB 인스턴스 그룹에 속한 DB 인스턴스 목록 |
-| dbInstances.dbInstanceId | Body | String | DB 인스턴스의 식별자 |
-| dbInstances.dbInstanceType | Body | Enum | DB 인스턴스의 역할 타입<br/>- MASTER: `마스터`<br/>- FAILED_MASTER: `장애 마스터`<br/>- CANDIDATE_MASTER: `예비 마스터`<br/>- READ_ONLY_SLAVE: `읽기 복제본` |
-| dbInstances.dbInstanceStatus | Body | Enum | DB 인스턴스의 현재 상태<br/>- BEFORE_CREATE: `생성 이전 (회색)`<br/>- AVAILABLE: `사용 가능 (녹색)`<br/>- STORAGE_FULL: `용량 부족 (적색)`<br/>- FAIL_TO_CREATE: `생성 실패 (적색)`<br/>- FAIL_TO_CONNECT: `연결 실패 (적색)`<br/>- REPLICATION_STOP: `복제 중단 (적색)`<br/>- REPLICATION_DELAY: `복제 지연 (황색)`<br/>- FAILOVER: `장애 조치 완료 (적색)`<br/>- SHUTDOWN: `중지 됨 (회색)`<br/>- DELETED: `삭제됨 (회색)` |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbInstanceGroupId": "dbInstanceGroupId-example",
-    "replicationType": "STANDALONE",
-    "dbInstances": [
-        {
-            "dbInstanceStatus": "BEFORE_CREATE"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## DB 인스턴스 사양
-
-### DB 인스턴스 사양 목록 보기
-
-```http
-GET /v4.0/db-flavors
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| dbFlavors | Body | Array | DB 인스턴스 사양 목록 |
-| dbFlavors.dbFlavorId | Body | String | DB 인스턴스 사양의 식별자 |
-| dbFlavors.dbFlavorName | Body | String | DB 인스턴스 사양 이름 |
-| dbFlavors.ram | Body | Number | 메모리 용량(MB) |
-| dbFlavors.vcpus | Body | Number | CPU 코어 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "dbFlavors": [
-        {
-            "vcpus": 1
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 가용성 영역
-
-### 가용성 영역 목록 보기
-
-```http
-GET /v4.0/availability-zones
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| availabilityZones | Body | Array | 가용성 영역 목록 |
-| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
-| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
-| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "availabilityZones": [
-        {
-            "zoneState": {
-                "available": false
-            }
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 네트워크
-
-### 서브넷 목록 보기
-
-```http
-GET /v4.0/network/subnets
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| subnets | Body | Array | 서브넷 목록 |
-| subnets.subnetId | Body | String | 서브넷의 식별자 |
-| subnets.subnetName | Body | String | 서브넷을 식별할 수 있는 이름 |
-| subnets.subnetCidr | Body | String | 서브넷의 CIDR |
-| subnets.usingGateway | Body | Boolean | 게이트웨이 사용 여부 |
-| subnets.availableIpCount | Body | Number | 사용 가능한 IP 수 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "subnets": [
-        {
-            "availableIpCount": 1
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-## 데이터 스토리지
-
-### 스토리지 타입 목록 보기
-
-```http
-GET /v4.0/storage-types
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| storageTypes | Body | Array | 스토리지 타입 목록 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "storageTypes": []
-}
-```
-
-</p>
-</details>
-
----
-
-## 모니터링
-
-### 통계 정보 조회
-
-```http
-GET /v4.0/metric-statistics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### Metric 목록 보기
-
-```http
-GET /v4.0/metrics
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| metrics | Body | Array | Metric 목록 |
-| metrics.measureName | Body | String | 조회 지표 유형 |
-| metrics.unit | Body | String | 측정값 단위 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "metrics": [
-        {
-            "unit": "unit-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
 ## 백업
 
 ### 백업 상태
@@ -3966,6 +3606,751 @@ POST /v4.0/backups/{backupId}/restore
 
 </p>
 </details>
+
+---
+
+## DB 보안 그룹
+
+### DB 보안 그룹 진행 상태
+
+| 상태              | 설명           |
+|-----------------|--------------|
+| `NONE`          | 진행 중인 작업이 없음 |
+| `CREATING_RULE` | 규칙 정책 생성 중   |
+| `UPDATING_RULE` | 규칙 정책 수정 중   |
+| `DELETING_RULE` | 규칙 정책 삭제 중   |
+
+### DB 보안 그룹 목록 보기
+
+```http
+GET /v4.0/db-security-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 DB 보안 그룹 목록 수 |
+| dbSecurityGroups | Body | Array | DB 보안 그룹 목록 |
+| dbSecurityGroups.dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroups.dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| dbSecurityGroups.description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| dbSecurityGroups.progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| dbSecurityGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| dbSecurityGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "dbSecurityGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 생성하기
+
+```http
+POST /v4.0/db-security-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupName | Body | String | O | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| rules | Body | Array | O | DB 보안 그룹 규칙 목록 |
+| rules.direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | O | 포트 객체 |
+| rules.port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| rules.port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| rules.cidr | Body | String | O | CIDR |
+| rules.description | Body | String | X | 보안 그룹 규칙에 대한 추가 정보 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example",
+    "rules": [
+        {
+            "description": "description-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 상세 보기
+
+```http
+GET /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| dbSecurityGroupId | Body | String | DB 보안 그룹의 식별자 |
+| dbSecurityGroupName | Body | String | DB 보안 그룹을 식별할 수 있는 이름 |
+| description | Body | String | DB 보안 그룹에 대한 추가 정보 |
+| progressStatus | Body | Enum | DB 보안 그룹의 현재 진행 상태<br/>- NONE: `없음`<br/>- CREATING_RULE: `규칙 생성중`<br/>- UPDATING_RULE: `규칙 수정중`<br/>- DELETING_RULE: `규칙 삭제중`<br/>- APPLYING_DEFAULT_RULE: `기본 규칙 적용중` |
+| rules | Body | Array | DB 보안 그룹 규칙 목록 |
+| rules.ruleId | Body | String | DB 보안 그룹 규칙의 식별자 |
+| rules.description | Body | String | DB 보안 그룹 규칙에 대한 추가 정보 |
+| rules.direction | Body | Enum | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| rules.etherType | Body | Enum | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| rules.port | Body | Object | 포트 객체 |
+| rules.port.portType | Body | Enum | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| rules.port.minPort | Body | Number | 최소 포트 범위 |
+| rules.port.maxPort | Body | Number | 최대 포트 범위 |
+| rules.cidr | Body | String | CIDR |
+| rules.createdYmdt | Body | DateTime | 생성 일시 |
+| rules.updatedYmdt | Body | DateTime | 수정 일시 |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "dbSecurityGroupId": "dbSecurityGroupId-example",
+    "dbSecurityGroupName": "dbSecurityGroupName-example",
+    "description": "description-example",
+    "progressStatus": "NONE",
+    "rules": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| dbSecurityGroupName | Body | String | X | DB 보안 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | DB 보안 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "dbSecurityGroupName": "dbSecurityGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### DB 보안 그룹 규칙 삭제하기
+
+```http
+DELETE /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleIds | Query | String | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 생성하기
+
+```http
+POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### DB 보안 그룹 규칙 수정하기
+
+```http
+PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| dbSecurityGroupId | URL | UUID | O |  |
+| ruleId | URL | UUID | O |  |
+| direction | Body | Enum | O | 통신 방향<br/>- INGRESS: `수신`<br/>- EGRESS: `송신` |
+| etherType | Body | Enum | O | Ether 타입<br/>- IPV4: `IPv4 형식`<br/>- IPV6: `IPv6 형식` |
+| port | Body | Object | O | 포트 객체 |
+| port.portType | Body | Enum | O | 포트 타입<br/>- ALL: `포트 범위 전체 (사용자 콘솔에서는 사용하지 않음)`<br/>- PORT: `특정 포트`<br/>- DB_PORT: `DB 수신 포트`<br/>- PORT_RANGE: `포트 범위` |
+| port.minPort | Body | Number | X | 최소 포트 범위<br/>- 최솟값: `3306` |
+| port.maxPort | Body | Number | X | 최대 포트 범위<br/>- 최댓값: `65535` |
+| cidr | Body | String | O | CIDR |
+| description | Body | String | X | DB 보안 그룹 규칙에 대한 추가 정보<br/>- 최대 길이: `200` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "direction": "INGRESS",
+    "etherType": "IPV4",
+    "port": {
+        "portType": "ALL",
+        "minPort": 3306,
+        "maxPort": 1
+    },
+    "cidr": "cidr-example",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| jobId | Body | String | 작업의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "jobId": "jobId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+## 파라미터 그룹
+
+### 파라미터 그룹 목록 보기
+
+```http
+GET /v4.0/parameter-groups
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
+| parameterGroups | Body | Array | 파라미터 그룹 목록 |
+| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
+| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
+| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "totalCounts": 1,
+    "parameterGroups": [
+        {
+            "updatedYmdt": "2023-12-31T15:00:00+09:00"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 생성하기
+
+```http
+POST /v4.0/parameter-groups
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+| dbVersion | Body | Enum | O | DB 엔진 유형 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 삭제하기
+
+```http
+DELETE /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 상세 보기
+
+```http
+GET /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
+| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
+| dbVersion | Body | Enum | DB 엔진 유형 |
+| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
+| parameters | Body | Array | 파라미터 목록 |
+| parameters.parameterId | Body | String | 파라미터의 식별자 |
+| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
+| parameters.parameterName | Body | String | 파라미터 이름 |
+| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
+| parameters.value | Body | String | 현재 설정된 값 |
+| parameters.defaultValue | Body | String | 기본값 |
+| parameters.allowedValue | Body | String | 허용된 값 |
+| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
+| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
+| createdYmdt | Body | DateTime | 생성 일시 |
+| updatedYmdt | Body | DateTime | 수정 일시 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example",
+    "parameterGroupName": "parameterGroupName-example",
+    "description": "description-example",
+    "dbVersion": "ENUM_VALUE",
+    "parameterGroupStatus": "STABLE",
+    "parameters": [
+        {
+            "applyType": "BOTH"
+        }
+    ],
+    "createdYmdt": "2023-12-31T15:00:00+09:00",
+    "updatedYmdt": "2023-12-31T15:00:00+09:00"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 그룹 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 복사하기
+
+```http
+POST /v4.0/parameter-groups/{parameterGroupId}/copy
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
+| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "parameterGroupName": "parameterGroupName",
+    "description": "description-example"
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "parameterGroupId": "parameterGroupId-example"
+}
+```
+
+</p>
+</details>
+
+---
+
+### 파라미터 수정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
+```
+
+#### 요청
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
+| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
+| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "modifiedParameters": [
+        {
+            "value": "value-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### 파라미터 그룹 재설정하기
+
+```http
+PUT /v4.0/parameter-groups/{parameterGroupId}/reset
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+| 이름 | 종류 | 형식 | 필수 | 설명 |
+|-----|-----|-----|-----|-----|
+| parameterGroupId | URL | UUID | O |  |
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
 
 ---
 
@@ -4413,6 +4798,65 @@ PUT /v4.0/notification-groups/{notificationGroupId}
 
 ---
 
+## 모니터링
+
+### 통계 정보 조회
+
+```http
+GET /v4.0/metric-statistics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+이 API는 응답 본문을 반환하지 않습니다.
+
+---
+
+### Metric 목록 보기
+
+```http
+GET /v4.0/metrics
+```
+
+#### 요청
+
+이 API는 요청 본문을 요구하지 않습니다.
+
+#### 응답
+
+| 이름 | 종류 | 형식 | 설명 |
+|-----|-----|-----|-----|
+| metrics | Body | Array | Metric 목록 |
+| metrics.measureName | Body | String | 조회 지표 유형 |
+| metrics.unit | Body | String | 측정값 단위 |
+
+<details><summary>예시</summary>
+<p>
+
+```json
+{
+    "header": {
+        "resultCode": 0,
+        "resultMessage": "SUCCESS",
+        "isSuccessful": true
+    },
+    "metrics": [
+        {
+            "unit": "unit-example"
+        }
+    ]
+}
+```
+
+</p>
+</details>
+
+---
+
 ## 이벤트
 
 ### 이벤트 카테고리
@@ -4713,50 +5157,26 @@ PUT /v4.0/event-subscriptions/{eventSubscriptionId}
 
 ---
 
-## 작업 정보
+## 가용성 영역
 
-### 작업 상태
-
-| 상태명                | 설명                   |
-|--------------------|----------------------|
-| `PREPARING`        | 작업이 준비 중인 경우         |
-| `READY`            | 작업이 준비 완료된 경우        |
-| `RUNNING`          | 작업이 진행 중인 경우         |
-| `COMPLETED`        | 작업이 완료된 경우           |
-| `REGISTERED`       | 작업이 등록된 경우           |
-| `WAIT_TO_REGISTER` | 작업 등록 대기 중인 경우       |
-| `INTERRUPTED`      | 작업 진행 중 인터럽트가 발생한 경우 |
-| `CANCELED`         | 작업이 취소된 경우           |
-| `FAILED`           | 작업이 실패한 경우           |
-| `ERROR`            | 작업 진행 중 오류가 발생한 경우   |
-| `DELETED`          | 작업이 삭제된 경우           |
-| `FAIL_TO_READY`    | 작업 준비에 실패한 경우        |
-
-### 작업 정보 상세 보기
+### 가용성 영역 목록 보기
 
 ```http
-GET /v4.0/jobs/{jobId}
+GET /v4.0/availability-zones
 ```
 
 #### 요청
 
 이 API는 요청 본문을 요구하지 않습니다.
 
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| jobId | URL | UUID | O |  |
-
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
 |-----|-----|-----|-----|
-| jobId | Body | String | 작업의 식별자 |
-| jobStatus | Body | Enum | 작업의 현재 상태<br/>- DELETED<br/>- CANNOT_PROGRESS<br/>- FAILED<br/>- ERROR<br/>- CANCELED<br/>- INTERRUPTED<br/>- COMPLETED<br/>- RUNNING<br/>- PREPARING<br/>- READY<br/>- CREATED<br/>- FAIL_TO_READY<br/>- REGISTERED<br/>- FAIL_TO_REGISTER<br/>- WAIT_TO_REGISTER |
-| resourceRelations | Body | Array | 연관 리소스 목록 |
-| resourceRelations.resourceType | Body | String | 연관 리소스 유형 |
-| resourceRelations.resourceId | Body | String | 연관 리소스의 식별자 |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
+| availabilityZones | Body | Array | 가용성 영역 목록 |
+| availabilityZones.availabilityZoneName | Body | String | 가용성 영역 이름 |
+| availabilityZones.zoneState | Body | Object | 가용성 영역 상태 |
+| availabilityZones.zoneState.available | Body | Boolean | 가용성 영역의 사용 가능 여부 |
 
 <details><summary>예시</summary>
 <p>
@@ -4768,431 +5188,11 @@ GET /v4.0/jobs/{jobId}
         "resultMessage": "SUCCESS",
         "isSuccessful": true
     },
-    "jobId": "jobId-example",
-    "jobStatus": "DELETED",
-    "resourceRelations": [
+    "availabilityZones": [
         {
-            "resourceId": "resourceId-example"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-## 파라미터 그룹
-
-### 파라미터 그룹 목록 보기
-
-```http
-GET /v4.0/parameter-groups
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| totalCounts | Body | Number | 전체 파라미터 그룹 수 |
-| parameterGroups | Body | Array | 파라미터 그룹 목록 |
-| parameterGroups.parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroups.parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| parameterGroups.description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| parameterGroups.dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroups.parameterGroupType | Body | Enum | 파라미터 그룹 유형<br/>- USER<br/>- ADMIN<br/>- DEFAULT<br/>- CLUSTER_USER |
-| parameterGroups.parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameterGroups.createdYmdt | Body | DateTime | 생성 일시 |
-| parameterGroups.updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "totalCounts": 1,
-    "parameterGroups": [
-        {
-            "updatedYmdt": "2023-12-31T15:00:00+09:00"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 생성하기
-
-```http
-POST /v4.0/parameter-groups
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-| dbVersion | Body | Enum | O | DB 엔진 유형 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 삭제하기
-
-```http
-DELETE /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 상세 보기
-
-```http
-GET /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-| parameterGroupName | Body | String | 파라미터 그룹을 식별할 수 있는 이름 |
-| description | Body | String | 파라미터 그룹에 대한 추가 정보 |
-| dbVersion | Body | Enum | DB 엔진 유형 |
-| parameterGroupStatus | Body | Enum | 파라미터 그룹의 현재 상태<br/>- STABLE: `적용 완료`<br/>- NEED_TO_APPLY: `적용 필요`<br/>- DELETED: `삭제됨` |
-| parameters | Body | Array | 파라미터 목록 |
-| parameters.parameterId | Body | String | 파라미터의 식별자 |
-| parameters.parameterFileGroup | Body | Enum | 파라미터 파일 그룹 타입<br/>- CLIENT<br/>- MYSQL<br/>- MYSQLD |
-| parameters.parameterName | Body | String | 파라미터 이름 |
-| parameters.fileParameterName | Body | String | 파라미터 파일 이름 |
-| parameters.value | Body | String | 현재 설정된 값 |
-| parameters.defaultValue | Body | String | 기본값 |
-| parameters.allowedValue | Body | String | 허용된 값 |
-| parameters.updateType | Body | Enum | 수정 타입<br/>- VARIABLE<br/>- CONSTANT<br/>- INIT_VARIABLE |
-| parameters.applyType | Body | Enum | 적용 타입<br/>- BOTH<br/>- SESSION<br/>- FILE |
-| createdYmdt | Body | DateTime | 생성 일시 |
-| updatedYmdt | Body | DateTime | 수정 일시 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example",
-    "parameterGroupName": "parameterGroupName-example",
-    "description": "description-example",
-    "dbVersion": "ENUM_VALUE",
-    "parameterGroupStatus": "STABLE",
-    "parameters": [
-        {
-            "applyType": "BOTH"
-        }
-    ],
-    "createdYmdt": "2023-12-31T15:00:00+09:00",
-    "updatedYmdt": "2023-12-31T15:00:00+09:00"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 그룹 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | X | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 복사하기
-
-```http
-POST /v4.0/parameter-groups/{parameterGroupId}/copy
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| parameterGroupName | Body | String | O | 파라미터 그룹을 식별할 수 있는 이름<br/>- 최소 길이: `1`<br/>- 최대 길이: `100` |
-| description | Body | String | X | 파라미터 그룹에 대한 추가 정보<br/>- 최대 길이: `100` |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "parameterGroupName": "parameterGroupName",
-    "description": "description-example"
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| parameterGroupId | Body | String | 파라미터 그룹의 식별자 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "parameterGroupId": "parameterGroupId-example"
-}
-```
-
-</p>
-</details>
-
----
-
-### 파라미터 수정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/parameters
-```
-
-#### 요청
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-| modifiedParameters | Body | Array | O | 변경할 파라미터 목록 |
-| modifiedParameters.parameterId | Body | UUID | O | 파라미터의 식별자 |
-| modifiedParameters.value | Body | String | O | 변경할 파라미터 값 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "modifiedParameters": [
-        {
-            "value": "value-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-### 파라미터 그룹 재설정하기
-
-```http
-PUT /v4.0/parameter-groups/{parameterGroupId}/reset
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-| 이름 | 종류 | 형식 | 필수 | 설명 |
-|-----|-----|-----|-----|-----|
-| parameterGroupId | URL | UUID | O |  |
-
-#### 응답
-
-이 API는 응답 본문을 반환하지 않습니다.
-
----
-
-## 프로젝트 정보
-
-### 프로젝트 멤버 목록 보기
-
-```http
-GET /v4.0/project/members
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| members | Body | Array | 프로젝트 멤버 목록 |
-| members.memberId | Body | String | 프로젝트 멤버의 식별자 |
-| members.memberName | Body | String | 프로젝트 멤버의 이름 |
-| members.emailAddress | Body | String | 프로젝트 멤버의 이메일 주소 |
-| members.phoneNumber | Body | String | 프로젝트 멤버의 전화번호 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "members": [
-        {
-            "phoneNumber": "phoneNumber-example"
-        }
-    ]
-}
-```
-
-</p>
-</details>
-
----
-
-### 리전 목록 보기
-
-```http
-GET /v4.0/project/regions
-```
-
-#### 요청
-
-이 API는 요청 본문을 요구하지 않습니다.
-
-#### 응답
-
-| 이름 | 종류 | 형식 | 설명 |
-|-----|-----|-----|-----|
-| regions | Body | Array | 리전 목록 |
-| regions.regionCode | Body | Enum | 리전 코드<br/>- KR1: `한국(판교)` |
-| regions.isEnabled | Body | Boolean | 리전의 활성화 여부 |
-
-<details><summary>예시</summary>
-<p>
-
-```json
-{
-    "header": {
-        "resultCode": 0,
-        "resultMessage": "SUCCESS",
-        "isSuccessful": true
-    },
-    "regions": [
-        {
-            "isEnabled": false
+            "zoneState": {
+                "available": false
+            }
         }
     ]
 }


### PR DESCRIPTION
## 개요
nc-rds `feature/4321` 의 API 가이드 생성기 출력으로 RDS for MariaDB 가이드를 동기화합니다.
- **버전**: `v3.0`, `v4.0`
- **언어**: `ko`(생성기 산출), `en`·`ja`(MySQL 번역본에서 엔진 델타만 적용해 파생)
- **환경**: base(public), gov

## 핵심 변경
- **MariaDB v3.0 가이드 신규 추가**
  - 생성기 진입점이 `mysql v3.0/v4.0`·`mariadb v4.0` 만 생성하고 `mariadb v3.0` 이 누락돼 있었습니다. MariaDB v3.0 API 는 실재·발행 중이고 MySQL wire 를 공유해 v3.0 컨트롤러가 그대로 존재하므로, 생성 대상에 추가했습니다.
  - 기존 수동 관리 `v3.0` 가이드를 생성기 산출물로 대체합니다(코드 = Single Source of Truth 통일).
- **백업 복제 리전(replicationRegion) / 리전 코드 노출을 (MariaDB × realm) 가용 리전으로 정합화**
  - MariaDB public/gov 모두 **KR1 단일** (배포 config 상 slave-regions 없음)
  - 가용 리전 근거: 배포 환경 config 의 `region.master-region` ∪ `region.slave-regions`
- **EN/JA 파생 방식**: MySQL v3.0/v4.0 번역본 기준으로 엔진 델타만 결정적 적용 — 엔진명(RDS for MariaDB)·권한 접두사(`RDSforMariaDB:`)·엔드포인트 host·리전(KR1)·인증 플러그인(`ED25519`)·DB 엔진 버전표. 도메인 용어/문구는 발행 번역 그대로 유지.

## 참고
- 생성기 기준 **전체 재생성**이라 리전 외에도 표 정렬/문구/섹션 순서 등 포맷 차이가 diff 에 포함됩니다(생성기를 source of truth 로 통일).
- v2.0 가이드는 생성기 비대상이라 미변경.
- zh(중국어)는 생성기/번역 파이프라인 범위 밖이라 미변경.
