### PR TITLE
docs(ko): 제약 위반 예시 보강 (sourceId UUID·tenantId·host)

### DIFF
--- a/ko/api-guide-v4.0-gov.md
+++ b/ko/api-guide-v4.0-gov.md
@@ -944,7 +944,7 @@ POST /v4.0/db-instances/restore-from-obs
         ]
     },
     "restore": {
-        "tenantId": "tenantId-example",
+        "tenantId": "0123456789abcdef0123456789abcdef",
         "username": "username-example",
         "password": "password-example",
         "targetContainer": "targetContainer-example",
@@ -1526,7 +1526,7 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```json
 {
     "certificateTypes": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -1769,7 +1769,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
         {
             "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
-            "host": "host-example",
+            "host": "192.168.0.1",
             "authorityType": "CUSTOM",
             "dbUserStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -1817,7 +1817,7 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 {
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
-    "host": "host-example",
+    "host": "192.168.0.1",
     "authorityType": "CUSTOM",
     "authenticationPlugin": "NATIVE",
     "tlsOption": "NONE"
@@ -2405,7 +2405,7 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```json
 {
     "logFileNames": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -3914,7 +3914,7 @@ POST /v4.0/backups/{backupId}/export
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -5640,7 +5640,7 @@ GET /v4.0/events
 | events | Body | Array | 이벤트 목록 |
 | events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
 | events.messages | Body | Array | 이벤트 메세지 목록 |
 | events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
@@ -5662,7 +5662,7 @@ GET /v4.0/events
         {
             "eventCategoryType": "ALL",
             "eventCode": "ENUM_VALUE",
-            "sourceId": "sourceId-example",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "sourceName": "sourceName-example",
             "messages": [
                 {
@@ -5713,7 +5713,7 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
 | eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
 | eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
@@ -5740,7 +5740,7 @@ GET /v4.0/event-subscriptions
             "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "sourceId-example",
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
                     "eventCategoryType": "ALL"
                 }
             ],

--- a/ko/api-guide-v4.0.md
+++ b/ko/api-guide-v4.0.md
@@ -944,7 +944,7 @@ POST /v4.0/db-instances/restore-from-obs
         ]
     },
     "restore": {
-        "tenantId": "tenantId-example",
+        "tenantId": "0123456789abcdef0123456789abcdef",
         "username": "username-example",
         "password": "password-example",
         "targetContainer": "targetContainer-example",
@@ -1526,7 +1526,7 @@ POST /v4.0/db-instances/{dbInstanceId}/certificates/upload
 ```json
 {
     "certificateTypes": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -1769,7 +1769,7 @@ GET /v4.0/db-instances/{dbInstanceId}/db-users
         {
             "dbUserId": "550e8400-e29b-41d4-a716-446655440000",
             "dbUserName": "dbUserName-example",
-            "host": "host-example",
+            "host": "192.168.0.1",
             "authorityType": "CUSTOM",
             "dbUserStatus": "STABLE",
             "createdYmdt": "2023-12-31T15:00:00+09:00",
@@ -1817,7 +1817,7 @@ POST /v4.0/db-instances/{dbInstanceId}/db-users
 {
     "dbUserName": "dbUserName",
     "dbPassword": "dbPassword",
-    "host": "host-example",
+    "host": "192.168.0.1",
     "authorityType": "CUSTOM",
     "authenticationPlugin": "NATIVE",
     "tlsOption": "NONE"
@@ -2405,7 +2405,7 @@ POST /v4.0/db-instances/{dbInstanceId}/log-files/export
 ```json
 {
     "logFileNames": [],
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -3914,7 +3914,7 @@ POST /v4.0/backups/{backupId}/export
 
 ```json
 {
-    "tenantId": "tenantId-example",
+    "tenantId": "0123456789abcdef0123456789abcdef",
     "username": "username-example",
     "password": "password-example",
     "targetContainer": "targetContainer-example",
@@ -5640,7 +5640,7 @@ GET /v4.0/events
 | events | Body | Array | 이벤트 목록 |
 | events.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | events.eventCode | Body | Enum | 발생한 이벤트의 유형 |
-| events.sourceId | Body | String | 이벤트 소스의 식별자 |
+| events.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | events.sourceName | Body | String | 이벤트 소스를 식별할 수 있는 이름 |
 | events.messages | Body | Array | 이벤트 메세지 목록 |
 | events.messages.langCode | Body | Enum | 언어 코드<br/>- KO<br/>- EN<br/>- JA<br/>- ZH |
@@ -5662,7 +5662,7 @@ GET /v4.0/events
         {
             "eventCategoryType": "ALL",
             "eventCode": "ENUM_VALUE",
-            "sourceId": "sourceId-example",
+            "sourceId": "550e8400-e29b-41d4-a716-446655440000",
             "sourceName": "sourceName-example",
             "messages": [
                 {
@@ -5713,7 +5713,7 @@ GET /v4.0/event-subscriptions
 | eventSubscriptions.notifySms | Body | Boolean | SMS 발송 여부 |
 | eventSubscriptions.eventCodes | Body | Array | 구독할 이벤트 코드 목록 |
 | eventSubscriptions.sources | Body | Array | 구독할 이벤트 소스 목록 |
-| eventSubscriptions.sources.sourceId | Body | String | 이벤트 소스의 식별자 |
+| eventSubscriptions.sources.sourceId | Body | UUID | 이벤트 소스의 식별자 |
 | eventSubscriptions.sources.eventCategoryType | Body | Enum | 이벤트 카테고리 유형<br/>- ALL<br/>- INSTANCE<br/>- DB_SECURITY_GROUP<br/>- MONITORING<br/>- JOB<br/>- BACKUP<br/>- TENANT |
 | eventSubscriptions.userGroupIds | Body | Array | 이벤트 구독 중인 사용자 그룹의 식별자 목록 |
 | eventSubscriptions.createdYmdt | Body | DateTime | 생성 일시 |
@@ -5740,7 +5740,7 @@ GET /v4.0/event-subscriptions
             "eventCodes": [],
             "sources": [
                 {
-                    "sourceId": "sourceId-example",
+                    "sourceId": "550e8400-e29b-41d4-a716-446655440000",
                     "eventCategoryType": "ALL"
                 }
             ],


### PR DESCRIPTION
## 요약
이전 PR(예시 품질 1.0.4, 머지됨) 위에 **제약 위반 예시 추가 보강분**만 분리. base=feature/4321 이라 diff = 이번 보강만.

## 변경
- `sourceId` 응답: 형식 String→**UUID**, 예시 `550e8400-...` (Request의 @UUID와 일치)
- `tenantId`: `@Length(min=32)` 충족하는 32자 예시 (기존 16자 placeholder는 길이 위반)
- `host`: `@Pattern`(IP) 충족하는 `192.168.0.1` (기존 placeholder는 패턴 위반)

## 근거
nc-rds VO 어노테이션 코드 기반 검증 후 재생성 (nhn-api-codex 1.0.4).