### PR TITLE
docs(ko): API 가이드 예시 품질 개선 (nhn-api-codex 1.0.4)

### DIFF
--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -118,8 +118,8 @@ GET /v4.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -275,7 +275,7 @@ GET /v4.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -743,7 +743,7 @@ POST /v4.0/db-instances
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -802,7 +802,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -877,7 +877,7 @@ POST /v4.0/db-instances/restore-from-obs
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -938,7 +938,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1244,7 +1244,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
@@ -1264,7 +1264,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1299,7 +1299,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1314,7 +1314,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2751,13 +2751,13 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example"
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2956,7 +2956,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 스토리지 자동 확장 사용 시
@@ -3001,7 +3001,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3271,7 +3271,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
@@ -3352,7 +3352,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3995,7 +3995,7 @@ POST /v4.0/backups/{backupId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -4049,7 +4049,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4198,7 +4198,7 @@ POST /v4.0/db-security-groups
                 "minPort": 3306,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4327,7 +4327,7 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
@@ -4465,7 +4465,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4537,7 +4537,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -118,8 +118,8 @@ GET /v4.0/project/members
         {
             "memberId": "550e8400-e29b-41d4-a716-446655440000",
             "memberName": "memberName-example",
-            "emailAddress": "emailAddress-example",
-            "phoneNumber": "phoneNumber-example"
+            "emailAddress": "user@example.com",
+            "phoneNumber": "010-1234-5678"
         }
     ]
 }
@@ -275,7 +275,7 @@ GET /v4.0/network/subnets
         {
             "subnetId": "550e8400-e29b-41d4-a716-446655440000",
             "subnetName": "subnetName-example",
-            "subnetCidr": "subnetCidr-example",
+            "subnetCidr": "192.168.0.0/24",
             "usingGateway": false,
             "availableIpCount": 1
         }
@@ -743,7 +743,7 @@ POST /v4.0/db-instances
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -802,7 +802,7 @@ POST /v4.0/db-instances
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -877,7 +877,7 @@ POST /v4.0/db-instances/restore-from-obs
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | O | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.tenantId | Body | String | O | 백업이 저장된 오브젝트 스토리지의 테넌트 ID |
@@ -938,7 +938,7 @@ POST /v4.0/db-instances/restore-from-obs
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -1244,7 +1244,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | 백업 Duration<br/>- HALF_AN_HOUR<br/>- ONE_HOUR<br/>- ONE_HOUR_AND_HALF<br/>- TWO_HOURS<br/>- TWO_HOURS_AND_HALF<br/>- THREE_HOURS |
 
 <details><summary>예시</summary>
@@ -1264,7 +1264,7 @@ GET /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -1299,7 +1299,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
 | replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 <details><summary>예시</summary>
@@ -1314,7 +1314,7 @@ PUT /v4.0/db-instances/{dbInstanceId}/backup-info
     "useBackupLock": false,
     "backupSchedules": [
         {
-            "backupWndBgnTime": "backupWndBgnTime-example",
+            "backupWndBgnTime": "00:00:00",
             "backupWndDuration": "HALF_AN_HOUR"
         }
     ]
@@ -2751,13 +2751,13 @@ GET /v4.0/db-instances/{dbInstanceId}/network-info
     "subnet": {
         "subnetId": "550e8400-e29b-41d4-a716-446655440000",
         "subnetName": "subnetName-example",
-        "subnetCidr": "subnetCidr-example"
+        "subnetCidr": "192.168.0.0/24"
     },
     "endPoints": [
         {
             "domain": "domain-example",
-            "ipAddress": "ipAddress-example",
-            "endPointType": "endPointType-example"
+            "ipAddress": "192.168.0.1",
+            "endPointType": "https://example.com"
         }
     ]
 }
@@ -2956,7 +2956,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 스토리지 자동 확장 사용 시
@@ -3001,7 +3001,7 @@ POST /v4.0/db-instances/{dbInstanceId}/replicate
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3271,7 +3271,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부<br/>- 기본값: `true` |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미입력 시 원본 인스턴스의 백업 스케쥴이 적용됩니다. |
-| backup.backupSchedules.backupWndBgnTime | Body | String | X | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | X | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | X | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 | restore | Body | Object | O | 복원 정보 객체 |
 | restore.restoreType | Body | Enum | O | 복원 타입<br/>- TIMESTAMP: `복원 가능한 시간 이내의 시간을 이용한 시점 복원`<br/>- BINLOG: `복원 가능한 바이너리 로그 위치를 이용한 시점 복원`<br/>- BACKUP: `기존에 생성한 백업을 이용한 스냅숏 복원` |
@@ -3352,7 +3352,7 @@ POST /v4.0/db-instances/{dbInstanceId}/restore
         "useBackupLock": true,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -3995,7 +3995,7 @@ POST /v4.0/backups/{backupId}/restore
 | backup.replicationRegion | Body | Enum | X | 백업 복제 리전<br/>- KR1: `한국(판교)` |
 | backup.useBackupLock | Body | Boolean | X | 테이블 잠금 사용 여부. 미지정 시 원본 인스턴스 값 사용 |
 | backup.backupSchedules | Body | Array | X | 백업 스케쥴 목록. 미지정 시 원본 인스턴스 값 사용 |
-| backup.backupSchedules.backupWndBgnTime | Body | String | O | 백업 시작 시각 |
+| backup.backupSchedules.backupWndBgnTime | Body | Time | O | 백업 시작 시각 |
 | backup.backupSchedules.backupWndDuration | Body | Enum | O | 백업 Duration<br/>- HALF_AN_HOUR: `30분`<br/>- ONE_HOUR: `1시간`<br/>- ONE_HOUR_AND_HALF: `1시간 30분`<br/>- TWO_HOURS: `2시간`<br/>- TWO_HOURS_AND_HALF: `2시간 30분`<br/>- THREE_HOURS: `3시간` |
 
 #### 고가용성 사용 시
@@ -4049,7 +4049,7 @@ POST /v4.0/backups/{backupId}/restore
         "useBackupLock": false,
         "backupSchedules": [
             {
-                "backupWndBgnTime": "backupWndBgnTime-example",
+                "backupWndBgnTime": "00:00:00",
                 "backupWndDuration": "HALF_AN_HOUR"
             }
         ]
@@ -4198,7 +4198,7 @@ POST /v4.0/db-security-groups
                 "minPort": 3306,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "description": "description-example"
         }
     ]
@@ -4327,7 +4327,7 @@ GET /v4.0/db-security-groups/{dbSecurityGroupId}
                 "minPort": 1,
                 "maxPort": 1
             },
-            "cidr": "cidr-example",
+            "cidr": "192.168.0.0/24",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
             "updatedYmdt": "2023-12-31T15:00:00+09:00"
         }
@@ -4465,7 +4465,7 @@ POST /v4.0/db-security-groups/{dbSecurityGroupId}/rules
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```
@@ -4537,7 +4537,7 @@ PUT /v4.0/db-security-groups/{dbSecurityGroupId}/rules/{ruleId}
         "minPort": 3306,
         "maxPort": 1
     },
-    "cidr": "cidr-example",
+    "cidr": "192.168.0.0/24",
     "description": "description-example"
 }
 ```


### PR DESCRIPTION
## 요약
기존 PR(`feature/4321`, nhn-api-codex 1.0.3) 위에 **예시 품질 개선분(1.0.4)만** 분리한 PR.
base 가 `feature/4321` 이라 diff = 1.0.3→1.0.4 예시 개선만 보입니다.

## 변경
- email/cidr/phone/ip/uuid → 형식에 맞는 실제 예시 (placeholder 제거)
- 시각 필드(LocalTime) 형식 표기 String→Time, 예시 `00:00:00`
- nc-rds feature/4321 코드 기반 재생성 (nhn-api-codex 1.0.4)

## 비고
nhn-api-codex 1.0.4 Nexus 릴리스 + nc-rds 의존 bump 완료. 검토 후 feature/4321 로 머지.